### PR TITLE
Order should be consistent: TYPES > FUNCTIONS > MACROS > CALLBACKS

### DIFF
--- a/lib/ex_doc/formatter/html/templates/module_template.eex
+++ b/lib/ex_doc/formatter/html/templates/module_template.eex
@@ -33,6 +33,9 @@
         <%= unless Enum.empty?(functions) and Enum.empty?(macros) do %>
           <li><a href="#summary">Summary</a></li>
         <% end %>
+        <%= unless Enum.empty?(types) do %>
+          <li><a href="#types_details">Types</a></li>
+        <% end %>
         <%= unless Enum.empty?(functions) do %>
           <li><a href="#functions_details">Functions</a></li>
         <% end %>
@@ -41,9 +44,6 @@
         <% end %>
         <%= unless Enum.empty?(callbacks) do %>
           <li><a href="#callbacks_details">Callbacks</a></li>
-        <% end %>
-        <%= unless Enum.empty?(types) do %>
-          <li><a href="#types_details">Types</a></li>
         <% end %>
       </ul>
 

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -97,8 +97,8 @@ defmodule ExDoc.Retriever do
 
     if type == :behaviour do
       callbacks = Enum.into(Kernel.Typespec.beam_callbacks(module) || [], %{})
-      docs = Enum.map(Enum.sort(module.__behaviour__(:docs)),
-                      &get_callback(&1, source_path, source_url, callbacks)) ++ docs
+      docs = docs ++ Enum.map(Enum.sort(module.__behaviour__(:docs)),
+                      &get_callback(&1, source_path, source_url, callbacks))
     end
 
     { line, moduledoc } = Code.get_docs(module, :moduledoc)


### PR DESCRIPTION
Order should be consistent: **TYPES > FUNCTIONS > MACROS > CALLBACKS**

This commit fixes the order in the function/macros under each the module on the directory on the left,
and links in the heading in the module page.
