### PR TITLE
[TravisCI] Migrate from legacy to container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,7 @@ before_script:
 script:
   - "mix do local.hex --force, deps.get && mix test --include pandoc"
   - node_modules/.bin/gulp
+cache:
+  directories:
+    - node_modules
+    - deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: erlang
+sudo: false
 elixir:
   - 1.0.2
 otp_release:
@@ -9,8 +10,10 @@ notifications:
   recipients:
     - jose.valim@plataformatec.com.br
 before_install:
-  - wget -c https://github.com/jgm/pandoc/releases/download/1.13.2/pandoc-1.13.2-1-amd64.deb
-  - sudo dpkg -i pandoc-1.13.2-1-amd64.deb
+  - wget -c https://github.com/jgm/pandoc/releases/download/1.15.0.6/pandoc-1.15.0.6-1-amd64.deb
+  - ar -x pandoc-1.15.0.6-1-amd64.deb
+  - tar xzf data.tar.gz
+  - export PATH=$PATH:$PWD/usr/bin/
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/assets/test/helpers.spec.js
+++ b/assets/test/helpers.spec.js
@@ -1,7 +1,6 @@
 var helpers = require('../js/helpers')
 
 describe('helpers', function () {
-
   describe('escapeText', function () {
     var escapeText = helpers.escapeText
 


### PR DESCRIPTION
This PR includes certain improvements when we use Travis:

- Use the new container-based infrastructure
- Cache directories `node_modules` (for `npm install`) and `deps` (for `mix deps.get`)
- Use the latest release of Pandoc
- Fix a little ESLint error, with this the build result exit with 0 (OK)

@josevalim Let me know what do you think about this? Is it OK to cache `deps` directory?