### PR TITLE
Add sort function by name/arity

### DIFF
--- a/lib/ex_doc.ex
+++ b/lib/ex_doc.ex
@@ -52,6 +52,20 @@ defmodule ExDoc do
     struct(preconfig, options)
   end
 
+  @doc """
+  Sorts ExDoc structs by name and arity.
+  """
+  @spec sort(Enum.t) :: Enum.t
+  def sort(collection) do
+    Enum.sort(collection, fn(x, y) ->
+      if x.name == y.name do
+        x.arity <= y.arity
+      else
+        x.name <= y.name
+      end
+    end)
+  end
+
   # Short path for programmatic interface
   defp find_formatter(modname) when is_atom(modname), do: modname
 

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -4,6 +4,7 @@ defmodule ExDoc.Formatter.HTML.Templates do
   """
 
   require EEx
+  require ExDoc
 
   @doc """
   Generate content from the module template for a given `node`

--- a/lib/ex_doc/formatter/html/templates/module_template.eex
+++ b/lib/ex_doc/formatter/html/templates/module_template.eex
@@ -43,7 +43,7 @@
             Types
           </h1>
           <div class="types-list">
-            <%= for node <- types, do: type_detail_template(node, module) %>
+            <%= for node <- ExDoc.sort(types), do: type_detail_template(node, module) %>
           </div>
         </section>
       <% end %>
@@ -56,7 +56,7 @@
             </a>
             Functions
           </h1>
-          <%= for node <- functions, do: detail_template(node, module) %>
+          <%= for node <- ExDoc.sort(functions), do: detail_template(node, module) %>
         </section>
       <% end %>
 
@@ -68,7 +68,7 @@
             </a>
             Macros
           </h1>
-          <%= for node <- macros, do: detail_template(node, module) %>
+          <%= for node <- ExDoc.sort(macros), do: detail_template(node, module) %>
         </section>
       <% end %>
 
@@ -80,7 +80,7 @@
             </a>
             Callbacks
           </h1>
-          <%= for node <- callbacks, do: detail_template(node, module) %>
+          <%= for node <- ExDoc.sort(callbacks), do: detail_template(node, module) %>
         </section>
       <% end %>
     <%= footer_template %>

--- a/lib/ex_doc/formatter/html/templates/summary_template.eex
+++ b/lib/ex_doc/formatter/html/templates/summary_template.eex
@@ -3,6 +3,6 @@
     <h2>
       <a href="#<%= name %>"><%= String.capitalize name %></a>
     </h2>
-    <%= for node <- Enum.sort(nodes), do: summary_item_template(node) %>
+    <%= for node <- ExDoc.sort(nodes), do: summary_item_template(node) %>
   </div>
 <% end %>

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -22,6 +22,7 @@ defmodule ExDoc.Retriever do
   Functions to extract documentation information from modules.
   """
 
+  require ExDoc
   alias ExDoc.Retriever.Error
   alias Kernel.Typespec
 

--- a/test/ex_doc_test.exs
+++ b/test/ex_doc_test.exs
@@ -52,4 +52,25 @@ defmodule ExDocTest do
   test "version" do
     assert ExDoc.version =~ ~r{\d+\.\d+\.\d+} 
   end
+
+  test "sort" do
+    assert ExDoc.sort([
+      %ExDoc.FunctionNode{arity: 2, id: "//2", name: :/, },
+      %ExDoc.FunctionNode{arity: 2, id: "!=/2", name: :!=, },
+      %ExDoc.FunctionNode{arity: 100, id: "zoom/100", name: :zoom, },
+      %ExDoc.FunctionNode{arity: 1, id: "run/1", name: :run, },
+      %ExDoc.FunctionNode{arity: 3, id: "run/3", name: :run, },
+      %ExDoc.FunctionNode{arity: 2, id: "--/2", name: :--, },
+      %ExDoc.FunctionNode{arity: 2, id: "run/2", name: :run, },
+    ]) == [
+      %ExDoc.FunctionNode{arity: 2, id: "!=/2", name: :!=, },
+      %ExDoc.FunctionNode{arity: 2, id: "--/2", name: :--, },
+      %ExDoc.FunctionNode{arity: 2, id: "//2", name: :/, },
+      %ExDoc.FunctionNode{arity: 1, id: "run/1", name: :run, },
+      %ExDoc.FunctionNode{arity: 2, id: "run/2", name: :run, },
+      %ExDoc.FunctionNode{arity: 3, id: "run/3", name: :run, },
+      %ExDoc.FunctionNode{arity: 100, id: "zoom/100", name: :zoom, },
+    ]
+  end
+
 end


### PR DESCRIPTION
this fixes this bug that the lists in the summary were not sorted.
http://elixir-lang.org/docs/master/elixir/Kernel.html#summary

I created a `ExDoc.sort` function that sort functions by their name and their arities in case they share the same name.
