### PR TITLE
Link to pages and load frame

### DIFF
--- a/lib/ex_doc/formatter/html/templates/index_template.eex
+++ b/lib/ex_doc/formatter/html/templates/index_template.eex
@@ -4,9 +4,18 @@
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 	<title><%= config.project %> v<%= config.version %> Documentation</title>
+	<script type="text/javascript" charset="utf-8">
+		window.onload = function frame_redirect() {
+			if ( window.location.href.match(/\/#!/, window.location.hash)  ) {
+				document.querySelector('#main').src = window.location.href.replace(/\/#!/, '/');
+			} else if ( window.location.href.match(/\/<%= config.main %>.html#!/, window.location.hash)  ) {
+				document.querySelector('#main').src = window.location.href.replace(/\/<%= config.main %>.html#!/, '/');
+			}
+		}
+	</script>	
 </head>
 <frameset cols="20%,*">
-  <frame name="list" src="modules_list.html" />
-  <frame name="main" src="<%= config.main %>.html" />
+  <frame name="list" id="list" src="modules_list.html" />
+  <frame name="main" id="main" src="<%= config.main %>.html" />
 </frameset>
 </html>

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-%{"earmark": {:package, "0.1.10"},
+%{"earmark": {:hex, :earmark, "0.1.10"},
   "hoedown": {:git, "git://github.com/hoedown/hoedown.git", "0610117f44b173a4e2112afb2f510156a32355b5", []},
   "markdown": {:git, "git://github.com/devinus/markdown.git", "a428908a6dd88f351775d1d3da530a1a2aa0d6cb", []}}


### PR DESCRIPTION
I noticed in the elixir website, when trying to link to a page in the docs, the frames are missing.
well, this solves this issue.

Let's say you want to link to: 
http://eksperimental.github.io/elixir/doc/Kernel.SpecialForms.html

then if you want to load the frames you link to:
http://eksperimental.github.io/elixir/doc//#!Kernel.SpecialForms.html
or even to special function in particular
http://eksperimental.github.io/elixir/doc/#!Kernel.SpecialForms.html#__DIR__/0

Let's say you are running the file in your computer, so you have to call `index.html`
http://eksperimental.github.io/elixir/doc/index.html#!Kernel.SpecialForms.html#__DIR__/0
it does still work.

Too bad I cannot update the url when you click, (so you can directly copy the url from the address bar) this is due to security restrictions dealing with frames... hopefully when we get rid of frames, we won't need this anymore.