### PR TITLE
.travis.yml: automatically download latest pandoc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,9 @@ notifications:
   recipients:
     - jose.valim@plataformatec.com.br
 before_install:
-  - wget -c https://github.com/jgm/pandoc/releases/download/1.15.0.6/pandoc-1.15.0.6-1-amd64.deb
-  - ar -x pandoc-1.15.0.6-1-amd64.deb
-  - tar xzf data.tar.gz
+  - ./travis-before-install.sh
   - export PATH=$PATH:$PWD/usr/bin/
+  - pandoc --version
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/travis-before-install.sh
+++ b/travis-before-install.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# Download latest version of `pandoc`
+url_latest_release="https://github.com/jgm/pandoc/releases/latest"
+package_path="$( \
+  # find out real url
+  curl --silent --show-error --fail --head "https://github.com/jgm/pandoc/releases/latest" | \
+  grep "Location: " | cut -d" " -f2 | sed -e 's/\r//g' -e 's/\n//g' | \
+  
+  # get and parse page
+  xargs curl --silent --show-error --fail | \
+  grep -oP "(?<=(href=\"))/[^>\"]+/releases/download/[^>\"]+-amd64.deb(?=\")" | \
+  
+  # get first result in case more than one file is available
+  head -n1 \
+)"
+
+if [ -z "${package_path}" ]; then
+  echo "* [ERROR]: Unable to determine latest Pandoc package" >&2
+  exit 1
+fi
+
+set -e
+echo "Downloading: https://github.com${package_path}"
+curl --location --output "pandoc-latest-amd64.deb" "https://github.com${package_path}" 
+ar -x pandoc-latest-amd64.deb
+tar xzf data.tar.gz


### PR DESCRIPTION
travis-before-install.sh created.
it checks the latest stable relesase
based on this redirect url: https://github.com/jgm/pandoc/releases/latest
then, we parse the page, and determine look for the *-amd64.deb file.
So long as there is a file that matches this naming convention it will be retrieved,
and if may are provided, the firt one will be chosen.

If no file could be determined, then an error message is displayed.

/cc @milmazz 