### PR TITLE
Redirect template added & Duplicate index page removed

### DIFF
--- a/lib/ex_doc.ex
+++ b/lib/ex_doc.ex
@@ -21,12 +21,15 @@ defmodule ExDoc do
   Generates documentation for the given `project`, `version`
   and `options`.
   """
+  @spec generate_docs(String.t, String.t, Keyword.t) :: atom
   def generate_docs(project, version, options) when is_binary(project) and is_binary(version) and is_list(options) do
     config = build_config(project, version, options)
     docs = config.retriever.docs_from_dir(config.source_beam, config)
     find_formatter(config.formatter).run(docs, config)
   end
 
+  # Builds configuration by merging `options`, and normalizing the options.
+  # @spec build_config(String.t, String.t, Keyword.t) :: %ExDoc.Config{Keyword.t}
   defp build_config(project, version, options) do
     options = normalize_options(options)
     preconfig = %Config{
@@ -61,14 +64,16 @@ defmodule ExDoc do
   # Helpers
 
   defp normalize_options(options) do
+    options_norm = []
+
     pattern = options[:source_url_pattern] || guess_url(options[:source_url], options[:source_ref] || "master")
-    normalized_options = [source_url_pattern: pattern]
+    options_norm = options_norm ++ [source_url_pattern: pattern]
 
     if is_bitstring(options[:output]) do
-      normalized_options = normalized_options ++ [output: String.rstrip(options[:output], ?/)]
+      options_norm = options_norm ++ [output: String.rstrip(options[:output], ?/)]
     end
 
-    Keyword.merge(options, normalized_options)
+    Keyword.merge(options, options_norm)
   end
 
   defp guess_url(url = <<"https://github.com/", _ :: binary>>, ref) do

--- a/lib/ex_doc.ex
+++ b/lib/ex_doc.ex
@@ -29,7 +29,7 @@ defmodule ExDoc do
   end
 
   # Builds configuration by merging `options`, and normalizing the options.
-  # @spec build_config(String.t, String.t, Keyword.t) :: %ExDoc.Config{Keyword.t}
+  @spec build_config(String.t, String.t, Keyword.t) :: %ExDoc.Config{}
   defp build_config(project, version, options) do
     options = normalize_options(options)
     preconfig = %Config{
@@ -64,16 +64,14 @@ defmodule ExDoc do
   # Helpers
 
   defp normalize_options(options) do
-    options_norm = []
-
     pattern = options[:source_url_pattern] || guess_url(options[:source_url], options[:source_ref] || "master")
-    options_norm = options_norm ++ [source_url_pattern: pattern]
+    options = Keyword.put(options, :source_url_pattern, pattern)
 
     if is_bitstring(options[:output]) do
-      options_norm = options_norm ++ [output: String.rstrip(options[:output], ?/)]
+      options = Keyword.put(options, :output, String.rstrip(options[:output], ?/))
     end
 
-    Keyword.merge(options, options_norm)
+    options
   end
 
   defp guess_url(url = <<"https://github.com/", _ :: binary>>, ref) do

--- a/lib/ex_doc.ex
+++ b/lib/ex_doc.ex
@@ -62,7 +62,13 @@ defmodule ExDoc do
 
   defp normalize_options(options) do
     pattern = options[:source_url_pattern] || guess_url(options[:source_url], options[:source_ref] || "master")
-    Keyword.put(options, :source_url_pattern, pattern)
+    normalized_options = [source_url_pattern: pattern]
+
+    if is_bitstring(options[:output]) do
+      normalized_options = normalized_options ++ [output: String.rstrip(options[:output], ?/)]
+    end
+
+    Keyword.merge(options, normalized_options)
   end
 
   defp guess_url(url = <<"https://github.com/", _ :: binary>>, ref) do

--- a/lib/ex_doc/cli.ex
+++ b/lib/ex_doc/cli.ex
@@ -1,8 +1,8 @@
 defmodule ExDoc.CLI do
   def run(args, generator \\ &ExDoc.generate_docs/3) do
     {opts, args, _} = OptionParser.parse(args,
-               aliases: [o: :output, f: :formatter, u: :source_url, r: :source_root,
-                         m: :main, p: :homepage_url, c: :config])
+               aliases: [o: :output, f: :formatter, c: :config, r: :source_root,
+                         u: :source_url, m: :main, p: :homepage_url])
 
     [project, version, source_beam] = parse_args(args)
 
@@ -63,14 +63,15 @@ defmodule ExDoc.CLI do
       PROJECT            Project name
       VERSION            Version number
       BEAMS              Path to compiled beam files
-      -o, --output       Path to output docs, default: docs
-      --readme           Path to README.md file to generate a project README, default: nil
-      -f, --formatter    Docs formatter to use; default: html
+      -o, --output       Path to output docs, default: "doc"
+      --readme           Path to README.md file to generate a project README, default: `nil`
+      -f, --formatter    Docs formatter to use, default: "html"
       -c, --config       Path to the formatter's config file
-      -r, --source-root  Path to the source code root, default: .
+      -r, --source-root  Path to the source code root, default: "."
       -u, --source-url   URL to the source code
-      --source-ref       Branch/commit/tag used for source link inference, default: master
-      -m, --main         The main, entry-point module in docs
+      --source-ref       Branch/commit/tag used for source link inference, default: "master"
+      -m, --main         The main, entry-point module in docs,
+                           default: "overview" when --fomatter is "html"
       -p  --homepage-url URL to link to for the site name
 
     ## Source linking

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -6,15 +6,10 @@ defmodule ExDoc.Formatter.HTML do
   alias ExDoc.Formatter.HTML.Templates
   alias ExDoc.Formatter.HTML.Autolink
 
-  defmodule Config do
-    defstruct [
-      main: "overview",
-    ]
-  end
-
   @doc """
   Generate HTML documentation for the given modules
   """
+  # @spec run(list, %ExDoc.Config{Keyword.t}) :: String.t
   def run(module_nodes, config) when is_map(config) do
     config = build_config(config)
     output = Path.expand(config.output)
@@ -40,7 +35,14 @@ defmodule ExDoc.Formatter.HTML do
   end
 
   defp build_config(config) when is_map(config) do
-    Map.merge(config, %Config{}, fn(_k, v1, v2) ->
+    if config.main == "index" do
+      raise ArgumentError, message: "`main` cannot be set to \"index\", otherwise it will recursively link to itself"
+    end
+
+    preconfig = %{
+      main: "overview",
+    }
+    Map.merge(config, preconfig, fn(_k, v1, v2) ->
       if is_nil(v1) do v2; else v1; end
     end)
   end

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -6,12 +6,15 @@ defmodule ExDoc.Formatter.HTML do
   alias ExDoc.Formatter.HTML.Templates
   alias ExDoc.Formatter.HTML.Autolink
 
+  # default values
+  @main "overview"
+
   @doc """
   Generate HTML documentation for the given modules
   """
-  # @spec run(list, %ExDoc.Config{Keyword.t}) :: String.t
+  @spec run(list, %ExDoc.Config{}) :: String.t
   def run(module_nodes, config) when is_map(config) do
-    config = build_config(config)
+    config = normalize_config(config)
     output = Path.expand(config.output)
     File.rm_rf! output
     :ok = File.mkdir_p output
@@ -34,17 +37,14 @@ defmodule ExDoc.Formatter.HTML do
     Path.join(config.output, "index.html")
   end
 
-  defp build_config(config) when is_map(config) do
+  # Builds `config` by setting default values and checking for non-valid ones.
+  @spec normalize_config(%ExDoc.Config{}) :: %ExDoc.Config{}
+  defp normalize_config(config) when is_map(config) do
     if config.main == "index" do
-      raise ArgumentError, message: "`main` cannot be set to \"index\", otherwise it will recursively link to itself"
+      raise ArgumentError, message: "\"main\" cannot be set to \"index\", otherwise it will recursively link to itself"
     end
 
-    preconfig = %{
-      main: "overview",
-    }
-    Map.merge(config, preconfig, fn(_k, v1, v2) ->
-      if is_nil(v1) do v2; else v1; end
-    end)
+    Map.put(config, :main, config.main || @main)
   end
 
   defp generate_index(output, config) do

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -109,7 +109,7 @@ defmodule ExDoc.Formatter.HTML.Templates do
     head_template: [:page],
     module_template: [:config, :module, :types, :functions, :macros, :callbacks, :all, :has_readme],
     overview_entry_template: [:node],
-    overview_template: [:config, :modules, :exceptions, :protocols, :has_readme, :has_main],
+    overview_template: [:config, :modules, :exceptions, :protocols, :has_readme],
     readme_template: [:config, :modules, :exceptions, :protocols, :content],
     sidebar_items_entry_template: [:node],
     sidebar_items_keys_template: [:node],
@@ -117,6 +117,7 @@ defmodule ExDoc.Formatter.HTML.Templates do
     sidebar_template: [:config, :modules, :exceptions, :protocols, :has_readme],
     summary_template: [:node],
     type_detail_template: [:node, :_module],
+    redirect_template: [:config, :redirect_to],
   ]
 
   Enum.each templates, fn({ name, args }) ->

--- a/lib/ex_doc/formatter/html/templates/overview_template.eex
+++ b/lib/ex_doc/formatter/html/templates/overview_template.eex
@@ -5,10 +5,8 @@
         <button type="button" class="btn btn-default btn-sm" data-toggle="offcanvas">
           <span class="glyphicon glyphicon-menu-hamburger"></span>
         </button>
-        <%= if has_readme || has_main do %>
+        <%= if has_readme do %>
           <%= page_breadcrumbs(config, "Overview", "overview.html#content") %>
-        <% else %>
-          <%= page_breadcrumbs(config, "Overview", "index.html#content") %>
         <% end %>
       </div>
 

--- a/lib/ex_doc/formatter/html/templates/readme_template.eex
+++ b/lib/ex_doc/formatter/html/templates/readme_template.eex
@@ -5,7 +5,7 @@
   <button type="button" class="btn btn-default btn-sm" data-toggle="offcanvas">
     <span class="glyphicon glyphicon-menu-hamburger"></span>
   </button>
-  <%= page_breadcrumbs(config, "README", "index.html#content") %>
+  <%= page_breadcrumbs(config, "README", "readme.html#content") %>
 </div>
 
 <%= to_html(content) %>

--- a/lib/ex_doc/formatter/html/templates/redirect_template.eex
+++ b/lib/ex_doc/formatter/html/templates/redirect_template.eex
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= config.project %> – Redirecting...</title>
+    <meta http-equiv="refresh" content="0; url=<%= h(redirect_to) %>" />
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="generator" content="ExDoc" />
+  </head>
+  <body>
+    <div style="font-size: 1.2em; text-align:center; margin: 3.6em; ">
+      <p><strong>The page you have requested has been moved.</strong></p>
+      <p>If you are not redirected automatically, visit <a href="<%= h(redirect_to) %>"><%= h(redirect_to) %></a></p>
+      <script>
+        document.location.href = "<%= redirect_to %>";
+      </script>
+    </div>
+  </body>
+</html>

--- a/lib/ex_doc/formatter/html/templates/sidebar_template.eex
+++ b/lib/ex_doc/formatter/html/templates/sidebar_template.eex
@@ -15,18 +15,10 @@
   </h1>
 
   <h2 id="sub_list_header">
-    <%= cond do %>
-      <%= config.main && has_readme -> %>
-        <a href="readme.html">README</a>
-        <a href="overview.html">Overview</a>
-      <%= config.main && !has_readme -> %>
-        <a href="overview.html">Overview</a>
-      <%= !config.main && has_readme -> %>
-        <a href="index.html">README</a>
-        <a href="overview.html">Overview</a>
-      <%= !config.main && !has_readme -> %>
-        <a href="index.html">Overview</a>
+    <%= if has_readme do %>
+      <a href="readme.html">README</a> 
     <% end %>
+    <a href="overview.html">Overview</a>
   </h2>
 
   <div class="nav">

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -31,26 +31,30 @@ defmodule Mix.Tasks.Docs do
 
   * `:formatter` - doc formatter to use; default: "html".
 
-  * `:source_root` - path to the source code root directory; default: "." (current directory).
+  * `:source_root` - path to the source code root directory;
+    default: "." _(current directory)_.
 
   * `:source_beam` - path to the beam directory; default: mix's compile path.
-
+  
   * `:source_url_pattern` - public URL of the project.
     Derived from project's `:source_url` if not present.
 
   * `:source_ref` - the branch/commit/tag used for source link inference.
     Ignored if `:source_url_pattern` is provided; default: master.
 
-  * `:main` - main page of the documentation. It may be a module or a
-    generated page, like "overview" or "README";
+  * `:main` - main page of the documentation. It may be a module or a generated page,
+    like "overview" or "readme"; default: "overview" when --fomatter is "html".
   """
 
   @doc false
   def run(args, config \\ Mix.Project.config, generator \\ &ExDoc.generate_docs/3) do
     Mix.Task.run "compile"
 
-    {cli_opts, args, _} = OptionParser.parse(args, aliases: [o: :output],
-                                                   switches: [output: :string])
+    {cli_opts, args, _} = OptionParser.parse( args,
+                            aliases: [o: :output, f: :formatter, c: :config,
+                                      r: :source_root, u: :source_url,
+                                      m: :main, p: :homepage_url, ],
+                            switches: [output: :string], )
 
     if args != [] do
       Mix.raise "Extraneous arguments on the command line"

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -13,9 +13,14 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
   end
 
   defp doc_config do
-    %ExDoc.Config{project: "Elixir", version: "1.0.1", source_root: File.cwd!,
-                  source_url_pattern: "#{source_url}/blob/master/%{path}#L%{line}",
-                  homepage_url: homepage_url, source_url: source_url}
+    %ExDoc.Config{
+      project: "Elixir",
+      version: "1.0.1",
+      source_root: File.cwd!,
+      source_url_pattern: "#{source_url}/blob/master/%{path}#L%{line}",
+      homepage_url: homepage_url,
+      source_url: source_url,
+    }
   end
 
   defp get_module_page(names) do
@@ -85,12 +90,12 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
 
   test "listing page has README link if present" do
     content = Templates.sidebar_template(doc_config, [], [], [], true)
-    assert content =~ ~r{<a href="index.html">README</a>}
+    assert content =~ ~r{<a href="readme.html">README</a>}
   end
 
   test "listing page doesn't have README link if not present" do
     content = Templates.sidebar_template(doc_config, [], [], [], false)
-    refute content =~ ~r{<a href="index.html">README</a>}
+    refute content =~ ~r{<a href="readme.html">README</a>}
   end
 
   ## MODULES

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -4,13 +4,16 @@ defmodule ExDoc.Formatter.HTMLTest do
   alias ExDoc.Formatter.HTML
 
   setup_all do
-    File.copy("test/fixtures/README.md", "test/tmp/README.md")
+    {:ok, _} = File.copy("test/fixtures/README.md", "test/tmp/README.md")
+
     :ok
   end
 
   setup do
-    File.rm_rf("#{output_dir}")
-    File.mkdir(output_dir)
+    {:ok, _} = File.rm_rf(output_dir)
+    :ok = File.mkdir(output_dir)
+    {:ok, []} = File.ls(output_dir)
+
     :ok
   end
 
@@ -125,18 +128,13 @@ defmodule ExDoc.Formatter.HTMLTest do
   end
 
   test "run generates index.html and normalized options" do
-    # 1. Check for default [main: "overview"]
-    # 2. Check for output dir having trailing "/" stripped
-    for dir <- ["#{output_dir}", "#{output_dir}/", "#{output_dir}//"] do
-      File.rm_rf(output_dir)
-      File.mkdir(output_dir)
-      refute File.regular?("#{output_dir}/index.html")
-      generate_docs doc_config([output: dir, main: nil, ])
+    # 1. Check for output dir having trailing "/" stripped
+    # 2. Check for default [main: "overview"]
+    generate_docs doc_config([output: "#{output_dir}//", main: nil, ])
 
-      content = File.read!("#{output_dir}/index.html")
-      assert content =~ ~r{<meta http-equiv="refresh" content="0; url=overview.html"\s*/>}
-      assert File.regular?("#{output_dir}/readme.html")
-    end
+    content = File.read!("#{output_dir}/index.html")
+    assert content =~ ~r{<meta http-equiv="refresh" content="0; url=overview.html"\s*/>}
+    assert File.regular?("#{output_dir}/overview.html")
   end
 
   test "run generates trying to set 'main: index', should fail" do

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -42,17 +42,6 @@ defmodule ExDoc.Formatter.HTMLTest do
     ExDoc.generate_docs(config[:project], config[:version], config)
   end
 
-  test "run generates the html file with the documentation" do
-    generate_docs(doc_config)
-
-    assert File.regular?("#{output_dir}/CompiledWithDocs.html")
-    assert File.regular?("#{output_dir}/CompiledWithDocs.Nested.html")
-    assert File.regular?("#{output_dir}/readme.html")
-    assert File.regular?("#{output_dir}/overview.html")
-    content = File.read!("#{output_dir}/index.html")
-    assert content =~ ~r{<meta http-equiv="refresh" content="0; url=overview.html"\s*/>}
-  end
-
   test "run generates the html file with the documentation and readme.html" do
     generate_docs(doc_config)
 
@@ -63,14 +52,16 @@ defmodule ExDoc.Formatter.HTMLTest do
     assert content =~ ~r{<meta http-equiv="refresh" content="0; url=overview.html"\s*/>}
   end
 
-  test "run generates in specified output directory" do
-    config = doc_config([output: "#{output_dir}/another_dir"])
+  test "run generates in specified output directory and redirect index.html file" do
+    config = doc_config([output: "#{output_dir}/another_dir", main: "RandomError", ])
     generate_docs(config)
 
     assert File.regular?("#{output_dir}/another_dir/CompiledWithDocs.html")
-    assert File.regular?("#{output_dir}/another_dir/index.html")
     assert File.regular?("#{output_dir}/another_dir/dist/app.css")
     assert File.regular?("#{output_dir}/another_dir/dist/app.js")
+    assert File.regular?("#{output_dir}/another_dir/RandomError.html")
+    content = File.read!("#{output_dir}/another_dir/index.html")
+    assert content =~ ~r{<meta http-equiv="refresh" content="0; url=RandomError.html"\s*/>}
   end
 
   test "run generates all listing files" do
@@ -109,6 +100,14 @@ defmodule ExDoc.Formatter.HTMLTest do
     assert content =~ ~r{<a href="TypesAndSpecs.Sub.html"><code>TypesAndSpecs.Sub</code></a>}
   end
 
+  test "run should not generate the readme file" do
+    generate_docs(doc_config([readme: nil, ]))
+
+    refute File.regular?("#{output_dir}/readme.html")
+    content = File.read!("#{output_dir}/index.html")
+    refute content =~ ~r{<title>[^<]* README</title>}
+  end
+
   test "make markdown codeblocks pretty" do
     with_empty_class = "<pre><code class=\"\">mix run --no-halt path/to/file.exs"
     without_class = "<pre><code>mix run --no-halt path/to/file.exs"
@@ -125,33 +124,27 @@ defmodule ExDoc.Formatter.HTMLTest do
           "<pre><code class=\"iex elixir\">iex&gt; max(4, 5)"
   end
 
-  test "run generates the redirect index.html" do
-    config = doc_config([project: "Elixir", version: "1.0.1", output: "#{output_dir}/redirect", main: "RandomError", ])
-    generate_docs(config)
-
-    assert File.regular?("#{output_dir}/redirect/RandomError.html")
-    content = File.read!("#{output_dir}/redirect/index.html")
-    assert content =~ ~r{<meta http-equiv="refresh" content="0; url=RandomError.html"\s*/>}
-  end
-
   test "run generates index.html and normalized options" do
-    for dir <- ["test/tmp/doc", "test/tmp/doc/", "test/tmp/doc//"] do
-      generate_docs doc_config([output: dir])
+    # 1. Check for default [main: "overview"]
+    # 2. Check for output dir having trailing "/" stripped
+    for dir <- ["#{output_dir}", "#{output_dir}/", "#{output_dir}//"] do
+      File.rm_rf(output_dir)
+      File.mkdir(output_dir)
+      refute File.regular?("#{output_dir}/index.html")
+      generate_docs doc_config([output: dir, main: nil, ])
 
-      content = File.read!("test/tmp/doc/index.html")
+      content = File.read!("#{output_dir}/index.html")
       assert content =~ ~r{<meta http-equiv="refresh" content="0; url=overview.html"\s*/>}
-      assert File.regular?("test/tmp/doc/readme.html")
+      assert File.regular?("#{output_dir}/readme.html")
     end
   end
 
-  test "run generates trying to set 'main: index'" do
+  test "run generates trying to set 'main: index', should fail" do
     config = doc_config([main: "index"])
     assert_raise ArgumentError,
-                 "`main` cannot be set to \"index\", otherwise it will recursively link to itself",
+                 "\"main\" cannot be set to \"index\", otherwise it will recursively link to itself",
                  fn -> generate_docs(config) end
-    refute File.regular?("test/tmp/doc/index.html")
-    refute File.regular?("test/tmp/doc/overview.html")
-    refute File.regular?("test/tmp/doc/readme.html")
+    assert {:ok, []} == File.ls "#{output_dir}"
   end
 
 end

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -38,6 +38,21 @@ defmodule ExDoc.Formatter.HTMLTest do
 
     assert File.regular?("#{output_dir}/CompiledWithDocs.html")
     assert File.regular?("#{output_dir}/CompiledWithDocs.Nested.html")
+    assert File.regular?("#{output_dir}/readme.html")
+    assert File.regular?("#{output_dir}/overview.html")
+    content = File.read!("#{output_dir}/index.html")
+    assert content =~ ~r{<meta http-equiv="refresh" content="0; url=overview.html"\s*/>}
+  end
+
+  test "run generates the html file with the documentation and readme.html" do
+    config = Map.merge(doc_config, %{})
+    HTML.run(get_modules, config)
+
+    assert File.regular?("#{output_dir}/CompiledWithDocs.html")
+    assert File.regular?("#{output_dir}/CompiledWithDocs.Nested.html")
+    assert File.regular?("#{output_dir}/readme.html")
+    content = File.read!("#{output_dir}/index.html")
+    assert content =~ ~r{<meta http-equiv="refresh" content="0; url=overview.html"\s*/>}
   end
 
   test "run generates in specified output directory" do
@@ -70,7 +85,6 @@ defmodule ExDoc.Formatter.HTMLTest do
   test "run generates the overview file" do
     HTML.run(get_modules, doc_config)
 
-    assert File.regular?("#{output_dir}/overview.html")
     content = File.read!("#{output_dir}/overview.html")
     assert content =~ ~r{<a href="CompiledWithDocs.html">CompiledWithDocs</a>}
     assert content =~ ~r{<p>moduledoc</p>}
@@ -80,8 +94,8 @@ defmodule ExDoc.Formatter.HTMLTest do
   test "run generates the readme file" do
     HTML.run(get_modules, doc_config)
 
-    assert File.regular?("#{output_dir}/index.html")
-    content = File.read!("#{output_dir}/index.html")
+    content = File.read!("#{output_dir}/readme.html")
+    assert content =~ ~r{<title>[^<]* README</title>}
     assert content =~ ~r{<a href="RandomError.html"><code>RandomError</code>}
     assert content =~ ~r{<a href="CustomBehaviourImpl.html#hello/1"><code>CustomBehaviourImpl.hello/1</code>}
     assert content =~ ~r{<a href="TypesAndSpecs.Sub.html"><code>TypesAndSpecs.Sub</code></a>}
@@ -102,4 +116,32 @@ defmodule ExDoc.Formatter.HTMLTest do
     assert HTML.pretty_codeblocks(iex_detected_without_class) ==
           "<pre><code class=\"iex elixir\">iex&gt; max(4, 5)"
   end
+
+  test "run generates the redirect index.html" do
+    config = %ExDoc.Config{output: "#{output_dir}/redirect", main: "RandomError", }
+    HTML.run(get_modules(config), config)
+
+    assert File.regular?("#{output_dir}/redirect/RandomError.html")
+    content = File.read!("#{output_dir}/redirect/index.html")
+    assert content =~ ~r{<meta http-equiv="refresh" content="0; url=RandomError.html"\s*/>}
+  end
+
+  test "run generates index.html and normalized options" do
+    config = Map.merge(doc_config, %{output: "test/tmp/doc//"})
+    HTML.run(get_modules, config)
+
+    content = File.read!("test/tmp/doc/index.html")
+    assert content =~ ~r{<meta http-equiv="refresh" content="0; url=overview.html"\s*/>}
+    assert File.regular?("test/tmp/doc/readme.html")
+  end
+
+  test "run generates trying to sex 'main: index.html'" do
+    config = Map.merge(doc_config, %{main: "index"})
+    HTML.run(get_modules, config)
+
+    content = File.read!("test/tmp/doc/index.html")
+    assert content =~ ~r{<meta http-equiv="refresh" content="0; url=index.html"\s*/>}
+    assert File.regular?("test/tmp/doc/readme.html")
+  end
+
 end

--- a/test/ex_doc_test.exs
+++ b/test/ex_doc_test.exs
@@ -15,6 +15,22 @@ defmodule ExDocTest do
     end
   end
 
+  test "build_config & normalize_options" do
+    project = "Elixir"
+    version = "1"
+    options = [formatter: IdentityFormatter, retriever: IdentityRetriever,
+               source_root: "root_dir", source_beam: "beam_dir",]
+
+    {_, config} = ExDoc.generate_docs project, version, Keyword.merge(options, [output: "test/tmp/docs"])
+    assert config.output == "test/tmp/docs"
+
+    {_, config} = ExDoc.generate_docs project, version, Keyword.merge(options, [output: "test/tmp/docs/"])
+    assert config.output == "test/tmp/docs"
+
+    {_, config} = ExDoc.generate_docs project, version, Keyword.merge(options, [output: "test/tmp/docs//"])
+    assert config.output == "test/tmp/docs"
+  end
+
   test "source_beam sets source dir" do
     options = [formatter: IdentityFormatter, retriever: IdentityRetriever,
                source_root: "root_dir", source_beam: "beam_dir"]
@@ -42,4 +58,5 @@ defmodule ExDocTest do
   after
     File.rm!("test.config")
   end
+
 end


### PR DESCRIPTION
The current implementation of the index page made of a copy of
the "main" page in index.html. Creating an unncessary duplicate page.
This commit creates an HTML redirect page.