### PR TITLE
Limit the module types in the navigation area

### DIFF
--- a/lib/ex_doc/formatter/html/templates/js/app.js
+++ b/lib/ex_doc/formatter/html/templates/js/app.js
@@ -357,7 +357,7 @@
         }
 
         module_type = $('#content h1 small').text();
-        if (module_type) {
+        if (module_type && (module_type === 'exception' || module_type === 'protocol')) {
             module_type = module_type + 's'; // pluralize 'exception' or 'protocol'
         } else {
             module_type = 'modules';


### PR DESCRIPTION
The navigation area only accepts `exceptions` and `protocols` as module types, this means that we need to ignore others (e.g. behaviour). #232 