### PR TITLE
Fix for including macro specs

### DIFF
--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -136,6 +136,9 @@ defmodule ExDoc.Retriever do
     true
   end
 
+  defp spec_name(name, arity, :defmacro), do: { String.to_atom("MACRO-" <> to_string(name)), arity + 1 }
+  defp spec_name(name, arity, _), do: { name, arity }
+
   defp get_function(function, source_path, source_url, all_specs, cb_impls) do
     { { name, arity }, line, type, signature, doc } = function
     behaviour = Dict.get(cb_impls, { name, arity })
@@ -148,7 +151,7 @@ defmodule ExDoc.Retriever do
       end
 
     specs = all_specs
-            |> Dict.get({ name, arity }, [])
+            |> Dict.get(spec_name(name, arity, type), [])
             |> Enum.map(&Kernel.Typespec.spec_to_ast(name, &1))
 
     %ExDoc.FunctionNode{

--- a/test/ex_doc/retriever_test.exs
+++ b/test/ex_doc/retriever_test.exs
@@ -61,13 +61,23 @@ defmodule ExDoc.RetrieverTest do
 
   test "docs_from_files returns the specs for each non-private function" do
     [node] = docs_from_files ["TypesAndSpecs"]
-    [add, _] = node.docs
+    [add, _, _] = node.docs
 
     assert add.id     == "add/2"
     assert add.doc    == nil
     assert add.type   == :def
     assert Macro.to_string(add.specs) ==
            "[add(integer(), opaque()) :: integer()]"
+  end
+
+  test "docs_from_files returns the specs for non-private macros" do
+    [node] = docs_from_files ["TypesAndSpecs"]
+    [_, _, macro] = node.docs
+
+    assert macro.id   == "macro_spec/1"
+    assert macro.doc  == nil
+    assert macro.type == :defmacro
+    assert Macro.to_string(macro.specs) == "[macro_spec(term(), any()) :: {:ok, any()}]"
   end
 
   test "docs_from_files returns the spec info for each non-private module type" do

--- a/test/fixtures/types_and_specs.ex
+++ b/test/fixtures/types_and_specs.ex
@@ -22,4 +22,10 @@ defmodule TypesAndSpecs do
   # This is just to ignore warnings about unused private types/functions.
   @spec ignore(private) :: integer
   def ignore(_), do: minus(0, 0)
+
+  @spec macro_spec(any) :: { :ok, any }
+  defmacro macro_spec(v), do: { :ok, v }
+
+  @spec priv_macro_spec(any) :: { :no, any }
+  defmacrop priv_macro_spec(v), do: { :no, v }
 end


### PR DESCRIPTION
Fix to https://github.com/elixir-lang/ex_doc/issues/164

The macro specs include a first argument of type term(), I'm not sure if it's best for that to be stripped out of the displayed spec or not. So I just left it be.
