### PR TITLE
Validate anchor links in sidebar + fix summary sorting

### DIFF
--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -121,7 +121,7 @@ defmodule ExDoc.Formatter.HTML.Templates do
   end
 
   defp sidebar_items_object(id, anchor) do
-    ~s/{"id":"#{id}","anchor":"#{anchor}"}/
+    ~s/{"id":"#{id}","anchor":"#{URI.encode(anchor)}"}/
   end
 
   defp group_types(node) do

--- a/lib/ex_doc/formatter/html/templates/summary_template.eex
+++ b/lib/ex_doc/formatter/html/templates/summary_template.eex
@@ -3,6 +3,6 @@
     <h2>
       <a href="#<%= name %>"><%= String.capitalize name %></a>
     </h2>
-    <%= for node <- Enum.sort(nodes), do: summary_item_template(node) %>
+    <%= for node <- nodes, do: summary_item_template(node) %>
   </div>
 <% end %>


### PR DESCRIPTION
enc() helper added.

Checked by htmlproof and html5validator

Also removed the Enum.sort() that messed up the order in summary