### PR TITLE
Handling defexceptions.

### DIFF
--- a/lib/ex_doc/html_formatter/templates.ex
+++ b/lib/ex_doc/html_formatter/templates.ex
@@ -27,7 +27,7 @@ defmodule ExDoc.HTMLFormatter.Templates do
 
   # Get fields for records an exceptions, removing any field
   # that starts with underscore
-  defp get_fields(ExDoc.ModuleNode[type: type] = node) when type in [:record, :exception] do
+  defp get_fields(ExDoc.ModuleNode[type: type] = node) when type in [:record] do
     node.module.__record__(:fields)
     |> Enum.filter(fn({f,_}) -> hd(atom_to_list(f)) != ?_ end)
     |> presence

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -177,14 +177,19 @@ defmodule ExDoc.Retriever do
   # protocol, implementation or simply a module
   defp detect_type(module) do
     cond do
-      function_exported?(module, :__record__, 1) ->
-        case module.__record__(:fields) do
-          [{ :__exception__, :__exception__}|_] -> :exception
-          _ -> :record
-        end
+      function_exported?(module, :__record__, 1) -> :record
+      check_exception(module) -> :exception
       function_exported?(module, :__protocol__, 1) -> :protocol
       function_exported?(module, :__impl__, 1) -> :impl
       true -> nil
+    end
+  end
+
+  defp check_exception(module) do
+    if function_exported?(module, :__struct__, 0) do
+      Exception.exception?(module.__struct__())
+    else
+      false
     end
   end
 

--- a/test/ex_doc/html_formatter/templates_test.exs
+++ b/test/ex_doc/html_formatter/templates_test.exs
@@ -117,20 +117,12 @@ defmodule ExDoc.HTMLFormatter.TemplatesTest do
     assert content =~ ~r/<a class="toggle">/
   end
 
-  test "no arrows for exceptions without functions" do
-    defexception NoFunException, message: "No functions"
-
-    [node] = ExDoc.Retriever.docs_from_modules([NoFunException], doc_config)
-    content = Templates.list_item_template(node)
-    refute content =~ ~r/<a class="toggle">/
-  end
-
-  test "arrows for exceptions with functions" do
-    defexception FunException, message: "No functions" do
-      def exception_fun, do: true
+  test "arrows for exceptions without functions" do
+    defmodule NoFunException do
+      defexception [:message]
     end
 
-    [node] = ExDoc.Retriever.docs_from_modules([FunException], doc_config)
+    [node] = ExDoc.Retriever.docs_from_modules([NoFunException], doc_config)
     content = Templates.list_item_template(node)
     assert content =~ ~r/<a class="toggle">/
   end
@@ -231,12 +223,6 @@ defmodule ExDoc.HTMLFormatter.TemplatesTest do
     content = get_module_page([CompiledRecord])
     assert content =~ ~r{<strong>foo:</strong> nil}m
     assert content =~ ~r{<strong>bar:</strong> "sample"}m
-  end
-
-  test "module_page outputs exceptions fields" do
-    content = get_module_page([RandomError])
-    refute content =~ ~r{<strong>__exception__:</strong>}m
-    assert content =~ ~r{<strong>message:</strong> "this is random!"}m
   end
 
   ## PROTOCOLS

--- a/test/ex_doc/retriever_test.exs
+++ b/test/ex_doc/retriever_test.exs
@@ -122,12 +122,6 @@ defmodule ExDoc.RetrieverTest do
     assert node.type == :exception
   end
 
-  test "ignore exceptions internal functions" do
-    [node] = docs_from_files ["RandomError"]
-    functions = Enum.map node.docs, fn(doc) -> doc.id end
-    assert functions == []
-  end
-
   ## BEHAVIOURS
 
   test "ignore behaviours internal functions" do

--- a/test/fixtures/record.ex
+++ b/test/fixtures/record.ex
@@ -1,4 +1,6 @@
 defrecord CompiledRecord, [foo: nil, bar: "sample"] do
   @moduledoc "Hello"
 end
-defexception RandomError, message: "this is random!"
+defmodule RandomError do
+  defexception [:message]
+end


### PR DESCRIPTION
Setting the node type correctly for defexceptions. Updated the tests for the new format. Removed tests which no longer seemed appropriate (for instance, all exceptions have the `exception` and `message` functions).

They still live under the `Records` heading, so we should figure where to put them moving forward.
