### PR TITLE
exit script properly

### DIFF
--- a/lib/ex_doc/cli.ex
+++ b/lib/ex_doc/cli.ex
@@ -39,17 +39,16 @@ defmodule ExDoc.CLI do
     result
   end
 
-
   defp parse_args([_project, _version, _source_beam] = args), do: args
   defp parse_args([_, _, _ | _]) do
     IO.puts "Too many arguments.\n"
     print_usage()
-    exit(1)
+    exit {:shutdown, 1}
   end
   defp parse_args(_) do
     IO.puts "Too few arguments.\n"
     print_usage()
-    exit(1)
+    exit {:shutdown, 1}
   end
 
   defp print_usage do


### PR DESCRIPTION
@josevalim Just stumbled over it. When use `exit/1` instead the following output will be produced. 

``` shell
$ ../ex_doc/bin/ex_doc

Too few arguments.

Usage:
  ex_doc PROJECT VERSION BEAMS [OPTIONS]

Examples:
  ex_doc "Dynamo" "0.8.0" "_build/shared/lib/dynamo/ebin" -u "https://github.com/elixir-lang/dynamo"

Options:
  PROJECT            Project name
  VERSION            Version number
  BEAMS              Path to compiled beam files
  -o, --output       Path to output docs, default: docs
  --readme           Path to README.md file to generate a project README, default: nil
  -f, --formatter    Docs formatter to use; default: html
  -c, --config       Path to the formatter's config file
  -r, --source-root  Path to the source code root, default: .
  -u, --source-url   URL to the source code
  --source-ref       Branch/commit/tag used for source link inference, default: master
  -m, --main         The main, entry-point module in docs
  -p  --homepage-url URL to link to for the site name

## Source linking

ExDoc by default provide links to the source code implementation as
long as `--source-url` or `--source-url-pattern` is provided. If you
provide `--source-url`, ExDoc will inflect the url pattern automatically
for GitHub and Bitbucket URLs. For example:

    --source-url "https://github.com/elixir-lang/dynamo"

Will be inflected as:

    https://github.com/elixir-lang/dynamo/blob/master/%{path}#L%{line}

To specify a particular branch or commit, use the `--source-ref` option:

    --source-url "https://github.com/elixir-lang/dynamo" --source-ref "v1.0"

will result in the following URL pattern:

    https://github.com/elixir-lang/dynamo/blob/v1.0/%{path}#L%{line}


** (exit) 1
    lib/ex_doc/cli.ex:51: ExDoc.CLI.parse_args/1
    lib/ex_doc/cli.ex:7: ExDoc.CLI.run/2
    (elixir) src/elixir_lexical.erl:17: :elixir_lexical.run/3
    (elixir) lib/code.ex:316: Code.require_file/2
```
