### PR TITLE
Add label tag element for search input field

### DIFF
--- a/lib/ex_doc/formatter/html/templates/sidebar_template.eex
+++ b/lib/ex_doc/formatter/html/templates/sidebar_template.eex
@@ -39,6 +39,7 @@
   <div id="search" class="row">
     <div class="col-xs-10">
       <div class="input-group input-group-sm">
+        <label for="search_field" class="sr-only">Search</label>
         <input type="text" id="search_field" class="form-control" placeholder="Search" autocomplete="off" autofocus="autofocus" results="0">
         <span class="input-group-btn">
           <button class="btn btn-default" type="button"><span class="glyphicon glyphicon-search"></span></button>


### PR DESCRIPTION
This commit fix the following issue mentioned on elixir #235:

> The `input` element (used as a search field) could be improve if we use
> the `<label>` element tag to describe the functionality of the search
> field, is not enough the placeholder attribute inside of the `<input>`
> element tag.