### PR TITLE
Fix search of docs for firefox

### DIFF
--- a/lib/templates/js/full_list.js
+++ b/lib/templates/js/full_list.js
@@ -21,9 +21,9 @@ function fullListSearch() {
     searchCache.push({name:link.text(), fullName:fullName, node:$(this), link:link});
   });
   
-  $('#search input').keyup(function() {
-    if ((event.keyCode > ignoreKeyCodeMin && event.keyCode < ignoreKeyCodeMax) 
-         || event.keyCode == commandKey)
+  $('#search input').keyup(function(evnt) {
+    if ((evnt.keyCode > ignoreKeyCodeMin && evnt.keyCode < ignoreKeyCodeMax)
+         || evnt.keyCode == commandKey)
       return;
     searchString = this.value;
     caseSensitiveMatch = searchString.match(/[A-Z]/) != null;


### PR DESCRIPTION
Search in firefox was broken. Firefox does not recognizes event as chrome/ie/firefox. Event object has to be passed at the keyup event callback.
