### PR TITLE
Update usage instructions for command-line ex_doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can ExDoc via the command line as follows:
 
 3. Next invoke the ex_doc executable from your project:
 
-        elixir -pa ebin PATH_TO_YOUR_EXDOC/bin/ex_doc "PROJECT_NAME" "PROJECT_VERSION" -m "PROJECT_MODULE" -u "https://github.com/GITHUB_USER/GITHUB_REPO"
+        PATH_TO_YOUR_EXDOC/bin/ex_doc "PROJECT_NAME" "PROJECT_VERSION" ebin -m "PROJECT_MODULE" -u "https://github.com/GITHUB_USER/GITHUB_REPO"
 
 For example, here are some acceptable values:
 


### PR DESCRIPTION
I have missed the commit which changed the usage, but this is what worked for me with the latest Elixir.
