### PR TITLE
ExDoc.CLI: support --version option

### DIFF
--- a/lib/ex_doc/cli.ex
+++ b/lib/ex_doc/cli.ex
@@ -3,9 +3,22 @@ defmodule ExDoc.CLI do
     {opts, args, _} = OptionParser.parse(args,
                aliases: [o: :output, f: :formatter, c: :config, r: :source_root,
                          u: :source_url, m: :main, p: :homepage_url, l: :logo,
-                         e: :extra],
+                         e: :extra, v: :version],
                switches: [extra: :keep])
 
+    cond do
+      List.keymember?(opts, :version, 0) ->
+        do_version
+      true ->
+        do_generate(args, opts, generator)
+    end
+  end
+
+  defp do_version do
+    IO.puts "ExDoc v#{ExDoc.version}"
+  end
+
+  defp do_generate(args, opts, generator) do
     [project, version, source_beam] = parse_args(args)
 
     Code.prepend_path(source_beam)
@@ -53,11 +66,13 @@ defmodule ExDoc.CLI do
   end
 
   defp parse_args([_project, _version, _source_beam] = args), do: args
+
   defp parse_args([_, _, _ | _]) do
     IO.puts "Too many arguments.\n"
     print_usage()
     exit {:shutdown, 1}
   end
+
   defp parse_args(_) do
     IO.puts "Too few arguments.\n"
     print_usage()
@@ -90,6 +105,7 @@ defmodule ExDoc.CLI do
       -l, --logo          Path to the image logo of the project (only PNG or JPEG accepted)
                           The image size will be 64x64 when --formatter is "html"
                           default: `nil`
+      -v, --version       Print ExDoc version
 
     ## Source linking
 

--- a/test/ex_doc/cli_test.exs
+++ b/test/ex_doc/cli_test.exs
@@ -1,6 +1,8 @@
 defmodule ExDoc.CLITest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureIO
+
   defp run(args) do
     ExDoc.CLI.run(args, &{&1, &2, &3})
   end
@@ -35,4 +37,15 @@ defmodule ExDoc.CLITest do
   after
     File.rm!("test.config")
   end
+
+  test "version" do
+    assert capture_io( fn ->
+      run(["--version"])
+    end) == "ExDoc v#{ExDoc.version}\n"
+
+    assert capture_io( fn ->
+      run(["-v"])
+    end) == "ExDoc v#{ExDoc.version}\n"
+  end
+
 end


### PR DESCRIPTION
We now support:

```sh
$ bin/ex_doc --version
ExDoc v0.10.0-dev

$ bin/ex_doc --version number
0.10.0-dev

$ bin/ex_doc --version oops
** (RuntimeError) unknown value "oops" for --version
    lib/ex_doc/cli.ex:22: ExDoc.CLI.do_version/1
    (elixir) lib/code.ex:363: Code.require_file/2
```

closes #399 