### PR TITLE
Several Small fixes

### DIFF
--- a/lib/ex_doc/cli.ex
+++ b/lib/ex_doc/cli.ex
@@ -64,12 +64,12 @@ defmodule ExDoc.CLI do
       VERSION            Version number
       BEAMS              Path to compiled beam files
       -o, --output       Path to output docs, default: "doc"
-      --readme           Path to README.md file to generate a project README, default: `nil`
+          --readme       Path to README.md file to generate a project README, default: `nil`
       -f, --formatter    Docs formatter to use, default: "html"
       -c, --config       Path to the formatter's config file
       -r, --source-root  Path to the source code root, default: "."
       -u, --source-url   URL to the source code
-      --source-ref       Branch/commit/tag used for source link inference, default: "master"
+          --source-ref   Branch/commit/tag used for source link inference, default: "master"
       -m, --main         The main, entry-point module in docs,
                            default: "overview" when --fomatter is "html"
       -p  --homepage-url URL to link to for the site name

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -106,7 +106,7 @@ defmodule ExDoc.Formatter.HTML.Templates do
   templates = [
     detail_template: [:node, :_module],
     footer_template: [],
-    head_template: [:page],
+    head_template: [:config, :page],
     module_template: [:config, :module, :types, :functions, :macros, :callbacks, :all, :has_readme],
     overview_entry_template: [:node],
     overview_template: [:config, :modules, :exceptions, :protocols, :has_readme],

--- a/lib/ex_doc/formatter/html/templates/head_template.eex
+++ b/lib/ex_doc/formatter/html/templates/head_template.eex
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <%= cond do %>
     <%= page.id == :module -> %>

--- a/lib/ex_doc/formatter/html/templates/head_template.eex
+++ b/lib/ex_doc/formatter/html/templates/head_template.eex
@@ -5,11 +5,11 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <%= cond do %>
       <%= page.id == :module -> %>
-        <title><%= page.module.id %> – <%= page.content.project %> v<%= page.content.version %></title>
+        <title><%= page.module %> – <%= config.project %> v<%= config.version %></title>
       <%= page.id == :readme -> %>
-         <title>README – <%= page.content.project %> v<%= page.content.version %></title>
+        <title>README – <%= config.project %> v<%= config.version %></title>
       <%= page.id == :overview -> %>
-        <title>Overview – <%= page.content.project %> v<%= page.content.version %></title>
+        <title>Overview – <%= config.project %> v<%= config.version %></title>
     <% end %>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="generator" content="ExDoc">

--- a/lib/ex_doc/formatter/html/templates/head_template.eex
+++ b/lib/ex_doc/formatter/html/templates/head_template.eex
@@ -4,12 +4,12 @@
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <%= cond do %>
-    <%= page.id == :module -> %>
-    <title><%= page.content %></title>
-    <%= page.id == :readme -> %>
-    <title><%= page.content.project %> v<%= page.content.version %> README</title>
-    <%= page.id == :overview -> %>
-    <title><%= page.content.project %> v<%= page.content.version %> Overview</title>
+      <%= page.id == :module -> %>
+        <title><%= page.module.id %> – <%= page.content.project %> v<%= page.content.version %></title>
+      <%= page.id == :readme -> %>
+         <title>README – <%= page.content.project %> v<%= page.content.version %></title>
+      <%= page.id == :overview -> %>
+        <title>Overview – <%= page.content.project %> v<%= page.content.version %></title>
     <% end %>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="generator" content="ExDoc">

--- a/lib/ex_doc/formatter/html/templates/module_template.eex
+++ b/lib/ex_doc/formatter/html/templates/module_template.eex
@@ -1,4 +1,4 @@
-    <%= head_template(%{id: :module, content: config, module: module}) %>
+    <%= head_template(config, %{id: :module, module: module.id}) %>
     <%= alias ExDoc.Formatter.HTML, as: H %>
     <%= sidebar_template(config, H.filter_list(:modules, all), H.filter_list(:exceptions, all), H.filter_list(:protocols, all), has_readme) %>
 

--- a/lib/ex_doc/formatter/html/templates/module_template.eex
+++ b/lib/ex_doc/formatter/html/templates/module_template.eex
@@ -1,4 +1,4 @@
-    <%= head_template(%{id: :module, content: module.id}) %>
+    <%= head_template(%{id: :module, content: config, module: module}) %>
     <%= alias ExDoc.Formatter.HTML, as: H %>
     <%= sidebar_template(config, H.filter_list(:modules, all), H.filter_list(:exceptions, all), H.filter_list(:protocols, all), has_readme) %>
 

--- a/lib/ex_doc/formatter/html/templates/overview_template.eex
+++ b/lib/ex_doc/formatter/html/templates/overview_template.eex
@@ -1,4 +1,4 @@
-    <%= head_template(%{id: :overview, content: config}) %>
+    <%= head_template(config, %{id: :overview}) %>
     <%= sidebar_template(config, modules, exceptions, protocols, has_readme) %>
 
       <div class="breadcrumbs">

--- a/lib/ex_doc/formatter/html/templates/readme_template.eex
+++ b/lib/ex_doc/formatter/html/templates/readme_template.eex
@@ -1,4 +1,4 @@
-<%= head_template(%{id: :readme, content: config}) %>
+<%= head_template(config, %{id: :readme}) %>
 <%= sidebar_template(config, modules, exceptions, protocols, true) %>
 
 <div class="breadcrumbs">

--- a/lib/ex_doc/formatter/html/templates/redirect_template.eex
+++ b/lib/ex_doc/formatter/html/templates/redirect_template.eex
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title><%= config.project %></title>
+    <title><%= config.project %> v<%= config.version %> – Documentation</title>
     <meta http-equiv="refresh" content="0; url=<%= h(redirect_to) %>" />
     <meta name="index" content="noindex" />
     <meta name="generator" content="ExDoc" />

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -80,9 +80,9 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
     content = Templates.sidebar_items_template([%{id: "modules", value: nodes}])
 
     assert content =~ ~r{.*\"id\":\s*\"CompiledWithDocs\".*}ms
-    assert content =~ ~r{.*\"id\":\s*\"CompiledWithDocs\".*\"docs\".*\"example\/2\".*}ms
-    assert content =~ ~r{.*\"id\":\s*\"CompiledWithDocs\".*\"docs\".*\"example_1\/0\".*}ms
-    assert content =~ ~r{.*\"id\":\s*\"CompiledWithDocs\".*\"docs\".*\"example_without_docs\/0\".*}ms
+    assert content =~ ~r{.*\"id\":\s*\"CompiledWithDocs\".*\"docs\".*\"example/2\".*}ms
+    assert content =~ ~r{.*\"id\":\s*\"CompiledWithDocs\".*\"docs\".*\"example_1/0\".*}ms
+    assert content =~ ~r{.*\"id\":\s*\"CompiledWithDocs\".*\"docs\".*\"example_without_docs/0\".*}ms
     assert content =~ ~r{.*"CompiledWithDocs.Nested\"}ms
     refute content =~ ~r{.*\"exceptions\":}ms
     refute content =~ ~r{.*\"protocols\":}ms
@@ -104,20 +104,20 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
     node = %ExDoc.ModuleNode{module: XPTOModule, moduledoc: nil, id: "XPTOModule"}
     content = Templates.module_page(node, doc_config, [node], false)
 
-    assert content =~ ~r/<title>XPTOModule [^<]*<\/title>/
-    assert content =~ ~r/<h1>\s*XPTOModule\s*<\/h1>/
+    assert content =~ ~r{<title>XPTOModule [^<]*</title>}
+    assert content =~ ~r{<h1>\s*XPTOModule\s*</h1>}
   end
 
   test "module_page outputs the functions and docstrings" do
     content = get_module_page([CompiledWithDocs])
 
-    assert content =~ ~r/<title>CompiledWithDocs [^<]*<\/title>/
-    assert content =~ ~r/<h1>\s*CompiledWithDocs\s*<\/h1>/
-    assert content =~ ~r/moduledoc.*Example.*CompiledWithDocs\.example.*/ms
-    assert content =~ ~r/example\/2.*Some example/ms
-    assert content =~ ~r/example_without_docs\/0.*<section class="docstring">.*<\/section>/ms
-    assert content =~ ~r/example_1\/0.*Another example/ms
-    assert content =~ ~r{<a href="#{source_url}/blob/master/test/fixtures/compiled_with_docs.ex#L10"[^>]*>Source<\/a>}ms
+    assert content =~ ~r{<title>CompiledWithDocs [^<]*</title>}
+    assert content =~ ~r{<h1>\s*CompiledWithDocs\s*</h1>}
+    assert content =~ ~r{moduledoc.*Example.*CompiledWithDocs\.example.*}ms
+    assert content =~ ~r{example/2.*Some example}ms
+    assert content =~ ~r{example_without_docs/0.*<section class="docstring">.*</section>}ms
+    assert content =~ ~r{example_1/0.*Another example}ms
+    assert content =~ ~r{<a href="#{source_url}/blob/master/test/fixtures/compiled_with_docs.ex#L10"[^>]*>Source</a>}ms
 
     assert content =~ ~s{<div class="detail_header" id="example_1/0">}
     assert content =~ ~s{<strong>example(foo, bar \\\\ Baz)</strong>}

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -104,14 +104,14 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
     node = %ExDoc.ModuleNode{module: XPTOModule, moduledoc: nil, id: "XPTOModule"}
     content = Templates.module_page(node, doc_config, [node], false)
 
-    assert content =~ ~r/<title>XPTOModule<\/title>/
+    assert content =~ ~r/<title>XPTOModule [^<]*<\/title>/
     assert content =~ ~r/<h1>\s*XPTOModule\s*<\/h1>/
   end
 
   test "module_page outputs the functions and docstrings" do
     content = get_module_page([CompiledWithDocs])
 
-    assert content =~ ~r/<title>CompiledWithDocs<\/title>/
+    assert content =~ ~r/<title>CompiledWithDocs [^<]*<\/title>/
     assert content =~ ~r/<h1>\s*CompiledWithDocs\s*<\/h1>/
     assert content =~ ~r/moduledoc.*Example.*CompiledWithDocs\.example.*/ms
     assert content =~ ~r/example\/2.*Some example/ms

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -72,7 +72,7 @@ defmodule ExDoc.Formatter.HTMLTest do
 
     content = File.read!("#{output_dir}/sidebar_items.js")
     assert content =~ ~r{.*"CompiledWithDocs\".*}ms
-    assert content =~ ~r{.*"CompiledWithDocs\".*\"example\/2\".*}ms
+    assert content =~ ~r{.*"CompiledWithDocs\".*\"example/2\".*}ms
     assert content =~ ~r{.*"CompiledWithDocs.Nested\".*}ms
     assert content =~ ~r{.*"UndefParent\.Nested\".*}ms
     assert content =~ ~r{.*"CustomBehaviourOne\".*}ms

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -97,7 +97,7 @@ defmodule ExDoc.Formatter.HTMLTest do
     generate_docs(doc_config)
 
     content = File.read!("#{output_dir}/readme.html")
-    assert content =~ ~r{<title>[^<]* README</title>}
+    assert content =~ ~r{<title>README [^<]*</title>}
     assert content =~ ~r{<a href="RandomError.html"><code>RandomError</code>}
     assert content =~ ~r{<a href="CustomBehaviourImpl.html#hello/1"><code>CustomBehaviourImpl.hello/1</code>}
     assert content =~ ~r{<a href="TypesAndSpecs.Sub.html"><code>TypesAndSpecs.Sub</code></a>}
@@ -108,7 +108,7 @@ defmodule ExDoc.Formatter.HTMLTest do
 
     refute File.regular?("#{output_dir}/readme.html")
     content = File.read!("#{output_dir}/index.html")
-    refute content =~ ~r{<title>[^<]* README</title>}
+    refute content =~ ~r{<title>README [^<]*</title>}
   end
 
   test "make markdown codeblocks pretty" do


### PR DESCRIPTION
* align text in the ExDoc.CLI help
* ~~close void elements in head_template~~
* Add Project Name and Version to `<title>`
  - This information should be present to avoid confusion with different versions. Specially when bookmarking.
* Get rid of `~r/ /` in favour of `~r{ }`
    To avoid escaping slashes
* head_template standardized & titles improved
  * head_template : Now it takes 2 args. Stadardize with the rest of the templates,
      taking "config" as first argument
  * ~~head_template: titles improved, to not so duplicate information when a module
      has the same name as the project. ex: ExUnit,
      instead of reading: "ExUnit – ExUnit v1.1.0-dev", it now reads:
      "ExUnit v1.1.0-dev – Documentation"~~