### PR TITLE
Use first <h1> as menu title if title is not configured

### DIFF
--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -191,6 +191,14 @@ defmodule ExDoc.Formatter.HTMLTest do
     assert content =~ ~r{"id":"readme","title":"Getting Started"}
    end
 
+  test "run uses first <h1> as menu title" do
+    generate_docs(doc_config(extras: ["test/fixtures/ExtraPage.md"]))
+    content = File.read!("#{output_dir}/extrapage.html")
+    assert content =~ ~r{<title>Extra Page Title – Elixir v1.0.1</title>}
+    content = File.read!("#{output_dir}/dist/sidebar_items.js")
+    assert content =~ ~r{"id":"extrapage","title":"Extra Page Title"}
+  end
+
   test "run normalizes options" do
     # 1. Check for output dir having trailing "/" stripped
     # 2. Check for default [main: "api-reference"]

--- a/test/fixtures/ExtraPage.md
+++ b/test/fixtures/ExtraPage.md
@@ -1,0 +1,15 @@
+# Extra Page Title
+
+some text
+
+## Section One
+
+more text
+
+# Another H1
+
+even more text
+
+## Section Two
+
+final text


### PR DESCRIPTION
Take the first line beginning with `# ` (the first `<h1>`) as the menu title, if a title wasn't specified in the configuration.

ExDoc already uses the `<h2>`'s as sub-menu items, so this seems natural to do.

Without this, I have to duplicate the header text in both the markdown file and the configuration.

Advice on implementation and testing is appreciated!  @bbense suggested using multiple defined functions instead of the conditional, see [1], but this seems to fit better with the other code in the module.

[1] http://wiki.wsmoak.net/cgi-bin/wiki.pl?ElixirSlack20151110