### PR TITLE
Allow definition of the path/title for extra files

### DIFF
--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -103,13 +103,15 @@ defmodule ExDoc.Formatter.HTML do
     [{"api-reference", "API Reference", []}|extras]
   end
 
-  defp generate_extra({input_file, output_file_name}, output, module_nodes, modules, exceptions, protocols, config) do
-    title = input_to_title(output_file_name)
+  defp generate_extra({input_file, options}, output, module_nodes, modules, exceptions, protocols, config) do
+    input_file = to_string(input_file)
+    title = options[:title] || input_to_title(input_file)
+    output_file_name = options[:path] || input_file |> input_to_title() |> title_to_filename()
 
     options = %{
       title: title,
-      output_file_name: title,
-      input: to_string(input_file),
+      output_file_name: output_file_name,
+      input: input_file,
       output: output
     }
 

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -49,8 +49,11 @@ defmodule Mix.Tasks.Docs do
   * `:extra_section` - String that define the section title of the additional
     Markdown pages (e.g. "GUIDES"); default: "PAGES"
 
-  * `:extras` - List of strings, each one must indicate the path to additional
-    Markdown pages (e.g. `["README.md", "CONTRIBUTING.md"]`); default: `[]`
+  * `:extras` - List of keywords, each key must indicate the path to additional
+    Markdown pages, the value for each keyword (optional) gives you more control
+    about the PATH and the title of the output files, please remember that the
+    title also will be used in the sidebar area (under the :extra_section); default: `[]`
+    (e.g. `["README.md", "CONTRIBUTING.md": [path: "CONTRIBUTORS", title: "Help us!"]]`)
   """
 
   @doc false

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -174,6 +174,23 @@ defmodule ExDoc.Formatter.HTMLTest do
     refute content =~ ~r{<title>README [^<]*</title>}
   end
 
+  test "run should generate the readme input file as getting-started" do
+    generate_docs(doc_config(extras: ["test/fixtures/README.md": [path: "GETTING-STARTED"]]))
+    refute File.regular?("#{output_dir}/readme.html")
+    content = File.read!("#{output_dir}/GETTING-STARTED.html")
+    assert content =~ ~r{<title>README [^<]*</title>}
+    content = File.read!("#{output_dir}/dist/sidebar_items.js")
+    assert content =~ ~r{"id":"GETTING-STARTED","title":"README"}
+  end
+
+  test "run uses custom menu title" do
+    generate_docs(doc_config(extras: ["test/fixtures/README.md": [title: "Getting Started"]]))
+    content = File.read!("#{output_dir}/readme.html")
+    assert content =~ ~r{<title>Getting Started – Elixir v1.0.1</title>}
+    content = File.read!("#{output_dir}/dist/sidebar_items.js")
+    assert content =~ ~r{"id":"readme","title":"Getting Started"}
+   end
+
   test "run normalizes options" do
     # 1. Check for output dir having trailing "/" stripped
     # 2. Check for default [main: "api-reference"]


### PR DESCRIPTION
Assuming the following configuration:

```elixir
     docs: [source_ref: "v#{@version}", main: "Phoenix", logo: "logo.png",
            extras: ["README.md",
                     "CHANGELOG.md": [title: "Changes"],
                     "CODE_OF_CONDUCT.md": [path: "code-of-conduct"],
                     "CONTRIBUTING.md": [path: "contributors", title: "We need your help!"]]],
```

Now the results are:

Input File | Output File | Menu name
------------ | --------------- | ---------------
`README.md` | `readme.html` | `README`
`CHANGELOG.md` | `changelog.html` | `Changes`
`CODE_OF_CONDUCT.md` | `code-of-conduct.html` | `CODE_OF_CONDUCT`
`CONTRIBUTING.md` | `contributors.html` | `We need your help!"

Related issues: #469 #468 #450