### PR TITLE
Fixed HTML5 markup validation errors.

### DIFF
--- a/lib/ex_doc/formatter/html/templates/index_template.eex
+++ b/lib/ex_doc/formatter/html/templates/index_template.eex
@@ -1,18 +1,18 @@
 <!DOCTYPE html>
 
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<html>
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-	<title><%= config.project %> v<%= config.version %> Documentation</title>
-	<script type="text/javascript" charset="utf-8">
-		window.onload = function frame_redirect() {
-			if ( window.location.href.match(/\/#!/, window.location.hash)  ) {
-				document.querySelector('#main').src = window.location.href.replace(/\/#!/, '/');
-			} else if ( window.location.href.match(/\/index.html#!/, window.location.hash)  ) {
-				document.querySelector('#main').src = window.location.href.replace(/\/index.html#!/, '/');
-			}
-		}
-	</script>	
+    <meta charset="utf-8"/>
+    <title><%= config.project %> v<%= config.version %> Documentation</title>
+    <script>
+        window.onload = function frame_redirect() {
+            if ( window.location.href.match(/\/#!/, window.location.hash)  ) {
+                document.querySelector('#main').src = window.location.href.replace(/\/#!/, '/');
+            } else if ( window.location.href.match(/\/index.html#!/, window.location.hash)  ) {
+                document.querySelector('#main').src = window.location.href.replace(/\/index.html#!/, '/');
+            }
+        }
+    </script>
 </head>
 <frameset cols="20%,*">
   <frame name="list" id="list" src="modules_list.html" />

--- a/lib/ex_doc/formatter/html/templates/list_template.eex
+++ b/lib/ex_doc/formatter/html/templates/list_template.eex
@@ -2,19 +2,11 @@
 <html>
   <head>
     <title>List of <%= String.capitalize("#{scope}") %></title>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <link rel="stylesheet" href="css/full_list.css" type="text/css" media="screen" charset="utf-8" />
-    <script type="text/javascript" charset="utf-8" src="js/jquery.js"></script>
-    <script type="text/javascript" charset="utf-8" src="js/full_list.js"></script>
+    <meta charset="utf-8" />
+    <link rel="stylesheet" href="css/full_list.css">
     <base id="base_target" target="_parent" />
   </head>
   <body class="frames">
-    <script type="text/javascript" charset="utf-8">
-      if (window.top.frames.main) {
-        document.getElementById('base_target').target = 'main';
-        document.body.className = 'frames';
-      }
-    </script>
     <section id="content">
       <h1 id="full_list_header">
         <%= if url = config.homepage_url || config.source_url do %>
@@ -42,8 +34,19 @@
       <ul id="full_list">
         <%= for node <- nodes, do: list_item_template(node) %>
       </ul>
-      
+
       <div id="no_results"></div>
     </section>
+
+    <!-- Scripts -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.5.2/jquery.min.js"></script>
+    <script>window.jQuery || document.write('<script src="js/jquery.js"><\/script>')</script>
+    <script src="js/full_list.js"></script>
+    <script>
+      if (window.top.frames.main) {
+        document.getElementById('base_target').target = 'main';
+        document.body.className = 'frames';
+      }
+    </script>
   </body>
 </html>

--- a/lib/ex_doc/formatter/html/templates/module_template.eex
+++ b/lib/ex_doc/formatter/html/templates/module_template.eex
@@ -3,27 +3,10 @@
   <head>
     <title><%= module.id %></title>
     <meta charset="utf-8" />
-    <link rel="stylesheet" href="css/style.css" type="text/css" media="screen" charset="utf-8" />
-    <link rel="stylesheet" href="css/elixir.css" type="text/css" media="screen" charset="utf-8" />
-    <script type="text/javascript" charset="utf-8">
-      relpath = '';
-      if (relpath != '') relpath += '/';
-    </script>
-
-    <script type="text/javascript" charset="utf-8" src="js/jquery.js"></script>
-    <script type="text/javascript" charset="utf-8" src="js/app.js"></script>
-    <script type="text/javascript" charset="utf-8" src="js/highlight.pack.js"></script>
-    <script type="text/javascript" charset="utf-8">
-      hljs.initHighlightingOnLoad();
-      hljs.configure({languages: []}); //disable autodetect
-    </script>
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="css/elixir.css">
   </head>
-
   <body>
-    <script type="text/javascript" charset="utf-8">
-      if (window.top.frames.main) document.body.className = 'frames';
-    </script>
-
     <section id="content">
       <div class="breadcrumbs"><%= module_breadcrumbs(config, all, module) %></div>
       <h1>
@@ -96,5 +79,21 @@
         </section>
       <% end %>
     </section>
+
+    <!-- Scripts -->
+    <script>
+      relpath = '';
+      if (relpath != '') relpath += '/';
+    </script>
+
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.5.2/jquery.min.js"></script>
+    <script>window.jQuery || document.write('<script src="js/jquery.js"><\/script>')</script>
+    <script src="js/app.js"></script>
+    <script src="js/highlight.pack.js"></script>
+    <script>
+      hljs.initHighlightingOnLoad();
+      hljs.configure({languages: []}); //disable autodetect
+      if (window.top.frames.main) { document.body.className = 'frames'; }
+    </script>
   </body>
 </html>

--- a/lib/ex_doc/formatter/html/templates/overview_template.eex
+++ b/lib/ex_doc/formatter/html/templates/overview_template.eex
@@ -3,22 +3,9 @@
   <head>
     <title>Overview</title>
     <meta charset="utf-8">
-    <link rel="stylesheet" href="css/style.css" type="text/css" media="screen" charset="utf-8" />
-
-    <script type="text/javascript" charset="utf-8">
-      relpath = '';
-      if (relpath != '') relpath += '/';
-    </script>
-
-    <script type="text/javascript" charset="utf-8" src="js/jquery.js"></script>
-    <script type="text/javascript" charset="utf-8" src="js/app.js"></script>
+    <link rel="stylesheet" href="css/style.css">
   </head>
-
   <body>
-    <script type="text/javascript" charset="utf-8">
-      if (window.top.frames.main) document.body.className = 'frames';
-    </script>
-
     <section id="content">
       <div class="breadcrumbs"><%= page_breadcrumbs(config, "Overview", "overview.html") %></div>
 
@@ -57,5 +44,18 @@
         </table>
       <% end %>
     </section>
+
+    <!-- Scripts -->
+    <script>
+      relpath = '';
+      if (relpath != '') relpath += '/';
+    </script>
+
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.5.2/jquery.min.js"></script>
+    <script>window.jQuery || document.write('<script src="js/jquery.js"><\/script>')</script>
+    <script src="js/app.js"></script>
+    <script>
+      if (window.top.frames.main) { document.body.className = 'frames'; }
+    </script>
   </body>
 </html>

--- a/lib/ex_doc/formatter/html/templates/readme_template.eex
+++ b/lib/ex_doc/formatter/html/templates/readme_template.eex
@@ -3,25 +3,24 @@
   <head>
     <title>README</title>
     <meta charset="utf-8" />
-    <link rel="stylesheet" href="css/style.css" type="text/css" media="screen" charset="utf-8" />
-
-    <script type="text/javascript" charset="utf-8">
-      relpath = '';
-      if (relpath != '') relpath += '/';
-    </script>
-
-    <script type="text/javascript" charset="utf-8" src="js/jquery.js"></script>
-    <script type="text/javascript" charset="utf-8" src="js/app.js"></script>
+    <link rel="stylesheet" href="css/style.css">
   </head>
-
   <body>
-    <script type="text/javascript" charset="utf-8">
-      if (window.top.frames.main) document.body.className = 'frames';
-    </script>
-
     <section id="content">
       <div class="breadcrumbs"><%= page_breadcrumbs(config, "README", "readme.html") %></div>
       <%= to_html(content) %>
     </section>
+
+    <!-- Scripts -->
+    <script type="text/javascript">
+      relpath = '';
+      if (relpath != '') relpath += '/';
+    </script>
+
+    <script src="js/jquery.js"></script>
+    <script src="js/app.js"></script>
+    <script>
+      if (window.top.frames.main) { document.body.className = 'frames'; }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
This PR include some improvements related with the markup, according to the specification for HTML5:

* The `type` attribute for the `script` element by default is `text/javascript` and now is optional.
* The `type` attribute for the `style` element by default is `text/css`, also the `charset` parameter must not be specified.
* Exactly one of the `name`, `http-equiv`, and `charset` attributes must be specified in the `meta` element.
* If either `name` or `http-equiv` is specified, then the `content` attribute must also be specified. Otherwise, it must be omitted.

I also put the scripts at the bottom of the page to avoid blocking parallel downloads, this might improve the overall rendering time. Finally, jQuery now can be obtained from a _Content Delivery Network_, if this fails we can obtain the local version.