### PR TITLE
Cleaner redirect template

### DIFF
--- a/lib/ex_doc/formatter/html/templates/redirect_template.eex
+++ b/lib/ex_doc/formatter/html/templates/redirect_template.eex
@@ -1,20 +1,11 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= config.project %> – Redirecting...</title>
-    <meta http-equiv="refresh" content="0; url=<%= h(redirect_to) %>" />
     <meta charset="utf-8" />
-    <meta http-equiv="x-ua-compatible" content="ie=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><%= config.project %></title>
+    <meta http-equiv="refresh" content="0; url=<%= h(redirect_to) %>" />
+    <meta name="index" content="noindex" />
     <meta name="generator" content="ExDoc" />
   </head>
-  <body>
-    <div style="font-size: 1.2em; text-align:center; margin: 3.6em; ">
-      <p><strong>The page you have requested has been moved.</strong></p>
-      <p>If you are not redirected automatically, visit <a href="<%= h(redirect_to) %>"><%= h(redirect_to) %></a></p>
-      <script>
-        document.location.href = "<%= redirect_to %>";
-      </script>
-    </div>
-  </body>
+  <body></body>
 </html>


### PR DESCRIPTION
Fixes: https://github.com/elixir-lang/ex_doc/issues/279 (introduced by https://github.com/elixir-lang/ex_doc/pull/265)

* Removes text from telling user is being redirected
* Javascript redirection removed
* Show only project name in `<title>`
* Move `<meta charsert>` to the very top
* Add: `<meta name="index" content="noindex" />` so it's not indexed by search engines

Browser History shows now the Title of the project.
You can go back and forth, without seeing the redirect page in the middle.