### PR TITLE
Sundown uses nmake on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,12 @@ ifeq ($(shell uname),Darwin)
 	OPTIONS=-dynamiclib -undefined dynamic_lookup
 endif
 
+ifeq ($(OS),Windows_NT)
+	SUNDOWN_MAKE=nmake -f Makefile.win
+else
+	SUNDOWN_MAKE=make
+endif
+
 all: ex_doc
 
 ex_doc:
@@ -20,7 +26,7 @@ sundown/src:
 	git submodule update --init
 
 sundown/libsundown.so: sundown/src
-	cd sundown && make
+	cd sundown && $(SUNDOWN_MAKE)
 
 SUNDOWN_OBJS=\
 	sundown/html/html.o \


### PR DESCRIPTION
For building Sundown itself, they supply a makefile for use with MSVC's `nmake` that should be used.  `mix compile` still fails since `CC` and friends are still statically defined for GCC.  So, next I'll probably either move more initializations into the if/else or just create an `nmake` makefile.  The `clean` target still functions thanks to MSYS on my system.
