### PR TITLE
Avoid double click in a sidebar link after search

### DIFF
--- a/lib/ex_doc/formatter/html/templates/js/app.js
+++ b/lib/ex_doc/formatter/html/templates/js/app.js
@@ -37,6 +37,12 @@
         });
     }
 
+    /**
+     * When the search field is empty show the children nodes of the #full_list
+     *
+     * Also removes the class .search_uncollapsed, .in_search, .found and .loading
+     * among other things to reset the sidebar default status
+     */
     function showAllResults() {
         clearTimeout(inSearch);
         inSearch = defaultSearchItemTimeOut;
@@ -56,6 +62,12 @@
         highlight();
     }
 
+    /**
+     * If no results were found, shows a message to the user.
+     *
+     * Also remove the 'loading' icon and clear the timeout returned
+     * initially by setTimeout.
+     */
     function searchDone() {
         highlight(true);
         if ($('#full_list li.found').size() === 0) {
@@ -75,6 +87,7 @@
             searchName,
             matchString,
             matchRegexp;
+
         for (i = 0; i < searchCache.length / 50; i += 1) {
             item = searchCache[searchIndex];
             searchName = (searchString.indexOf('.') !== -1 ? item.fullName : item.name);
@@ -102,12 +115,19 @@
         }, defaultSearchItemTimeOut);
     }
 
+    /**
+     * Fill the searchCache Array with the links found inside of the #full_list
+     *
+     * Define the initial set of events for the search field.
+     */
     function fullListSearch() {
         // generate cache
         searchCache = [];
+
         $('#full_list li').each(function () {
             var link = $(this).find('a.object_link:first'),
                 fullName;
+
             if (link.attr('title')) {
                 fullName = link.attr('title').split(' ')[0];
                 searchCache.push({
@@ -120,13 +140,13 @@
         });
 
         $('#search input').keypress(function (e) {
-            if (e.which === 13) {
+            if (e.which === 13) { // enter
                 $('#full_list li.found:first').find('a.object_link:first').click();
             }
         });
 
-        $('#search input').bind("keyup search reset change propertychange input paste", function (evnt) {
-            if ((evnt.keyCode > ignoreKeyCodeMin && evnt.keyCode < ignoreKeyCodeMax) || evnt.keyCode === commandKey) {
+        $('#search input').on('input', function (e) {
+            if ((e.keyCode > ignoreKeyCodeMin && e.keyCode < ignoreKeyCodeMax) || e.keyCode === commandKey) {
                 return;
             }
 
@@ -134,6 +154,7 @@
             searchString = this.value;
             caseSensitiveMatch = searchString.match(/[A-Z]/) !== null;
             regexSearchString = escapeText(searchString);
+
             if (searchString === "") {
                 showAllResults();
             } else {
@@ -152,7 +173,7 @@
     }
 
     function linkList() {
-        $('#full_list li, #full_list li a:last').click(function (evt) {
+        $('#full_list li, #full_list li a:last').click(function (e) {
             var toggle,
                 win;
 
@@ -162,7 +183,7 @@
 
             if (this.tagName.toLowerCase() === "li") {
                 toggle = $(this).children('a.toggle');
-                if (toggle.size() > 0 && evt.pageX < toggle.offset().left) {
+                if (toggle.size() > 0 && e.pageX < toggle.offset().left) {
                     toggle.click();
                     return false;
                 }
@@ -173,6 +194,7 @@
             }
 
             win = window.top.frames.main || window.parent;
+
             if (this.tagName.toLowerCase() === "a") {
                 clicked = $(this).parent('li').addClass('clicked');
                 win.location = this.href;
@@ -200,8 +222,8 @@
     }
 
     function escapeShortcut() {
-        $(document).keydown(function (evt) {
-            if (evt.which === 27) {
+        $(document).keydown(function (e) {
+            if (e.which === 27) { // escape
                 $('#search_frame', window.top.document).slideUp(100);
                 $('#search a', window.top.document).removeClass('active inactive');
                 $(window.top).focus();

--- a/lib/ex_doc/formatter/html/templates/sidebar_template.eex
+++ b/lib/ex_doc/formatter/html/templates/sidebar_template.eex
@@ -23,9 +23,9 @@
   </h2>
 
   <div class="nav">
-    <span class="selected"><a id="modules_list" href="#">Modules</a></span>
-    <span><a id="exceptions_list" href="#">Exceptions</a></span>
-    <span><a id="protocols_list" href="#">Protocols</a></span>
+    <span class="selected"><a id="modules_list" href="#full_list">Modules</a></span>
+    <span><a id="exceptions_list" href="#full_list">Exceptions</a></span>
+    <span><a id="protocols_list" href="#full_list">Protocols</a></span>
   </div>
 
   <div id="search"><input type="search" id="search_field" placeholder="Search" autocomplete="off" autofocus="autofocus" results="0" /></div>


### PR DESCRIPTION
The `input` event fires whenever the user has modified the data of
the control. So, this already covers the `keyup`, `paste`, etc.

This commit also includes the following:

 * Add documentation to some JS functions
 * Fix links in navigation area
 * Change the `evnt`, `evt` variables to `e` for consistency
 * Change `bind` to `on` method (jQuery)

Fix #222 