### PR TITLE
Build docs for umbrella projects

### DIFF
--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Docs do
   use Mix.Task
 
   @shortdoc "Generate HTML documentation for the project"
-
+  @recursive true
   @moduledoc """
   Uses ExDoc to generate a static web page from the docstrings extracted from
   all of the project's modules.


### PR DESCRIPTION
As suggested in Issue #96

One thing to note, putting `ex_doc` in the top-level `mix.exs` file generates an error when running `mix deps.get`. I think because there is no app present in the umbrella definition.

```
[jw-macbook-2 ~/Projects/umbrella_test]$ mix deps.get                                                                                                         [] 
* Compiling ex_doc
==> ex_doc
make: `priv/markdown.so' is up to date.

Compiled lib/mix/tasks/docs.ex
Generated ex_doc.app
* Compiling umbrella1
* Compiling umbrella2
** (Mix) Cannot access build without an application name, please ensure you are in a directory with a mix.exs file and it defines an :app name under the project configuration
```
