### PR TITLE
Fixed assert for Markdown.to_html("")

### DIFF
--- a/src/markdown_nif.c
+++ b/src/markdown_nif.c
@@ -26,6 +26,14 @@ static ERL_NIF_TERM render_term(ErlNifEnv* env, int argc, const ERL_NIF_TERM arg
     return enif_make_badarg(env);
   }
 
+  if (markdown_binary.size <= 0){
+    const char *empty_string = "";
+    const int empty_len = strlen(empty_string);
+    enif_alloc_binary(empty_len, &output_binary);
+    strncpy(output_binary.data, empty_string, empty_len);
+    return enif_make_binary(env, &output_binary);
+  }
+
   input = bufnew(markdown_binary.size);
   bufput(input, markdown_binary.data, markdown_binary.size);
   enif_release_binary(&markdown_binary);

--- a/test/markown_test.exs
+++ b/test/markown_test.exs
@@ -17,4 +17,8 @@ defmodule MarkdownTest do
     expected = %b(<p><a href="https://github.com/elixir-lang">https://github.com/elixir-lang</a></p>\n)
     assert Markdown.to_html("https://github.com/elixir-lang") == expected
   end
+
+  test "to_html handles empty input" do
+    assert Markdown.to_html("") == ""
+  end
 end


### PR DESCRIPTION
Ran into an assertion when trying to generate docs for this module:

``` elixir
defmodule Bob do
  @doc """
  """
  def example(), do: true
end
```

```
[jw-macbook-2 /tmp/bob]$ mix docs                                                                                                                               [] 
Compiled lib/bob.ex
Generated bob.app
Assertion failed: (buf && buf->unit), function bufput, file src/buffer.c, line 157.
[1]    3912 abort      mix docs
```

Figured fixing it in the nif was the best place to catch all possible use cases. I haven't done much nif coding, so making an size 0 `ErlNifBinary` and not actually copying anything to it might not be the smartest solution; open to cleaner suggestions.
