### PR TITLE
Licenses updated

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 ExDoc
 Copyright (c) 2012 Plataformatec
+https://github.com/elixir-lang/ex_doc/
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -15,34 +16,45 @@ Copyright (c) 2012 Plataformatec
 
 ==========================================================================
 
-CSS Template: lib/ex_doc/formatter/html/templates/css/style.css
+Bootstrap
+Copyright 2011. Twitter, Inc.
+http://getbootstrap.com
+
+  Licensed under the MIT license.
+  https://github.com/twbs/bootstrap/blob/master/LICENSE
+
+==========================================================================
+
+YARD
 Copyright (c) 2007 Loren Segal
+https://github.com/lsegal/yard
 
-	Permission is hereby granted, free of charge, to any person
-	obtaining a copy of this software and associated documentation
-	files (the "Software"), to deal in the Software without
-	restriction, including without limitation the rights to use,
-	copy, modify, merge, publish, distribute, sublicense, and/or sell
-	copies of the Software, and to permit persons to whom the
-	Software is furnished to do so, subject to the following
-	conditions:
+  Permission is hereby granted, free of charge, to any person
+  obtaining a copy of this software and associated documentation
+  files (the "Software"), to deal in the Software without
+  restriction, including without limitation the rights to use,
+  copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following
+  conditions:
 
-	The above copyright notice and this permission notice shall be
-	included in all copies or substantial portions of the Software.
+  The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of the Software.
 
-	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-	EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-	OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-	NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-	HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-	WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-	FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-	OTHER DEALINGS IN THE SOFTWARE.
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+  OTHER DEALINGS IN THE SOFTWARE.
 
 ==========================================================================
 
 highlight.js
 Copyright (c) 2006, Ivan Sagalaev
+https://highlightjs.org/
 
   All rights reserved.
   Redistribution and use in source and binary forms, with or without
@@ -70,8 +82,10 @@ Copyright (c) 2006, Ivan Sagalaev
 
 ==========================================================================
 
-lib/ex_doc/formatter/html/templates/css/elixir.css 
+github.com style
 (c) Vasily Polovnyov <vast@whiteants.net>
+https://github.com/isagalaev/highlight.js/blob/master/src/styles/github.css
+File: lib/ex_doc/formatter/html/templates/css/elixir.css
 
   Released under the same license as highlight.js
 
@@ -79,6 +93,7 @@ lib/ex_doc/formatter/html/templates/css/elixir.css
 
 jQuery JavaScript Library
 Copyright 2011, John Resig
+http://jquery.org
 
   Dual licensed under the MIT or GPL Version 2 licenses.
   http://jquery.org/license
@@ -89,5 +104,14 @@ Copyright 2011, The Dojo Foundation
 
   Released under the MIT, BSD, and GPL Licenses.
   https://github.com/jquery/sizzle/blob/master/LICENSE.txt
+
+==========================================================================
+
+normalize.css
+Copyright (c) Nicolas Gallagher and Jonathan Neal
+https://necolas.github.io/normalize.css/
+
+  Released under the MIT License.
+  https://github.com/necolas/normalize.css/blob/master/LICENSE.md
 
 ==========================================================================

--- a/README.md
+++ b/README.md
@@ -77,6 +77,6 @@ To see all options available when generating docs, just run `mix help docs`.
 
 # License
 
-ExDoc source code is released under Apache 2 License with snippets under MIT-LICENSE.
+ExDoc source code is released under Apache 2 License. The generated contents, however, are under different licenses based on projects used to help render html, including css, js and other assets.
 
-Check [LICENSE](LICENSE) file for more information.
+Check the [LICENSE](LICENSE) file for more information.

--- a/lib/ex_doc/formatter/html/templates/css/elixir.css
+++ b/lib/ex_doc/formatter/html/templates/css/elixir.css
@@ -1,6 +1,8 @@
 /*
 
 github.com style (c) Vasily Polovnyov <vast@whiteants.net>
+  Released under the same license as highlight.js
+  https://github.com/isagalaev/highlight.js/blob/master/LICENSE
 
 Source: https://github.com/isagalaev/highlight.js/blob/master/src/styles/github.css
 


### PR DESCRIPTION
 * normalized.css added to LICENSE
 * Links to the respective projects added
 * Removed  "CSS Template: lib/ex_doc/formatter/html/templates/css/style.css",
     since not only that the default template itself (css, html and js) is
     based on YARD
 * Tab replace with 2 spaces in the YARD license
 * Link to license added in /lib/ex_doc/formatter/html/templates/css/elixir.css