### PR TITLE
Empty #full_list if there are no nodes available

### DIFF
--- a/lib/ex_doc/formatter/html/templates/js/app.js
+++ b/lib/ex_doc/formatter/html/templates/js/app.js
@@ -245,6 +245,7 @@
                 });
 
             if (!filtered) {
+                full_list.replaceWith(fullList);
                 return;
             }
 

--- a/lib/ex_doc/formatter/html/templates/js/app.js
+++ b/lib/ex_doc/formatter/html/templates/js/app.js
@@ -18,17 +18,6 @@
         sidebarNav = $('.nav'),
         clicked = null;
 
-    // Fix outside world links
-    function fixOutsideWorldLinks() {
-        $('a').each(function () {
-            if (window.location.host !== this.host) {
-                this.target = '_parent';
-            }
-        });
-    }
-
-    fixOutsideWorldLinks();
-
     function escapeText(text) {
         return text.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, "\\$&");
     }


### PR DESCRIPTION
Right now if there are no nodes (protocols, modules or exceptions) available we don't remove all child nodes of the `#full_list` element.

Also, delete the `fixOutsideWorldLinks` function, is no longer required.