### PR TITLE
Preserve the original filename for extras

### DIFF
--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -103,12 +103,11 @@ defmodule ExDoc.Formatter.HTML do
     [{"api-reference", "API Reference", []}|extras]
   end
 
-  defp generate_extra({input_file, output_file_name}, output, module_nodes, modules, exceptions, protocols, config) do
-    title = input_to_title(output_file_name)
+  defp generate_extra({input_file, menu_title}, output, module_nodes, modules, exceptions, protocols, config) do
 
     options = %{
-      title: title,
-      output_file_name: title,
+      title: menu_title,
+      output_file_name: Path.basename(input_file, ".md"),
       input: to_string(input_file),
       output: output
     }


### PR DESCRIPTION
https://github.com/elixir-lang/ex_doc/pull/468 introduced the ability to specify the menu item text for an extra file, but the text is also used as the output filename, leading to things like Custom%20Menu%20Title.html.

This preserves the original filename, so my-extra-file.md simply becomes my-extra-file.html, and the second element of the tuple is only used as the menu item text.

(Note that José had a different comment on line 107.)