### PR TITLE
Marking variable as unused

### DIFF
--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -136,7 +136,7 @@ defmodule ExDoc.Retriever do
   end
 
   defp get_callback(callback, source_path, source_url, callbacks) do
-    { { name, arity } = tuple, line, kind, doc } = callback
+    { { name, arity } = tuple, line, _kind, doc } = callback
     { _, signatures } = List.keyfind(callbacks, tuple, 0, { nil, [] })
 
     if signature = Enum.first(signatures) do


### PR DESCRIPTION
Accidentally left the new tuple value without a leading underscore, so we get a compiler warning.
