### PR TITLE
Updated signature to handle map special forms

### DIFF
--- a/lib/ex_doc/html_formatter/templates.ex
+++ b/lib/ex_doc/html_formatter/templates.ex
@@ -51,7 +51,7 @@ defmodule ExDoc.HTMLFormatter.Templates do
     cond do
       name in [:__aliases__, :__block__] ->
         "#{name}(args)"
-      name in [:__ENV__, :__MODULE__, :__DIR__, :__CALLER__] ->
+      name in [:__ENV__, :__MODULE__, :__DIR__, :__CALLER__, :%, :%{}] ->
         "#{name}"
       true ->
         Macro.to_string { name, 0, args }


### PR DESCRIPTION
_Note:_ Made a new `v0.13` branch to capture all Erlang v0.13 changes.

Updated `ExDoc.HTMLFormatter.Templates.signature()` to handle the two new map special forms: `%{}` and `%Struct{}`. This allows `make docs` to run successfully in the Elixir `v0.13` branch.

Might need to create new specific cases to make the signatures better. Willing to take input.
