### PR TITLE
Do no show diff in /lib/ex_doc/formatter/html/templates/dist/*

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/lib/ex_doc/formatter/html/templates/dist/* -diff


### PR DESCRIPTION
Just treat them as binaries,
so it won't display the diff when we do `git log -p`
and run a diff.

Otherwise it spoils the output with such big files.

/cc @Dignifiedquire @milmazz 