### PR TITLE
Fix autolink anchors for non URL safe function names

### DIFF
--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -208,8 +208,10 @@ defmodule ExDoc.Formatter.HTML.Autolink do
     |> List.flatten()
     |> Enum.filter(&(&1 in locals))
     |> Enum.reduce(bin, fn (x, acc) ->
+         {prefix, _, function_name, arity} = split_function(x)
          escaped = Regex.escape(x)
-         Regex.replace(~r/(?<!\[)`(\s*(#{escaped})\s*)`(?!\])/, acc, "[`\\1`](#\\2)")
+         Regex.replace(~r/(?<!\[)`(\s*#{escaped}\s*)`(?!\])/, acc,
+           "[`#{function_name}/#{arity}`](##{prefix}#{enc_h function_name}/#{arity})")
        end)
   end
 
@@ -250,7 +252,7 @@ defmodule ExDoc.Formatter.HTML.Autolink do
          {prefix, mod_str, function_name, arity} = split_function(x)
          escaped = Regex.escape(x)
          Regex.replace(~r/(?<!\[)`(\s*#{escaped}\s*)`(?!\])/, acc,
-           "[`#{mod_str}.#{function_name}/#{arity}`](#{mod_str}.html##{prefix}#{function_name}/#{arity})")
+           "[`#{mod_str}.#{function_name}/#{arity}`](#{mod_str}.html##{prefix}#{enc_h function_name}/#{arity})")
        end)
   end
 

--- a/test/ex_doc/formatter/html/autolink_test.exs
+++ b/test/ex_doc/formatter/html/autolink_test.exs
@@ -10,7 +10,7 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
     assert Autolink.local_doc("`example/2` then `example/2`",
       ["example/2"]) == "[`example/2`](#example/2) then [`example/2`](#example/2)"
     assert Autolink.local_doc("`  spaces/0  `", ["spaces/0"]) ==
-      "[`  spaces/0  `](#spaces/0)"
+      "[`spaces/0`](#spaces/0)"
     assert Autolink.local_doc("`example/1` and `example/2`",
       ["example/1", "example/2"]) == "[`example/1`](#example/1) and [`example/2`](#example/2)"
     assert Autolink.local_doc("`funny_name\?/1` and `funny_name!/2`",
@@ -33,6 +33,7 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
     assert Autolink.local_doc("`!/1`", ["!/1"]) === "[`!/1`](#!/1)"
     assert Autolink.local_doc("`../2`", ["../2"]) === "[`../2`](#../2)"
     assert Autolink.local_doc("`--/2`", ["--/2"]) === "[`--/2`](#--/2)"
+    assert Autolink.local_doc("`<<>>/1`", ["<<>>/1"]) === "[`<<>>/1`](#%3C%3C%3E%3E/1)"
   end
 
   # project_functions
@@ -61,6 +62,7 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
     assert Autolink.project_functions("`Mod.!/1`", ["Mod.!/1"]) === "[`Mod.!/1`](Mod.html#!/1)"
     assert Autolink.project_functions("`Mod.../2`", ["Mod.../2"]) === "[`Mod.../2`](Mod.html#../2)"
     assert Autolink.project_functions("`Mod.--/2`", ["Mod.--/2"]) === "[`Mod.--/2`](Mod.html#--/2)"
+    assert Autolink.project_functions("`Mod.<<>>/1`", ["Mod.<<>>/1"]) === "[`Mod.<<>>/1`](Mod.html#%3C%3C%3E%3E/1)"
   end
 
   test "autolink creates links for callbacks" do


### PR DESCRIPTION
The function names need to be URL escaped in the auto-generated links as well. Other spots I found like the links in the sidebar were already corrected.

For example [this section in the elixir docs](http://elixir-lang.org/docs/stable/elixir/Kernel.SpecialForms.html#::/2) links to `<<>>/1`, which generates the following markup:

```html
<a href="#&lt;&lt;&gt;&gt;/1">...</a>
```

However, it should be like this

```html
<a href="#%3C%3C%3E%3E/1">...</a>
```

Note that I also changed the specs, which now assert that surrounding spaces are removed. This is now in line with the way `Autolink.project_functions` works, which also strips spaces.