### PR TITLE
Moving from __info__(:docs) to Code.get_docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule ExDoc.Mixfile do
   def project do
     [ app: :ex_doc,
       version: "0.1.0",
-      elixir: "~> 0.13.1-dev",
+      elixir: "~> 0.14.0-dev",
       compilers: [:sundown, :elixir, :app],
       source_url: "https://github.com/elixir-lang/ex_doc/"
     ]

--- a/test/ex_doc/html_formatter/templates_test.exs
+++ b/test/ex_doc/html_formatter/templates_test.exs
@@ -78,20 +78,12 @@ defmodule ExDoc.HTMLFormatter.TemplatesTest do
   ## LIST ITEMS
 
   test "arrows for modules with functions" do
-    defmodule FunctionModule do
-      def func, do: true
-    end
-
     [node] = ExDoc.Retriever.docs_from_modules([FunctionModule], doc_config)
     content = Templates.list_item_template(node)
     assert content =~ ~r/<a class="toggle">/
   end
 
   test "no arrows for modules without functions" do
-    defmodule NoFunctionsModule do
-      @moduledoc "Hello"
-    end
-
     [node] = ExDoc.Retriever.docs_from_modules([NoFunctionsModule], doc_config)
     content = Templates.list_item_template(node)
     refute content =~ ~r/<a class="toggle">/
@@ -182,18 +174,7 @@ defmodule ExDoc.HTMLFormatter.TemplatesTest do
     assert content =~ ~r{<div class="detail_header" id="hello/1">}
   end
 
-  ## RECORDS
-
-  test "module_page outputs the record type" do
-    content = get_module_page([CompiledRecord])
-    assert content =~ ~r{<h1>\s*CompiledRecord\s*<small>record</small>\s*<\/h1>}m
-  end
-
-  test "module_page outputs record fields" do
-    content = get_module_page([CompiledRecord])
-    assert content =~ ~r{<strong>foo:</strong> nil}m
-    assert content =~ ~r{<strong>bar:</strong> "sample"}m
-  end
+  ## EXCEPTIONS
 
   test "module_page outputs exceptions fields" do
     content = get_module_page([RandomError])

--- a/test/ex_doc/retriever_test.exs
+++ b/test/ex_doc/retriever_test.exs
@@ -102,19 +102,6 @@ defmodule ExDoc.RetrieverTest do
   end
 
 
-  ## RECORDS
-
-  test "docs_from_files properly tags records" do
-    [node] = docs_from_files ["CompiledRecord"]
-    assert node.type == :record
-  end
-
-  test "ignore records internal functions" do
-    [node] = docs_from_files ["CompiledRecord"]
-    functions = Enum.map node.docs, fn(doc) -> doc.id end
-    assert functions == []
-  end
-
   ## EXCEPTIONS
 
   test "docs_from_files properly tags exceptions" do

--- a/test/fixtures/function_module.ex
+++ b/test/fixtures/function_module.ex
@@ -1,0 +1,3 @@
+defmodule FunctionModule do
+  def func, do: true
+end

--- a/test/fixtures/no_function_module.ex
+++ b/test/fixtures/no_function_module.ex
@@ -1,0 +1,3 @@
+defmodule NoFunctionsModule do
+  @moduledoc "Hello"
+end

--- a/test/fixtures/random_error.ex
+++ b/test/fixtures/random_error.ex
@@ -1,0 +1,3 @@
+defmodule RandomError do
+  defexception [:message]
+end

--- a/test/fixtures/record.ex
+++ b/test/fixtures/record.ex
@@ -1,4 +1,0 @@
-defrecord CompiledRecord, [foo: nil, bar: "sample"] do
-  @moduledoc "Hello"
-end
-defexception RandomError, message: "this is random!"


### PR DESCRIPTION
Updated `mix.exs` file to `0.14-dev`.
Removed all references to `module.__info__(:docs)` and replaced them with `Code.get_docs`. Handled new output format.
Removed records and record tests.
Needed to move some fixtures out of modules and back into standalone files to access doc info.
