### PR TITLE
autolink project modules and functions in readme file

### DIFF
--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -15,7 +15,7 @@ defmodule ExDoc.Formatter.HTML do
 
     generate_index(output, config)
     generate_assets(output, config)
-    has_readme = config.readme && generate_readme(output, config)
+    has_readme = config.readme && generate_readme(output, modules, config)
 
     all = Autolink.all(modules)
     modules    = filter_list(:modules, all)
@@ -57,21 +57,22 @@ defmodule ExDoc.Formatter.HTML do
     end
   end
 
-  defp generate_readme(output, config) do
+  defp generate_readme(output, modules, config) do
     File.rm("#{output}/README.html")
-    write_readme(output, File.read("README.md"), config)
+    write_readme(output, File.read("README.md"), modules, config)
   end
 
-  defp write_readme(output, {:ok, content}, config) do
+  defp write_readme(output, {:ok, content}, modules, config) do
+    content = Autolink.project_doc(content, modules)
     readme_html = Templates.readme_template(config, content)
     # Allow using nice codeblock syntax for readme too.
-    readme_html = String.replace(readme_html, "<pre><code>",
+    readme_html = String.replace(readme_html, "<pre><code class=\"\">",
                                  "<pre class=\"codeblock\"><code>")
     File.write("#{output}/README.html", readme_html)
     true
   end
 
-  defp write_readme(_, _, _) do
+  defp write_readme(_, _, _, _) do
     false
   end
 

--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -20,32 +20,30 @@ defmodule ExDoc.Formatter.HTML.Autolink do
   """
   def all(modules) do
     aliases = Enum.map modules, &(&1.module)
-    project_funs = for m <- modules, d <- m.docs, do: m.id <> "." <> d.id
-    project_modules = modules |> Enum.map(&module_to_string/1) |> Enum.uniq
-    Enum.map modules, &(&1 |> all_docs(project_funs, project_modules) |> all_typespecs(aliases))
+    Enum.map modules, &(&1 |> all_docs(modules) |> all_typespecs(aliases))
   end
 
   defp module_to_string(module) do
     inspect module.module
   end
 
-  defp all_docs(module, project_funs, modules) do
+  defp all_docs(module, modules) do
     locals = Enum.map module.docs, &(&1.id)
 
     if moduledoc = module.moduledoc do
-      moduledoc = moduledoc |> local_doc(locals) |> project_doc(project_funs, modules)
+      moduledoc = moduledoc |> local_doc(locals) |> project_doc(modules)
     end
 
     docs = for node <- module.docs do
       if doc = node.doc do
-        doc = doc |> local_doc(locals) |> project_doc(project_funs, modules)
+        doc = doc |> local_doc(locals) |> project_doc(modules)
       end
       %{node | doc: doc}
     end
 
     typedocs = for node <- module.typespecs do
       if doc = node.doc do
-        doc = doc |> local_doc(locals) |> project_doc(project_funs, modules)
+        doc = doc |> local_doc(locals) |> project_doc(modules)
       end
       %{node | doc: doc}
     end
@@ -164,8 +162,10 @@ defmodule ExDoc.Formatter.HTML.Autolink do
   @doc """
   Creates links to modules and functions defined in the project.
   """
-  def project_doc(bin, project_funs, modules) when is_binary(bin) do
-    bin |> project_functions(project_funs) |> project_modules(modules) |> erlang_functions
+  def project_doc(bin, modules) when is_binary(bin) do
+    project_funs = for m <- modules, d <- m.docs, do: m.id <> "." <> d.id
+    project_modules = modules |> Enum.map(&module_to_string/1) |> Enum.uniq
+    bin |> project_functions(project_funs) |> project_modules(project_modules) |> erlang_functions
   end
 
   @doc """

--- a/lib/ex_doc/formatter/html/templates/readme_template.eex
+++ b/lib/ex_doc/formatter/html/templates/readme_template.eex
@@ -25,4 +25,3 @@
     </div>
   </body>
 </html>
-

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -6,8 +6,10 @@ defmodule ExDoc.Formatter.HTMLTest do
   setup_all do
     :file.set_cwd("test")
     :file.make_dir(output_dir)
+    :file.copy("fixtures/README.md", "README.md")
 
     on_exit fn ->
+      :file.delete("README.md")
       System.cmd "rm", ["-rf", "#{output_dir}"]
       :file.set_cwd("..")
     end
@@ -24,7 +26,7 @@ defmodule ExDoc.Formatter.HTMLTest do
   end
 
   defp doc_config do
-    %ExDoc.Config{project: "Elixir", version: "1.0.1", source_root: beam_dir}
+    %ExDoc.Config{project: "Elixir", version: "1.0.1", source_root: beam_dir, readme: true}
   end
 
   defp get_modules(config \\ doc_config) do
@@ -73,5 +75,15 @@ defmodule ExDoc.Formatter.HTMLTest do
     assert content =~ ~r{<a href="CompiledWithDocs.html">CompiledWithDocs</a>}
     assert content =~ ~r{<p>moduledoc</p>}
     assert content =~ ~r{<a href="CompiledWithDocs.Nested.html">CompiledWithDocs.Nested</a>}
+  end
+
+  test "run generates the readme file" do
+    HTML.run(get_modules, doc_config)
+
+    assert File.regular?("#{output_dir}/README.html")
+    content = File.read!("#{output_dir}/README.html")
+    assert content =~ ~r{<a href="RandomError.html"><code>RandomError</code>}
+    assert content =~ ~r{<a href="CustomBehaviourImpl.html#hello/1"><code>CustomBehaviourImpl.hello/1</code>}
+    assert content =~ ~r{<a href="TypesAndSpecs.Sub.html"><code>TypesAndSpecs.Sub</code></a>}
   end
 end

--- a/test/fixtures/README.md
+++ b/test/fixtures/README.md
@@ -1,0 +1,3 @@
+`RandomError`
+`CustomBehaviourImpl.hello/1`
+`TypesAndSpecs.Sub`


### PR DESCRIPTION
@josevalim could you give me some feedback about this?

I'm not sure about the changes in `Autolink`, but now `project_doc` can be used without any kind of preparation of getting functions/modules name lists before calling it. Because there is just the info about the modules in the `HTML` module, I thought that would be the proper way to use. 
- refine `Autolink` module and `Autolink.project_doc/1` function to use it properly outsite of the Module
- `HTML.write_readme/4` uses `Autolink.project_doc/1` now to autolink readme file content
- fix 'codeblock' string replacement in `HTML.write_readme/4`. plain used ``` blocks are parsed as `<pre><code class="">`
