### PR TITLE
remove trailing semicolon from  Synopsis

### DIFF
--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -47,10 +47,23 @@ defmodule ExDoc.Formatter.HTML.Templates do
     end
   end
 
-  # Get the first paragraph of the documentation of a node, if any.
-  defp synopsis(nil), do: nil
-  defp synopsis(doc) do
-    String.split(doc, ~r/\n\s*\n/) |> hd |> String.strip() |> String.rstrip(?.)
+  @doc """
+  Gets the first paragraph of the documentation of a node. It strips
+  surrounding spaces and strips traling `:` and `.`.
+
+  If `doc` is `nil`, it returns `nil`.
+  """
+  @spec synopsis(String.t) :: String.t
+  @spec synopsis(nil) :: nil
+
+  def synopsis(nil), do: nil
+  def synopsis(""),  do: ""
+  def synopsis(doc) when is_bitstring(doc) do
+    String.split(doc, ~r/\n\s*\n/)
+    |> hd
+    |> String.strip()
+    |> String.replace(~r{[.:\s]+$}, "")
+    |> String.rstrip()
   end
 
   defp presence([]),    do: nil

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -28,7 +28,8 @@ defmodule ExDoc.Retriever do
   @doc """
   Extract documentation from all modules in the specified directory
   """
-  def docs_from_dir(dir, config) do
+  @spec docs_from_dir(Path.t, %ExDoc.Config{}) :: [%ExDoc.ModuleNode{}]
+  def docs_from_dir(dir, config) when is_binary(dir) do
     files = Path.wildcard Path.expand("Elixir.*.beam", dir)
     docs_from_files(files, config)
   end
@@ -36,6 +37,7 @@ defmodule ExDoc.Retriever do
   @doc """
   Extract documentation from all modules in the specified list of files
   """
+  @spec docs_from_files([Path.t], %ExDoc.Config{}) :: [%ExDoc.ModuleNode{}]
   def docs_from_files(files, config) when is_list(files) do
     files
     |> Enum.map(&filename_to_module(&1))
@@ -45,6 +47,7 @@ defmodule ExDoc.Retriever do
   @doc """
   Extract documentation from all modules in the list `modules`
   """
+  @spec docs_from_modules([atom], %ExDoc.Config{}) :: [%ExDoc.ModuleNode{}]
   def docs_from_modules(modules, config) when is_list(modules) do
     modules
     |> Enum.map(&get_module(&1, config))

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -31,6 +31,39 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
     Templates.module_page(hd(mods), [], [], [], doc_config)
   end
 
+  test "synopsis" do
+    assert Templates.synopsis(nil) == nil
+    assert Templates.synopsis("") == ""
+    assert Templates.synopsis(".") == ""
+    assert Templates.synopsis(".::.") == ""
+    assert Templates.synopsis(" .= .: :.") == ".="
+    assert Templates.synopsis(" Description: ") == "Description"
+    assert Templates.synopsis("abcd") == "abcd"
+    assert_raise FunctionClauseError, fn ->
+      Templates.synopsis(:abcd)
+    end
+  end
+
+  test "synopsis should not end have trailing periods or semicolons" do
+    doc1 = """
+    Summaries should not be displayed with trailing punctuation . :
+
+    ## Example
+    """
+
+    doc2 = """
+    Example function: Summary should not display trailing puntuation :. 
+
+    ## Example:
+    """
+
+    assert Templates.synopsis(doc1) ==
+      "Summaries should not be displayed with trailing punctuation"
+
+    assert Templates.synopsis(doc2) ==
+      "Example function: Summary should not display trailing puntuation"
+  end
+
   ## LISTING
 
   test "enables nav link when module type have at least one element" do

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -18,7 +18,7 @@ defmodule ExDoc.Formatter.HTMLTest do
     [project: "Elixir",
      version: "1.0.1",
      formatter: "html",
-     output: "test/tmp/doc",
+     output: output_dir,
      source_root: beam_dir,
      source_beam: beam_dir,
      logo: "test/fixtures/elixir.png",


### PR DESCRIPTION
this commit improves the removal of trailing punctuation from summary
semicolon has been added as it appeared showing up in a quiet a few
cases in summaries

tests added

ExDoc.Formatter.HTML.Templates.api_reference_page/5 added to ease testing.

and also added specs for  ExDoc.Retriever.docs_from_*