### PR TITLE
Load font css from https: when required

### DIFF
--- a/lib/ex_doc/formatter/html/templates/head_template.eex
+++ b/lib/ex_doc/formatter/html/templates/head_template.eex
@@ -19,7 +19,7 @@
     <script>
       var cdn_protocol;
       cdn_protocol = ( window.location.protocol == 'https:' ) ? "https:" : "http:";
-      document.write('<link href="' + cdn_protocol + '\/\/fonts.googleapis.com\/css?family=Lato:400,300,700,900|Merriweather:300italic,300,700,700italic|Inconsolata:400,700" rel="stylesheet" type="text/css">');
+      document.write('<link href="' + cdn_protocol + '\/\/fonts.googleapis.com\/css?family=Lato:400,300,700,900%7CMerriweather:300italic,300,700,700italic%7CInconsolata:400,700" rel="stylesheet" type="text/css">');
     </script>
     <link rel="stylesheet" href="dist/app.css">
     <script src="dist/sidebar_items.js"></script>

--- a/lib/ex_doc/formatter/html/templates/head_template.eex
+++ b/lib/ex_doc/formatter/html/templates/head_template.eex
@@ -16,8 +16,12 @@
     <% end %>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="generator" content="ExDoc v<%= ExDoc.version %>">
-    <link href="http://fonts.googleapis.com/css?family=Lato:400,300,700,900|Merriweather:300italic,300,700,700italic|Inconsolata:400,700" rel="stylesheet" type="text/css">
-    <link rel="stylesheet" href="dist/app.css" />
+    <script>
+      var cdn_protocol;
+      cdn_protocol = ( window.location.protocol == 'https:' ) ? "https:" : "http:";
+      document.write('<link href="' + cdn_protocol + '\/\/fonts.googleapis.com\/css?family=Lato:400,300,700,900|Merriweather:300italic,300,700,700italic|Inconsolata:400,700" rel="stylesheet" type="text/css">');
+    </script>
+    <link rel="stylesheet" href="dist/app.css">
     <script src="dist/sidebar_items.js"></script>
   </head>
   <body>


### PR DESCRIPTION
This fixes the issue with loading a css file from unsecure
source when the docs are loaded from https://