### PR TITLE
Path to README.md can be passed in as argument

### DIFF
--- a/lib/ex_doc.ex
+++ b/lib/ex_doc.ex
@@ -4,7 +4,7 @@ defmodule ExDoc do
       output: "docs", source_root: nil, source_url: nil, source_url_pattern: nil,
       homepage_url: nil, source_beam: nil, retriever: ExDoc.Retriever,
       formatter: "html", project: nil, version: nil, main: nil,
-      readme: false, formatter_opts: []
+      readme: nil, formatter_opts: []
     ]
   end
 

--- a/lib/ex_doc/cli.ex
+++ b/lib/ex_doc/cli.ex
@@ -1,6 +1,6 @@
 defmodule ExDoc.CLI do
   def run(args, generator \\ &ExDoc.generate_docs/3) do
-    {opts, args, _} = OptionParser.parse(args, switches: [readme: :boolean],
+    {opts, args, _} = OptionParser.parse(args,
                aliases: [o: :output, f: :formatter, u: :source_url, r: :source_root,
                          m: :main, p: :homepage_url, c: :config])
 
@@ -65,7 +65,7 @@ defmodule ExDoc.CLI do
       VERSION            Version number
       BEAMS              Path to compiled beam files
       -o, --output       Path to output docs, default: docs
-      --readme           Generate a project README from a README.md file, default: false
+      --readme           Path to README.md file to generate a project README, default: nil
       -f, --formatter    Docs formatter to use; default: html
       -c, --config       Path to the formatter's config file
       -r, --source-root  Path to the source code root, default: .

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -59,21 +59,27 @@ defmodule ExDoc.Formatter.HTML do
 
   defp generate_readme(output, modules, config) do
     File.rm("#{output}/README.html")
-    write_readme(output, File.read("README.md"), modules, config)
+    readme_path = Path.expand(config.readme)
+    write_readme(output, File.read(readme_path), modules, config)
   end
 
   defp write_readme(output, {:ok, content}, modules, config) do
     content = Autolink.project_doc(content, modules)
-    readme_html = Templates.readme_template(config, content)
-    # Allow using nice codeblock syntax for readme too.
-    readme_html = String.replace(readme_html, "<pre><code class=\"\">",
-                                 "<pre class=\"codeblock\"><code>")
+    readme_html = Templates.readme_template(config, content) |> pretty_codeblocks
     File.write("#{output}/README.html", readme_html)
     true
   end
 
   defp write_readme(_, _, _, _) do
     false
+  end
+
+  @doc false
+  # Helper to handle plain code blocks (```...```) without
+  # language specification and indentation code blocks
+  def pretty_codeblocks(bin) do
+    Regex.replace(~r/<pre><code\s*(class=\"\")?>/,
+                  bin, "<pre class=\"codeblock\">")
   end
 
   @doc false

--- a/test/ex_doc_test.exs
+++ b/test/ex_doc_test.exs
@@ -34,11 +34,11 @@ defmodule ExDocTest do
   test "command-line config" do
     File.write!("test.config", ~s([key: "val"]))
 
-    {project, version, opts} = run(["ExDoc", "--readme", "1.2.3", "...", "-c", "test.config"])
+    {project, version, opts} = run(["ExDoc", "--readme", "README.md", "1.2.3", "...", "-c", "test.config"])
 
     assert project == "ExDoc"
     assert version == "1.2.3"
-    assert Enum.sort(opts) == [formatter_opts: [key: "val"], readme: true, source_beam: "..."]
+    assert Enum.sort(opts) == [formatter_opts: [key: "val"], readme: "README.md", source_beam: "..."]
   after
     File.rm!("test.config")
   end


### PR DESCRIPTION
@josevalim did you thought about something like this?
- introduce `readme_path` to the config
- fix the case of codeblock variations which doens't format correct in the
  frontend
