### PR TITLE
Fix passing atom to mix task :main option

### DIFF
--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -66,7 +66,7 @@ defmodule Mix.Tasks.Docs do
         options = Keyword.put(options, :main, (Mix.project[:app] |> atom_to_binary |> Mix.Utils.camelize))
 
       is_atom(options[:main]) ->
-        options = Keyword.update(options, :main, &Module.to_binary(&1))
+        options = Keyword.update!(options, :main, &inspect/1)
     end
 
     if formatter = options[:formatter] do


### PR DESCRIPTION
Looks like this code wasn't kept in sync with the Elixir main repo.
