### PR TITLE
Fixing ambiguity compile error based on elixir 0.9.4-dev

### DIFF
--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -160,7 +160,7 @@ defmodule ExDoc.Retriever do
     module = binary_to_atom name
 
     unless Code.ensure_loaded?(module), do:
-      raise Error, message: "module #{inspect module} is not defined/available"
+      raise(Error, message: "module #{inspect module} is not defined/available")
 
     case module.__info__(:moduledoc) do
       { _, false } ->
@@ -168,7 +168,7 @@ defmodule ExDoc.Retriever do
       { _, _moduledoc } ->
         { Module.split(name), module, detect_type(module) }
       _ ->
-        raise Error, message: "module #{inspect module} was not compiled with flag --docs"
+        raise(Error, message: "module #{inspect module} was not compiled with flag --docs")
     end
   end
 


### PR DESCRIPTION
To reproduce, git clone latest project and then "mix compile", you will see a error similar to:

== Compilation error on file lib/ex_doc/retriever.ex ==
*\* (SyntaxError) /Users/aforward/tp/projects/ex_doc/lib/ex_doc/retriever.ex:163: unexpected comma. Parentheses are required to solve ambiguity in nested calls. Syntax error before: ','
    src/elixir_parser.yrl:621: :elixir_parser.throw/3
    src/elixir_parser.yrl:377: :elixir_parser.yeccpars2_282/7
    /usr/local/Cellar/erlang-r16/R16B/lib/erlang/lib/parsetools-2.0.9/include/yeccpre.hrl:56: :elixir_parser.yeccpars0/5
    src/elixir_translator.erl:16: :elixir_translator.forms/4
    src/elixir_translator.erl:28: :elixir_translator.forms!/4
    src/elixir_compiler.erl:24: :elixir_compiler.string/2
    src/elixir_compiler.erl:48: :elixir_compiler.file_to_path/2
    /private/tmp/elixir-GAQu/lib/elixir/lib/kernel/parallel_compiler.ex:68: Kernel.ParallelCompiler."-spawn_compilers/7-fun-0-"/3

Most likely due to the following update

https://github.com/elixir-lang/elixir/blob/master/CHANGELOG.md
[Kernel] Tighten up the grammar rules regarding parentheses omission, previously the examples below would compile but now they raise an error message:
