### PR TITLE
Sort callbacks alphabetically

### DIFF
--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -91,7 +91,7 @@ defmodule ExDoc.Retriever do
 
     if type == :behaviour do
       callbacks = Kernel.Typespec.beam_callbacks(module) || []
-      docs = Enum.map(module.__behaviour__(:docs),
+      docs = Enum.map(Enum.sort(module.__behaviour__(:docs)),
                       &get_callback(&1, source_path, source_url, callbacks)) ++ docs
     end
 

--- a/test/ex_doc/retriever_test.exs
+++ b/test/ex_doc/retriever_test.exs
@@ -146,7 +146,7 @@ defmodule ExDoc.RetrieverTest do
   test "undocumented callback implementations get default doc" do
     [node] = docs_from_files(["CustomBehaviour", "CustomBehaviourTwo", "CustomBehaviourImpl"])
              |> Enum.filter(&match?(ExDoc.ModuleNode[id: "CustomBehaviourImpl"], &1))
-    docs = Enum.sort(node.docs)
+    docs = node.docs
     assert Enum.map(docs, &(&1.id)) == ["bye/1", "hello/1"]
     assert Enum.at(docs, 0).doc ==
       "A doc for this so it doesn't use 'Callback implementation of'"


### PR DESCRIPTION
Callbacks weren't sorted alphabetically, which showed when looking at a large callback defining module such as `Dynamo.Connection`.
