### PR TITLE
Allow nice codeblocks for README

### DIFF
--- a/lib/ex_doc/html_formatter.ex
+++ b/lib/ex_doc/html_formatter.ex
@@ -65,6 +65,9 @@ defmodule ExDoc.HTMLFormatter do
 
   defp write_readme(output, {:ok, content}) do
     readme_html = Templates.readme_template(content)
+    # Allow using nice codeblock syntax for readme too.
+    readme_html = String.replace(readme_html, "<pre><code>",
+                                 "<pre class=\"codeblock\"><code>")
     File.write("#{output}/README.html", readme_html)
     true
   end

--- a/lib/ex_doc/html_formatter/templates/css/style.css
+++ b/lib/ex_doc/html_formatter/templates/css/style.css
@@ -27,7 +27,7 @@ div.docstring, p.docstring { margin-right: 6em; }
 .docstring h1 { font-size: 1.2em; }
 .docstring h2 { font-size: 1.1em; }
 .docstring h3, .docstring h4 { font-size: 1em; padding-top: 10px; }
-.docstring pre {
+.docstring pre, .codeblock {
   padding: 0.5em;
   border: #ffe0bb dotted 1px;
   background: #fffde8;


### PR DESCRIPTION
This is an ugly hack, but that's because our markdown pipeline isn't that great.
