### PR TITLE
Get rid of the 'extra-' prefix

### DIFF
--- a/lib/ex_doc/cli.ex
+++ b/lib/ex_doc/cli.ex
@@ -107,7 +107,7 @@ defmodule ExDoc.CLI do
       -u, --source-url    URL to the source code
           --source-ref    Branch/commit/tag used for source link inference, default: "master"
       -m, --main          The main, entry-point module in docs,
-                          default: "extra-api-reference" when --formatter is "html"
+                          default: "api-reference" when --formatter is "html"
       -p, --homepage-url  URL to link to for the site name
       -e, --extra         Allow users to include additional Markdown files
                           May be given multiple times

--- a/lib/ex_doc/formatter/html/templates/not_found_template.eex
+++ b/lib/ex_doc/formatter/html/templates/not_found_template.eex
@@ -5,7 +5,7 @@
 
 <p>Sorry, but the page you were trying to get to, does not exist. You
 may want to try searching this site using the sidebar or using our
-<a href="extra-api-reference.html" title="API Reference">API Reference</a> page to find what
+<a href="api-reference.html" title="API Reference">API Reference</a> page to find what
 you were looking for.</p>
 
 <%= footer_template(config) %>

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -40,8 +40,8 @@ defmodule Mix.Tasks.Docs do
     Ignored if `:source_url_pattern` is provided; default: master.
 
   * `:main` - main page of the documentation. It may be a module or a
-    generated page, like "Plug" or "extra-api-reference";
-    default: "extra-api-reference" when --formatter is "html".
+    generated page, like "Plug" or "api-reference";
+    default: "api-reference" when --formatter is "html".
 
   * `:logo` - Path to the image logo of the project (only PNG or JPEG accepted)
     The image size will be 64x64 when --formatter is "html".

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -56,7 +56,7 @@ defmodule ExDoc.Formatter.HTMLTest do
     assert File.regular?("#{output_dir}/CompiledWithDocs.Nested.html")
 
     content = File.read!("#{output_dir}/index.html")
-    assert content =~ ~r{<meta http-equiv="refresh" content="0; url=extra-api-reference.html">}
+    assert content =~ ~r{<meta http-equiv="refresh" content="0; url=api-reference.html">}
   end
 
   test "check headers for index.html and module pages" do
@@ -139,14 +139,14 @@ defmodule ExDoc.Formatter.HTMLTest do
     assert content =~ ~s("modules":[])
     assert content =~ ~s("exceptions":[])
     assert content =~ ~s("protocols":[])
-    assert content =~ ~s("extras":[{"id":"extra-api-reference","title":"API Reference","headers":[]},)
-    assert content =~ ~s({"id":"extra-readme","title":"README","headers":[{"id":" Header sample","anchor":"Header-sample"}]})
+    assert content =~ ~s("extras":[{"id":"api-reference","title":"API Reference","headers":[]},)
+    assert content =~ ~s({"id":"readme","title":"README","headers":[{"id":" Header sample","anchor":"Header-sample"}]})
   end
 
   test "run generates the api reference file" do
     generate_docs(doc_config)
 
-    content = File.read!("#{output_dir}/extra-api-reference.html")
+    content = File.read!("#{output_dir}/api-reference.html")
     assert content =~ ~r{<a href="CompiledWithDocs.html">CompiledWithDocs</a>}
     assert content =~ ~r{<p>moduledoc</p>}
     assert content =~ ~r{<a href="CompiledWithDocs.Nested.html">CompiledWithDocs.Nested</a>}
@@ -159,7 +159,7 @@ defmodule ExDoc.Formatter.HTMLTest do
     content = File.read!("#{output_dir}/index.html")
     assert content =~ ~r{<meta http-equiv="refresh" content="0; url=README.html">}
 
-    content = File.read!("#{output_dir}/extra-readme.html")
+    content = File.read!("#{output_dir}/readme.html")
     assert content =~ ~r{<title>README [^<]*</title>}
     assert content =~ ~r{<h2 id="Header-sample"> Header sample</h2>}
     assert content =~ ~r{<a href="RandomError.html"><code>RandomError</code>}
@@ -176,12 +176,12 @@ defmodule ExDoc.Formatter.HTMLTest do
 
   test "run normalizes options" do
     # 1. Check for output dir having trailing "/" stripped
-    # 2. Check for default [main: "extra-api-reference"]
+    # 2. Check for default [main: "api-reference"]
     generate_docs doc_config(output: "#{output_dir}//", main: nil)
 
     content = File.read!("#{output_dir}/index.html")
-    assert content =~ ~r{<meta http-equiv="refresh" content="0; url=extra-api-reference.html">}
-    assert File.regular?("#{output_dir}/extra-api-reference.html")
+    assert content =~ ~r{<meta http-equiv="refresh" content="0; url=api-reference.html">}
+    assert File.regular?("#{output_dir}/api-reference.html")
 
     # 3. main as index is not allowed
     config = doc_config([main: "index"])


### PR DESCRIPTION
This PR removes the `extra-` prefix from the additional documentation (specified with the option `extras`), this was suggested by @wsmoak, you can see more details about the discussion [here](https://groups.google.com/d/msg/elixir-lang-core/UzhyIhvQsC8/S_W5sk3yDAAJ)

@josevalim If you can, please let me know what do you think or if I need to fix something else.

As a side note, I also worked in another solution, moving all the additional documentation into the subdirectory `extras`, but, I like more this way.