### PR TITLE
Updating Markdown dep

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
 %{"hoedown": {:git, "git://github.com/hoedown/hoedown.git", "0610117f44b173a4e2112afb2f510156a32355b5", []},
-  "markdown": {:git, "git://github.com/devinus/markdown.git", "734db3b3a0c983ea0444dcbfbbcae8256db17019", []}}
+  "markdown": {:git, "git://github.com/devinus/markdown.git", "7b1912a693611a9445574e099687879948bafbae", []}}


### PR DESCRIPTION
Fixed deprecated `System.cmd/3` in markdown dependency.
