### PR TITLE
fix handleAnchor

### DIFF
--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -76,7 +76,7 @@ function fillSidebarWithNodes (nodes, filter) {
   function handleAnchor (e) {
     e.preventDefault()
 
-    var $target = $(event.target)
+    var $target = $(e.target)
 
     $docItems.removeClass('active')
     $target.closest('li').addClass('active')
@@ -93,7 +93,7 @@ function fillSidebarWithNodes (nodes, filter) {
   $('#full-list .node.clicked .deflink').on('click', e => {
     e.preventDefault()
 
-    var $target = $(event.target)
+    var $target = $(e.target)
 
     $defItems.removeClass('active')
     $target.closest('li').addClass('active')


### PR DESCRIPTION
I was seeing the [Ecto.Changeset doc](http://hexdocs.pm/ecto/Ecto.Changeset.html) and the anchors on sidebar doesn't works in Firefox. 

The problems is the global ```event``` is undefined in Firefox. I changed to use event from handler argument

Error: ```ReferenceError: event is not defined```
Firefox: 40.0.3 
OS: UbuntuGNOME linux