### PR TITLE
improved instrucitons for getting help

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ end
 
 Now you are ready to generate your project documentation with `mix docs`.
 
+To see all options available when generating docs, run `mix help docs`.   You may have to do `mix docs` or `mix deps.compile` first.
+
 ## Using ExDoc via command line
 
 You can ExDoc via the command line as follows:
@@ -74,8 +76,6 @@ Then add the entry:
     config :ex_doc, :markdown_processor, ExDoc.Markdown.Pandoc  # or ExDoc.Markdown.Hoedown
 
 to your `config/config.exs` file.
-
-To see all options available when generating docs, just run `mix help docs`.
 
 # License
 


### PR DESCRIPTION
Getting help for ex_doc wasn't obvious.   First you have to find the `mix help docs` reference which was in a non-obvious place, and then you had to figure out why it didn't work (because deps hadn't been compiled yet).    

I moved the line describing this under using with mix and added guidance about building deps.

