### PR TITLE
Enforce call to ExDoc.Formatter.HTML.run/3 to be done from ExDoc,

### DIFF
--- a/lib/ex_doc.ex
+++ b/lib/ex_doc.ex
@@ -33,7 +33,7 @@ defmodule ExDoc do
   def generate_docs(project, version, options) when is_binary(project) and is_binary(version) and is_list(options) do
     config = build_config(project, version, options)
     docs = config.retriever.docs_from_dir(config.source_beam, config)
-    find_formatter(config.formatter).run(docs, config)
+    find_formatter(config.formatter).run(docs, config, __MODULE__)
   end
 
   # Builds configuration by merging `options`, and normalizing the options.

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -1,7 +1,5 @@
 defmodule ExDoc.Formatter.HTML do
-  @moduledoc """
-  Provide HTML-formatted documentation
-  """
+  @moduledoc false
 
   alias ExDoc.Formatter.HTML.Templates
   alias ExDoc.Formatter.HTML.Autolink
@@ -10,10 +8,16 @@ defmodule ExDoc.Formatter.HTML do
   @main "overview"
 
   @doc """
-  Generate HTML documentation for the given modules
+  Generate HTML documentation for the given modules.
   """
-  @spec run(list, %ExDoc.Config{}) :: String.t
-  def run(module_nodes, config) when is_map(config) do
+  @spec run(list, %ExDoc.Config{}, module) :: String.t
+  def run(module_nodes, config, caller) when is_map(config) do
+    if caller !== ExDoc do
+      raise ArgumentError,
+        message: "#{__MODULE__}.run/3 is not supposed to be called directly from #{caller}. " <>
+                 "Please call \"ExDoc.generate_docs/3\" instead"
+    end
+
     config = normalize_config(config)
     output = Path.expand(config.output)
     File.rm_rf! output

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -191,4 +191,12 @@ defmodule ExDoc.Formatter.HTMLTest do
     assert {:ok, []} == File.ls "#{output_dir}"
   end
 
+  test "Elixir.ExDoc.Formatter.HTML.run/3 fails when called directly" do
+    assert_raise ArgumentError,
+      "Elixir.ExDoc.Formatter.HTML.run/3 is not supposed to be called directly from " <>
+      "Elixir.ExDoc.Formatter.HTMLTest. Please call \"ExDoc.generate_docs/3\" instead",
+      fn -> HTML.run([], %{}, __MODULE__) end
+    assert {:ok, []} == File.ls "#{output_dir}"
+  end
+
 end

--- a/test/ex_doc_test.exs
+++ b/test/ex_doc_test.exs
@@ -10,7 +10,7 @@ defmodule ExDocTest do
 
   # Simple formatter that returns whatever is passed into it
   defmodule IdentityFormatter do
-    def run(modules, config) do
+    def run(modules, config, _caller) do
       {modules, config}
     end
   end


### PR DESCRIPTION
[I have accidentally closed: https://github.com/elixir-lang/ex_doc/pull/301]

...and not directly.

This way we can assure the configs are passed through ExDoc, doing
the preconfiguration and the normalization.
