### PR TITLE
Fix the switch between nav elements

### DIFF
--- a/lib/ex_doc/formatter/html/templates/js/app.js
+++ b/lib/ex_doc/formatter/html/templates/js/app.js
@@ -333,30 +333,38 @@
         collapse();
     }
 
+    function setupSelected(id) {
+        $('#search input').val('');
+        ["#modules_list", "#exceptions_list", "#protocols_list"].forEach(function (element) {
+            if (element === id) {
+                $(element).parent().addClass('selected');
+            } else {
+                $(element).parent().removeClass('selected');
+            }
+        });
+    }
+
     sidebarNav.on('click', '#modules_list', function (e) {
         fillSidebarWithNodes(sidebarNodes, "modules");
         resetSidebar();
-        $('#modules_list').parent().addClass('selected');
-        $('#exceptions_list').parent().removeClass('selected');
-        $('#protocols_list').parent().removeClass('selected');
+        setupSelected('#modules_list');
+        showAllResults();
         e.preventDefault();
     });
 
     sidebarNav.on('click', '#exceptions_list', function (e) {
         fillSidebarWithNodes(sidebarNodes, "exceptions");
         resetSidebar();
-        $('#modules_list').parent().removeClass('selected');
-        $('#exceptions_list').parent().addClass('selected');
-        $('#protocols_list').parent().removeClass('selected');
+        setupSelected('#exceptions_list');
+        showAllResults();
         e.preventDefault();
     });
 
     sidebarNav.on('click', '#protocols_list', function (e) {
         fillSidebarWithNodes(sidebarNodes, "protocols");
         resetSidebar();
-        $('#modules_list').parent().removeClass('selected');
-        $('#exceptions_list').parent().removeClass('selected');
-        $('#protocols_list').parent().addClass('selected');
+        setupSelected('#protocols_list');
+        showAllResults();
         e.preventDefault();
     });
 


### PR DESCRIPTION
This commit fix the following issue mentioned in #231 and #232 

> Switching between "Modules, Exceptions and Protocols" once you searched
> something, it will will never shot the results in the other sections,
> and something the loading icon hangs there endlessly.

/cc @eksperimental @ericmj @josevalim 