### PR TITLE
fix typo in ex_doc module

### DIFF
--- a/lib/ex_doc.ex
+++ b/lib/ex_doc.ex
@@ -1,6 +1,6 @@
 defmodule ExDoc do
   @moduledoc """
-  Elixir Documentation System. ExDoc produce documentation for Elixir projects
+  Elixir Documentation System. ExDoc produces documentation for Elixir projects
   """
 
   defmodule Config do


### PR DESCRIPTION
fix a typo in ex_doc module docstring