### PR TITLE
fix `Error is not available` error in Retriever

### DIFF
--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -22,6 +22,7 @@ defmodule ExDoc.Retriever do
   Functions to extract documentation information from modules.
   """
 
+  alias ExDoc.Retriever.Error
 
   @doc """
   Extract documentation from all modules in the specified directory

--- a/test/ex_doc/retriever_test.exs
+++ b/test/ex_doc/retriever_test.exs
@@ -111,6 +111,12 @@ defmodule ExDoc.RetrieverTest do
     assert node.source == "http://foo.com/bar/test/fixtures/compiled_with_docs.ex\#L1"
   end
 
+  test "docs_from_modules fails when module is not available" do
+    config = %ExDoc.Config{source_url_pattern: "http://example.com/%{path}#L%{line}", source_root: File.cwd!}
+    assert_raise ExDoc.Retriever.Error, "module NotAvailable is not defined/available", fn ->
+      docs_from_files(["NotAvailable"], config)
+    end
+  end
 
   ## EXCEPTIONS
 


### PR DESCRIPTION
`Error` is used directly in ExDoc.Retriever, which will raise and error.