### PR TITLE
Index priority: Main -> README -> Overview

### DIFF
--- a/lib/ex_doc.ex
+++ b/lib/ex_doc.ex
@@ -23,7 +23,7 @@ defmodule ExDoc do
     preconfig = %Config{
       project: project,
       version: version,
-      main: options[:main] || project,
+      main: options[:main],
       homepage_url: options[:homepage_url],
       source_root: options[:source_root] || File.cwd!,
     }

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -102,7 +102,7 @@ defmodule ExDoc.Formatter.HTML.Templates do
   end
 
   templates = [
-    overview_template: [:config, :modules, :exceptions, :protocols, :has_readme],
+    overview_template: [:config, :modules, :exceptions, :protocols, :has_readme, :has_main],
     sidebar_template: [:config, :has_readme],
     sidebar_items_template: [:input],
     sidebar_items_keys_template: [:node],

--- a/lib/ex_doc/formatter/html/templates/overview_template.eex
+++ b/lib/ex_doc/formatter/html/templates/overview_template.eex
@@ -2,7 +2,7 @@
     <%= sidebar_template(config, has_readme) %>
     <section id="content">
       <div class="breadcrumbs">
-        <%= if has_readme do %>
+        <%= if has_readme || has_main do %>
           <%= page_breadcrumbs(config, "Overview", "overview.html") %>
         <% else %>
           <%= page_breadcrumbs(config, "Overview", "index.html") %>

--- a/lib/ex_doc/formatter/html/templates/sidebar_template.eex
+++ b/lib/ex_doc/formatter/html/templates/sidebar_template.eex
@@ -8,11 +8,17 @@
   </h1>
 
   <h2 id="sub_list_header">
-    <%= if has_readme do %>
-    <a href="index.html">README</a>
-    <a href="overview.html">Overview</a>
-    <% else %>
-    <a href="index.html">Overview</a>
+    <%= cond do %>
+      <%= config.main && has_readme -> %>
+        <a href="readme.html">README</a>
+        <a href="overview.html">Overview</a>
+      <%= config.main && !has_readme -> %>
+        <a href="overview.html">Overview</a>
+      <%= !config.main && has_readme -> %>
+        <a href="index.html">README</a>
+        <a href="overview.html">Overview</a>
+      <%= !config.main && !has_readme -> %>
+        <a href="index.html">Overview</a>
     <% end %>
   </h2>
 


### PR DESCRIPTION
Now we consider the following cases:

 * `--main` and `--readme` options are set: `--main` is `index.html`
 * `--main` is not set and `--readme` option is set: `--readme` is `index.html`
 * `--main` and `--readme` options are not set: Overview is `index.html`

@josevalim Please let me know if this fulfil your request. 

Fix: #221 