### PR TITLE
Mix task checking for source_url in project's configuration

### DIFF
--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -56,6 +56,10 @@ defmodule Mix.Tasks.Docs do
     version = Mix.project[:version] || "dev"
     options = Mix.project[:docs] || []
 
+    if source_url = Mix.project[:source_url] do
+      options = Keyword.put(options, :source_url, source_url)
+    end
+
     cond do
       nil?(options[:main]) ->
         # Try generating main module's name from the app name


### PR DESCRIPTION
The Mix task was looking for `:source_url` in the `docs` project configuration. Was working correctly when specified from the command line. Addresses Issue #80.
