### PR TITLE
Provide default docs for callback implementations

### DIFF
--- a/test/ex_doc/retriever_test.exs
+++ b/test/ex_doc/retriever_test.exs
@@ -143,6 +143,17 @@ defmodule ExDoc.RetrieverTest do
     assert hd(node.docs).signature == [{ :integer, [line: 7], [] }]
   end
 
+  test "undocumented callback implementations get default doc" do
+    [node] = docs_from_files(["CustomBehaviour", "CustomBehaviourTwo", "CustomBehaviourImpl"])
+             |> Enum.filter(&match?(ExDoc.ModuleNode[id: "CustomBehaviourImpl"], &1))
+    docs = Enum.sort(node.docs)
+    assert Enum.map(docs, &(&1.id)) == ["bye/1", "hello/1"]
+    assert Enum.at(docs, 0).doc ==
+      "A doc for this so it doesn't use 'Callback implementation of'"
+    assert Enum.at(docs, 1).doc ==
+      "Callback implementation of `CustomBehaviour.hello/1`."
+  end
+
   ## PROTOCOLS
 
   test "docs_from_files properly tag protocols" do

--- a/test/fixtures/behaviour.ex
+++ b/test/fixtures/behaviour.ex
@@ -6,3 +6,22 @@ defmodule CustomBehaviour do
   """
   defcallback hello(integer) :: integer
 end
+
+defmodule CustomBehaviourTwo do
+  use Behaviour
+
+  @doc """
+  This is a different sample callback.
+  """
+  defcallback bye(integer) :: integer
+end
+
+defmodule CustomBehaviourImpl do
+  @behaviour CustomBehaviour
+  @behaviour CustomBehaviourTwo
+
+  def hello(i), do: i
+
+  @doc "A doc for this so it doesn't use 'Callback implementation of'"
+  def bye(i), do: i
+end


### PR DESCRIPTION
This only triggers if there is no doc present and the module
has correctly declared @behaviour (in the correct spelling).

![hashset_with_default_docs](https://f.cloud.github.com/assets/4168875/1319853/0e7ad9fa-331c-11e3-9ced-5c85eccb3cbe.png)
