### PR TITLE
Fix the HTML escaping broken by 5b520c4

### DIFF
--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -69,7 +69,12 @@ defmodule ExDoc.Formatter.HTML.Templates do
   defp presence(other), do: other
 
   defp h(binary) do
-    escape_map = [{"&", "&amp;"}, {"<", "&lt;"}, {">", "&gt;"}, {"\"", "&quot;"}]
+    escape_map = [
+      {"&", "\\&amp;"},
+      {"<", "\\&lt;"},
+      {">", "\\&gt;"},
+      {"\"", "\\&quot;"}
+    ]
     Enum.reduce escape_map, binary, fn({pattern, escape}, acc) ->
       String.replace(acc, pattern, escape)
     end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-%{"earmark": {:package, "0.1.10"},
+%{"earmark": {:hex, :earmark, "0.1.10"},
   "hoedown": {:git, "git://github.com/hoedown/hoedown.git", "0610117f44b173a4e2112afb2f510156a32355b5", []},
   "markdown": {:git, "git://github.com/devinus/markdown.git", "a428908a6dd88f351775d1d3da530a1a2aa0d6cb", []}}


### PR DESCRIPTION
Following the discussion here: https://github.com/elixir-lang/ex_doc/commit/5b520c4cad67c3a4b55042ca588ecfb5bea0b41f#commitcomment-9521480.

This PR reverts a change introduced in 5b520c4 which made a lot of `ex_doc` output look like this:

```
iex\> ...
```