### PR TITLE
Load Jquery from CDN only when using a remote site

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -91,3 +91,13 @@ Copyright 2011, The Dojo Foundation
   https://github.com/jquery/sizzle/blob/master/LICENSE.txt
 
 ==========================================================================
+
+Javascript fuction "should_request_from_CDN", based the regular expression
+to detect the private networks on the works from
+"Regular Expression for URL validation"
+https://gist.github.com/dperini/729294
+
+Copyright (c) 2010-2013 Diego Perini (http://www.iport.it)
+Released under MIT License
+
+==========================================================================

--- a/lib/ex_doc/formatter/html/templates/footer_template.eex
+++ b/lib/ex_doc/formatter/html/templates/footer_template.eex
@@ -1,11 +1,6 @@
   </section> <!--/content -->
 </div><!--/row -->
   <!-- Scripts -->
-    <script>
-      relpath = '';
-      if (relpath != '') relpath += '/';
-    </script>
-
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
     <script>window.jQuery || document.write('<script src="js/jquery.js"><\/script>')</script>
     <script src="js/highlight.pack.js"></script>

--- a/lib/ex_doc/formatter/html/templates/footer_template.eex
+++ b/lib/ex_doc/formatter/html/templates/footer_template.eex
@@ -1,8 +1,31 @@
   </section> <!--/content -->
 </div><!--/row -->
   <!-- Scripts -->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
-    <script>window.jQuery || document.write('<script src="js/jquery.js"><\/script>')</script>
+    <script>
+      function should_request_from_CDN(protocol, host) {
+        var re_private_network = new RegExp(
+          "^(?:" +
+            "(?:(?:10|127)(?:\\.\\d{1,3}){3})" +
+            "|(?:(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})" +
+            "|(?:172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})" +
+          ")$"
+        );
+
+        // if protocol is either http: or https: AND it is not a private network
+        // AND the hostname contains ".", THEN request from CDN
+        if ( ( protocol == 'http:' || protocol == 'https:' ) &&
+               re_private_network.test(host) == false && host.indexOf('.') !== -1 ) {
+          return true;
+        } else {
+          return false;
+        }
+      }
+
+      if ( should_request_from_CDN(window.location.protocol, window.location.host) ) {
+        document.write('<script src="\/\/ajax.googleapis.com\/ajax\/libs\/jquery\/2.1.4\/jquery.min.js"><\/script>');
+      }
+    </script>
+    <script>window.jQuery || document.write('<script src="js\/jquery.js"><\/script>')</script>
     <script src="js/highlight.pack.js"></script>
     <script src="js/app.js"></script>
   </body>


### PR DESCRIPTION
A javascript function "should_request_from_CDN" has been created to determine
whether to load from the CDN or from a local copy.
The rules are. if the page is served via http or https, and the host is
not a private network (127.x.x.x, or 192.168.x.x., or others), and
the hostname is contains a "."  (to avoid loading from localhost and others
user may have configured), only then, it will load from the CDN.

Range of private networks I am using: https://en.wikipedia.org/wiki/Private_network#Private_IPv4_address_spaces

I have used parts of this code, to determine if it's a private network
https://gist.github.com/dperini/729294

The other change is that now it requests from "//" and not from "https://"
*****

A second commit removes something that was remaning from I don't know where
https://github.com/elixir-lang/ex_doc/commit/1bede82875d7a17bfb3642a4e44835f5ab831488
