### PR TITLE
Make docs_from_files and docs_from_modules behave the same

### DIFF
--- a/test/ex_doc/retriever_test.exs
+++ b/test/ex_doc/retriever_test.exs
@@ -11,6 +11,13 @@ defmodule ExDoc.RetrieverTest do
 
   ## MODULES
 
+  test "docs_from_files and docs_from_modules match" do
+    config = ExDoc.Config[source_url_pattern: "http://example.com/%{path}#L%{line}", source_root: File.cwd!]
+    file_nodes = Retriever.docs_from_files(["test/tmp/Elixir.UndefParent.Undocumented.beam"], config)
+    module_nodes = Retriever.docs_from_modules([UndefParent.Undocumented], config)
+    assert file_nodes == module_nodes
+  end
+
   test "docs_from_files returns the module id" do
     [node] = docs_from_files ["CompiledWithDocs"]
     assert node.id == "CompiledWithDocs"


### PR DESCRIPTION
`ExDoc.Retriever.docs_from_files` and `ExDoc.Retriever.docs_from_modules` handled modules with `@moduledoc false` differently. `docs_from_files` would return an empty list while `docs_from_modules` would return an `ExDoc.ModuleNode` with the `docs` field set to `[]`.

Both functions now return `[]`.

I ran into this difference while trying to remove the test fixtures from `ex_doc`. I can't think of a case where you want different behavior, but this might break code if someone was relying on it.
