### PR TITLE
Update local links to the current page

### DIFF
--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -82,7 +82,7 @@ defmodule ExDoc.Formatter.HTML.Templates do
       Enum.map_reduce(aliases, [], fn item, parents ->
         path = parents ++ [item]
         mod  = Module.concat(path)
-        page = if mod in modules, do: inspect(mod) <> ".html"
+        page = if mod in modules, do: inspect(mod) <> ".html#content"
         {{item, page}, path}
       end)
 

--- a/lib/ex_doc/formatter/html/templates/overview_template.eex
+++ b/lib/ex_doc/formatter/html/templates/overview_template.eex
@@ -6,9 +6,9 @@
           <span class="glyphicon glyphicon-menu-hamburger"></span>
         </button>
         <%= if has_readme || has_main do %>
-          <%= page_breadcrumbs(config, "Overview", "overview.html") %>
+          <%= page_breadcrumbs(config, "Overview", "overview.html#content") %>
         <% else %>
-          <%= page_breadcrumbs(config, "Overview", "index.html") %>
+          <%= page_breadcrumbs(config, "Overview", "index.html#content") %>
         <% end %>
       </div>
 

--- a/lib/ex_doc/formatter/html/templates/readme_template.eex
+++ b/lib/ex_doc/formatter/html/templates/readme_template.eex
@@ -5,7 +5,7 @@
   <button type="button" class="btn btn-default btn-sm" data-toggle="offcanvas">
     <span class="glyphicon glyphicon-menu-hamburger"></span>
   </button>
-  <%= page_breadcrumbs(config, "README", "index.html") %>
+  <%= page_breadcrumbs(config, "README", "index.html#content") %>
 </div>
 
 <%= to_html(content) %>

--- a/test/ex_doc/formatter/html/autolink_test.exs
+++ b/test/ex_doc/formatter/html/autolink_test.exs
@@ -79,14 +79,14 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
   end
 
   test "autolink modules in docs" do
-    assert Autolink.project_modules("`MyModule`", ["MyModule"]) == "[`MyModule`](MyModule.html)"
-    assert Autolink.project_modules("`MyModule.Nested`", ["MyModule.Nested"]) == "[`MyModule.Nested`](MyModule.Nested.html)"
-    assert Autolink.project_modules("`MyModule.Nested.Deep`", ["MyModule.Nested.Deep"]) ==
-      "[`MyModule.Nested.Deep`](MyModule.Nested.Deep.html)"
+    assert Autolink.project_modules("`MyModule`", ["MyModule"], "MyModule") == "[`MyModule`](MyModule.html#content)"
+    assert Autolink.project_modules("`MyModule.Nested`", ["MyModule.Nested"], "MyModule.Nested") == "[`MyModule.Nested`](MyModule.Nested.html#content)"
+    assert Autolink.project_modules("`MyModule.Nested.Deep`", ["MyModule.Nested.Deep"], "MyModule.Nested.Deep") ==
+      "[`MyModule.Nested.Deep`](MyModule.Nested.Deep.html#content)"
   end
 
   test "autolink modules doesn't link functions" do
-    assert Autolink.project_modules("`Mod.example/1`", ["Mod"]) == "`Mod.example/1`"
+    assert Autolink.project_modules("`Mod.example/1`", ["Mod"], "Mod") == "`Mod.example/1`"
   end
 
   test "autolink doesn't create links for pre-linked Mod docs" do

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -154,12 +154,12 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
     content = get_module_page([CompiledWithDocs])
     assert content =~ ~s{<div class="breadcrumbs">}
     assert content =~ ~s{Elixir v1.0.1 &rarr; <a href="overview.html">Overview</a> } <>
-                      ~s{&rarr; <a href="CompiledWithDocs.html">CompiledWithDocs</a>}
+                      ~s{&rarr; <a href="CompiledWithDocs.html#content">CompiledWithDocs</a>}
   end
 
   test "module_page breadcrumbs do not link to non-existent pages" do
     content = get_module_page([UndefParent.Nested])
-    assert content =~ ~r{&rarr; UndefParent &rarr; <a href="UndefParent.Nested.html">Nested</a>}
+    assert content =~ ~r{&rarr; UndefParent &rarr; <a href="UndefParent.Nested.html#content">Nested</a>}
   end
 
   test "module_page contains links to summary sections when those exist" do


### PR DESCRIPTION
Each local link that points to the current page must link to the top of the page instead, this way we can avoid reload the page each time that somebody follow those links. Fix #200 