### PR TITLE
fix PATH in bin/ex_doc (hardcoded Mix.env)

### DIFF
--- a/bin/ex_doc
+++ b/bin/ex_doc
@@ -1,6 +1,7 @@
 #!/usr/bin/env elixir
-Code.prepend_path Path.expand("../_build/dev/lib/earmark/ebin", __DIR__)
-Code.prepend_path Path.expand("../_build/dev/lib/ex_doc/ebin", __DIR__)
+mix_env = System.get_env["MIX_ENV"] || "dev"
+Code.prepend_path Path.expand("../_build/#{mix_env}/lib/earmark/ebin", __DIR__)
+Code.prepend_path Path.expand("../_build/#{mix_env}/lib/ex_doc/ebin", __DIR__)
 
 if Code.ensure_loaded?(ExDoc.CLI) do
   ExDoc.CLI.run(System.argv)


### PR DESCRIPTION
`Mix.env` is hardcoded in bin/ex_doc

```sh
$ reset; MIX_ENV=test mix do clean, compile, test

$ bin/elixir ../ex_doc/bin/ex_doc "EEx" "1.1.0-dev" "lib/eex/ebin" -m "EEx" -u "https://github.com/elixir-lang/elixir" --source-ref "22ab2d9cf8db6f6a2a7f7406c53500cdf870ee7b" -o doc/eex -p http://elixir-lang.org/docs.html
Error: cannot generate docs because ExDoc.CLI module is not available. Please run `mix compile` before or ensure ExDoc is available.
** (exit) 1
    /home/eksperimental/ex_doc/bin/ex_doc:10: (file)
    (elixir) lib/code.ex:363: Code.require_file/2

$ MIX_ENV=test bin/elixir ../ex_doc/bin/ex_doc "EEx" "1.1.0-dev" "lib/eex/ebin" -m "EEx" -u "https://github.com/elixir-lang/elixir" --source-ref "22ab2d9cf8db6f6a2a7f7406c53500cdf870ee7b" -o doc/eex -p http://elixir-lang.org/docs.html
Error: cannot generate docs because ExDoc.CLI module is not available. Please run `mix compile` before or ensure ExDoc is available.
** (exit) 1
    /home/eksperimental/ex_doc/bin/ex_doc:10: (file)
    (elixir) lib/code.ex:363: Code.require_file/2
```

with this fix, i can run 
```sh
$ reset; MIX_ENV=test mix do clean, compile, test
$ bin/elixir ../ex_doc/bin/ex_doc "EEx" "1.1.0-dev" "lib/eex/ebin" -m "EEx" -u "https://github.com/elixir-lang/elixir" --source-ref "22ab2d9cf8db6f6a2a7f7406c53500cdf870ee7b" -o doc/eex -p http://elixir-lang.org/docs.html
```
