### PR TITLE
Post coverage to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,10 @@ before_script:
   - sh -e /etc/init.d/xvfb start
   - npm install -g npm
   - npm install
+env:
+  - MIX_ENV=test
 script:
-  - "mix do local.hex --force, deps.get && mix test --include pandoc"
+  - "mix do local.hex --force, deps.get, test --include pandoc, coveralls.travis"
   - node_modules/.bin/gulp
 cache:
   directories:


### PR DESCRIPTION
This PR includes the Mix task `coveralls.travis`, which allows to submit the *coverage* results to the [coveralls.io](https://coveralls.io) servers when TravisCI build is executed.

Then we can show a *badge* in our README that shows the results.

@josevalim I think that to allow this, first [coveralls.io](https://coveralls.io) needs your authorization.

The coverage history is similar to this page:

https://coveralls.io/github/parroty/excoveralls