### PR TITLE
Update generate_assets to be a public function

### DIFF
--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -74,6 +74,11 @@ defmodule ExDoc.Formatter.HTML do
      {"fonts/*.{eot,svg,ttf,woff,woff2}", "fonts"}]
   end
 
+  # TODO: decouple EPUB/HTML
+  @doc """
+  Copy a list of assets into a given directory
+  """
+  @spec generate_assets(list, String.t) :: :ok
   def generate_assets(source, output) do
     Enum.each source, fn({ pattern, dir }) ->
       output = "#{output}/#{dir}"

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -84,7 +84,7 @@ defmodule ExDoc.Formatter.HTML do
   def generate_assets(source, output) do
     Enum.each source, fn({ pattern, dir }) ->
       output = "#{output}/#{dir}"
-      File.mkdir output
+      File.mkdir! output
 
       Enum.map Path.wildcard(pattern), fn(file) ->
         base = Path.basename(file)

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -1,5 +1,7 @@
 defmodule ExDoc.Formatter.HTML do
-  @moduledoc false
+  @moduledoc """
+  Generate HTML documentation for Elixir projects
+  """
 
   alias ExDoc.Formatter.HTML.Templates
   alias ExDoc.Formatter.HTML.Autolink

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -16,7 +16,7 @@ defmodule ExDoc.Formatter.HTML do
     File.rm_rf! output
     :ok = File.mkdir_p output
 
-    generate_assets(output, config)
+    assets |> templates_path |> generate_assets(output)
 
     all = Autolink.all(module_nodes)
     modules    = filter_list(:modules, all)
@@ -70,12 +70,12 @@ defmodule ExDoc.Formatter.HTML do
   end
 
   defp assets do
-    [{templates_path("dist/*.{css,js}"), "dist"},
-     {templates_path("fonts/*.{eot,svg,ttf,woff,woff2}"), "fonts"}]
+    [{"dist/*.{css,js}", "dist"},
+     {"fonts/*.{eot,svg,ttf,woff,woff2}", "fonts"}]
   end
 
-  defp generate_assets(output, _config) do
-    Enum.each assets, fn({ pattern, dir }) ->
+  def generate_assets(source, output) do
+    Enum.each source, fn({ pattern, dir }) ->
       output = "#{output}/#{dir}"
       File.mkdir output
 
@@ -189,7 +189,9 @@ defmodule ExDoc.Formatter.HTML do
     File.write!("#{output}/#{node.id}.html", content)
   end
 
-  defp templates_path(other) do
-    Path.expand("html/templates/#{other}", __DIR__)
+  defp templates_path(patterns) do
+    Enum.into(patterns, [], fn {pattern, dir} ->
+      {Path.expand("html/templates/#{pattern}", __DIR__), dir}
+    end)
   end
 end

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -184,4 +184,11 @@ defmodule ExDoc.Formatter.HTMLTest do
                  "image format not recognized, allowed formats are: .jpg, .png",
                  fn -> generate_docs(config) end
   end
+
+  test "Generate some assets" do
+    output = doc_config[:output]
+    HTML.generate_assets([{"test/fixtures/elixir.png", "images"}], output)
+
+    assert File.regular?("#{output}/images/elixir.png")
+  end
 end


### PR DESCRIPTION
This change will allow reuse the `generate_assets` function from others formatters (e.g. EPUB)