### PR TITLE
** (ExDoc.Retriever.Error) module MyListLexer was not compiled with flag --docs

### DIFF
--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -91,14 +91,18 @@ defmodule ExDoc.Retriever do
   end
 
   defp verify_module(module) do
-    case Code.get_docs(module, :moduledoc) do
-      {_line, false} ->
-        nil
-      {_, _} ->
-        module
-      nil ->
-        IO.puts(:stderr, "module #{inspect module} was not compiled with flag --docs")
-        nil
+    if function_exported?(module, :__info__, 1) do
+      case Code.get_docs(module, :moduledoc) do
+        {_line, false} ->
+          nil
+        {_, _} ->
+          module
+        nil ->
+          raise("module #{inspect module} was not compiled with flag --docs")
+      end
+    else
+      IO.puts(:stderr, "module #{inspect module} does not export __info__/1")
+      nil
     end
   end
 

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -97,7 +97,8 @@ defmodule ExDoc.Retriever do
       {_, _} ->
         module
       nil ->
-        raise(Error, message: "module #{inspect module} was not compiled with flag --docs")
+        IO.puts(:stderr, "module #{inspect module} was not compiled with flag --docs")
+        nil
     end
   end
 

--- a/test/ex_doc/retriever_test.exs
+++ b/test/ex_doc/retriever_test.exs
@@ -121,6 +121,16 @@ defmodule ExDoc.RetrieverTest do
     end
   end
 
+  test "docs_from_modules warns when module was not compiled with flag --docs" do
+    module = ExDoc.RetrieverTest.ModuleNotCompiledWithFlagDocs
+    {:ok, ^module} = :compile.file('#{__DIR__}/retriever_test/#{module}.erl')
+    "Elixir." <> module_name_suffix = module |> to_string
+
+    assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
+      Retriever.docs_from_modules([module], %ExDoc.Config{})
+    end) == "module #{module_name_suffix} was not compiled with flag --docs\n"
+  end
+
   ## EXCEPTIONS
 
   test "docs_from_files properly tags exceptions" do

--- a/test/ex_doc/retriever_test.exs
+++ b/test/ex_doc/retriever_test.exs
@@ -121,14 +121,14 @@ defmodule ExDoc.RetrieverTest do
     end
   end
 
-  test "docs_from_modules warns when module was not compiled with flag --docs" do
+  test "docs_from_modules warns when module does not export __info__/1" do
     module = ExDoc.RetrieverTest.ModuleNotCompiledWithFlagDocs
     {:ok, ^module} = :compile.file('#{__DIR__}/retriever_test/#{module}.erl')
     "Elixir." <> module_name_suffix = module |> to_string
 
     assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
       Retriever.docs_from_modules([module], %ExDoc.Config{})
-    end) == "module #{module_name_suffix} was not compiled with flag --docs\n"
+    end) == "module #{module_name_suffix} does not export __info__/1\n"
   end
 
   ## EXCEPTIONS

--- a/test/ex_doc/retriever_test/Elixir.ExDoc.RetrieverTest.ModuleNotCompiledWithFlagDocs.erl
+++ b/test/ex_doc/retriever_test/Elixir.ExDoc.RetrieverTest.ModuleNotCompiledWithFlagDocs.erl
@@ -1,0 +1,4 @@
+% This Erlang module is deliberately named like an Elixir module in order to
+% trigger a warning.  See https://github.com/elixir-lang/ex_doc/issues/453
+
+-module('Elixir.ExDoc.RetrieverTest.ModuleNotCompiledWithFlagDocs').


### PR DESCRIPTION
Hello,

I'm using ex_doc 0.10.0 with Elixir 1.1.1 and Erlang 18.1 under 64-bit Linux. :smiley:

[Following this guide](http://andrealeopardi.com/posts/tokenizing-and-parsing-in-elixir-using-leex-and-yecc/), I created a `src/Elixir.My.List.Lexer.xrl` file containing:

```erlang
Definitions.

INT        = [0-9]+
ATOM       = :[a-z_]+
WHITESPACE = [\s\t\n\r]

Rules.

{INT}         : {token, {int,  TokenLine, list_to_integer(TokenChars)}}.
{ATOM}        : {token, {atom, TokenLine, to_atom(TokenChars)}}.
\[            : {token, {'[',  TokenLine}}.
\]            : {token, {']',  TokenLine}}.
,             : {token, {',',  TokenLine}}.
{WHITESPACE}+ : skip_token.

Erlang code.

to_atom([$:|Chars]) ->
    list_to_atom(Chars).
```

Afterwards, I get the following error when running `mix docs`: :scream:

```sh
$ mix docs
Compiled src/Elixir.My.List.Lexer.xrl
Compiled src/Elixir.My.List.Lexer.erl
...
Generated my app
** (ExDoc.Retriever.Error) module My.List.Lexer was not compiled with flag --docs
    lib/ex_doc/retriever.ex:82: ExDoc.Retriever.verify_module/1
    lib/ex_doc/retriever.ex:71: ExDoc.Retriever.get_module/2
    (elixir) lib/enum.ex:1043: anonymous fn/3 in Enum.map/2
    (elixir) lib/enum.ex:1387: Enum."-reduce/3-lists^foldl/2-0-"/3
    (elixir) lib/enum.ex:1043: Enum.map/2
    lib/ex_doc/retriever.ex:50: ExDoc.Retriever.docs_from_modules/2
    lib/ex_doc.ex:37: ExDoc.generate_docs/3
    lib/mix/tasks/docs.ex:88: Mix.Tasks.Docs.run/3

exit 1
```

Unfortunately, `:leex.file/2` (which compiles the `*.xrl` file into a `*.erl` file) does not support the `--docs` compiler flag that ex_doc is telling me to use. :cold_sweat:  How would you suggest fixing this error? :bug:

Thanks for your consideration.