### PR TITLE
Makes ExDoc generate Valid HTML5 pages

### DIFF
--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -1,4 +1,5 @@
 defmodule ExDoc.Formatter.HTML.Autolink do
+  import ExDoc.Formatter.HTML.Templates, only: [h: 1, enc_h: 1]
   @moduledoc """
   Conveniences for autolinking locals, types and more.
   """
@@ -100,15 +101,17 @@ defmodule ExDoc.Formatter.HTML.Autolink do
         string = strip_parens(string, args)
         arity = length(args)
         if { name, arity } in typespecs do
-          ~s[<a href="#t:#{name}/#{arity}">#{string}</a>]
+          n = enc_h("#{name}")
+          ~s[<a href="#t:#{n}/#{arity}">#{h(string)}</a>]
         else
-          string
+         string
         end
       {{ :., _, [alias, name] }, _, args}, string when is_atom(name) and is_list(args) ->
         string = strip_parens(string, args)
         alias = expand_alias(alias)
         if source = get_source(alias, aliases) do
-          ~s[<a href="#{source}#{inspect alias}.html#t:#{name}/#{length(args)}">#{string}</a>]
+          n = enc_h("#{name}")
+          ~s[<a href="#{source}#{enc_h(inspect alias)}.html#t:#{n}/#{length(args)}">#{h(string)}</a>]
         else
           string
         end

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -56,11 +56,17 @@ defmodule ExDoc.Formatter.HTML.Templates do
   defp presence([]),    do: nil
   defp presence(other), do: other
 
-  defp h(binary) do
+  @doc false
+  def h(binary) do
     escape_map = [{"&", "&amp;"}, {"<", "&lt;"}, {">", "&gt;"}, {"\"", "&quot;"}]
     Enum.reduce escape_map, binary, fn({pattern, escape}, acc) ->
       String.replace(acc, pattern, escape)
     end
+  end
+
+  @doc false
+  def enc_h(binary) do
+    URI.encode(binary) |> h
   end
 
   @spec create_sidebar_items(list) :: String.t

--- a/lib/ex_doc/formatter/html/templates/api_reference_entry_template.eex
+++ b/lib/ex_doc/formatter/html/templates/api_reference_entry_template.eex
@@ -1,5 +1,5 @@
 <div class="summary-row">
-  <div class="summary-signature"><a href="<%=h node.id %>.html"><%=h node.id %></a></div>
+  <div class="summary-signature"><a href="<%=enc_h node.id %>.html"><%=h node.id %></a></div>
   <%= if node.moduledoc do %>
     <div class="summary-synopsis"><%= to_html(synopsis(node.moduledoc)) %></div>
   <% end %>

--- a/lib/ex_doc/formatter/html/templates/detail_template.eex
+++ b/lib/ex_doc/formatter/html/templates/detail_template.eex
@@ -1,5 +1,5 @@
-<div class="detail">
-  <div class="detail-header" id="<%=h link_id(node) %>">
+<div class="detail" id="<%=h link_id(node) %>">
+  <div class="detail-header">
     <a href="#<%=h link_id(node) %>" class="detail-link" title="Link to this <%= pretty_type(node) %>">
       <i class="icon-link"></i>
     </a>

--- a/lib/ex_doc/formatter/html/templates/detail_template.eex
+++ b/lib/ex_doc/formatter/html/templates/detail_template.eex
@@ -1,6 +1,6 @@
-<div class="detail" id="<%=h link_id(node) %>">
+<div class="detail" id="<%=enc_h link_id(node) %>">
   <div class="detail-header">
-    <a href="#<%=h link_id(node) %>" class="detail-link" title="Link to this <%= pretty_type(node) %>">
+    <a href="#<%=enc_h link_id(node) %>" class="detail-link" title="Link to this <%= pretty_type(node) %>">
       <i class="icon-link"></i>
     </a>
     <span class="signature"><%=h node.signature %></span>

--- a/lib/ex_doc/formatter/html/templates/redirect_template.eex
+++ b/lib/ex_doc/formatter/html/templates/redirect_template.eex
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title><%= config.project %> v<%= config.version %> – Documentation</title>
     <meta http-equiv="refresh" content="0; url=<%= h(redirect_to) %>">
-    <meta name="index" content="noindex">
+    <meta name="robots" content="noindex">
     <meta name="generator" content="ExDoc v<%= ExDoc.version %>">
   </head>
   <body></body>

--- a/lib/ex_doc/formatter/html/templates/sidebar_template.eex
+++ b/lib/ex_doc/formatter/html/templates/sidebar_template.eex
@@ -24,7 +24,7 @@
 
   <div class="sidebar-search">
     <i class="icon-search"></i>
-    <input type="text" class="sidebar-searchInput" placeholder="search" autocomplete="off" results="0" />
+    <input type="text" class="sidebar-searchInput" placeholder="search" autocomplete="off" />
   </div>
 
   <ul class="sidebar-listNav">

--- a/lib/ex_doc/formatter/html/templates/summary_item_template.eex
+++ b/lib/ex_doc/formatter/html/templates/summary_item_template.eex
@@ -1,6 +1,6 @@
 <div class="summary-row">
   <div class="summary-signature">
-    <a href="#<%=h link_id(node) %>"><%=h node.signature %></a>
+    <a href="#<%=enc_h link_id(node) %>"><%=h node.signature %></a>
   </div>
   <%= if node.doc do %>
     <div class="summary-synopsis"><%= to_html(synopsis(node.doc)) %></div>

--- a/lib/ex_doc/formatter/html/templates/type_detail_template.eex
+++ b/lib/ex_doc/formatter/html/templates/type_detail_template.eex
@@ -1,5 +1,5 @@
-<div class="type-detail">
-  <pre><code class="elixir" id="<%=h link_id(node) %>"><%= node.spec %></code></pre>
+<div id="<%=enc_h link_id(node) %>" class="type-detail">
+  <pre><code class="elixir"><%= node.spec %></code></pre>
   <%= if node.doc do %>
     <div class="typespec-doc"><%= to_html(node.doc) %></div>
   <% end %>

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -82,7 +82,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
     assert content =~ ~r{example_1/0.*Another example}ms
     assert content =~ ~r{<a href="#{source_url}/blob/master/test/fixtures/compiled_with_docs.ex#L10"[^>]*>\n\s*<i class="icon-code"></i>\n\s*</a>}ms
 
-    assert content =~ ~s{<div class="detail-header" id="example_1/0">}
+    assert content =~ ~s{<div class="detail" id="example_1/0">}
     assert content =~ ~s{example(foo, bar \\\\ Baz)}
     assert content =~ ~r{<a href="#example/2" class="detail-link" title="Link to this function">\n\s*<i class="icon-link"><\/i>\n\s*<\/a>}ms
   end
@@ -127,12 +127,12 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
     content = get_module_page([CustomBehaviourOne])
     assert content =~ ~r{<h1>\s*CustomBehaviourOne\s*<small>behaviour</small>}m
     assert content =~ ~r{Callbacks}
-    assert content =~ ~r{<div class="detail-header" id="c:hello/1">}
+    assert content =~ ~r{<div class="detail" id="c:hello/1">}
 
     content = get_module_page([CustomBehaviourTwo])
     assert content =~ ~r{<h1>\s*CustomBehaviourTwo\s*<small>behaviour</small>\s*}m
     assert content =~ ~r{Callbacks}
-    assert content =~ ~r{<div class="detail-header" id="c:bye/1">}
+    assert content =~ ~r{<div class="detail" id="c:bye/1">}
   end
 
   ## PROTOCOLS

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -61,7 +61,7 @@ defmodule ExDoc.Formatter.HTMLTest do
 
       index: %{
         title:   ~r{<title>Elixir v1.0.1 – Documentation</title>},
-        index:   ~r{<meta name="index" content="noindex"},
+        index:   ~r{<meta name="robots" content="noindex"},
         refresh: ~r{<meta http-equiv="refresh" content="0; url=RandomError.html">},
       },
 


### PR DESCRIPTION
This commits fixes every single bug,
thus it makes the docs generated (checked only on the Elixir docs)
valid HTML5 documents.

I throughly tested everything,
we didn't have that many issues. but they were hard to fix,
I have sent a few a few PRs to earmark because some issues came from there.
there is on last PR that needs to be reviewed and merged.

I have validated the Elixir docs using html-proofer and html5validator,
no internal broken links found, only one issue and we are 100% valid.
I will may need help to fix it.

OK. trying to push this so we can test the longer the better..

