### PR TITLE
fix(ExDoc.Retriever): fix invalid arguments for callbacks

### DIFF
--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -262,8 +262,9 @@ defmodule ExDoc.Retriever do
     |> Enum.take(-arity)
     |> Enum.with_index()
     |> Enum.map(fn
-      {{:::, _, [left, _]}, i} -> to_var(left, i)
-      {left, i} -> to_var(left, i)
+      {{:::, _, [left, _]}, i}         -> to_var(left, i)
+      {ast, i} when elem(ast, 0) == :| -> to_var({}, i)
+      {left, i}                        -> to_var(left, i)
     end)
   end
 

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -162,6 +162,8 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
     assert content =~ ~r{<h1>\n\s*<small class="visible-xs">Elixir v1.0.1</small>\n\s*CustomBehaviourOne\s*<small>behaviour</small>}m
     assert content =~ ~r{Callbacks}
     assert content =~ ~r{<div class="detail" id="c:hello/1">}
+    assert content =~ ~s[hello(integer)]
+    assert content =~ ~s[greet(arg0)]
 
     content = get_module_page([CustomBehaviourTwo])
     assert content =~ ~r{<h1>\n\s*<small class="visible-xs">Elixir v1.0.1</small>\n\s*CustomBehaviourTwo\s*<small>behaviour</small>\s*}m

--- a/test/ex_doc/retriever_test.exs
+++ b/test/ex_doc/retriever_test.exs
@@ -133,9 +133,12 @@ defmodule ExDoc.RetrieverTest do
   test "ignore behaviours internal functions" do
     [node] = docs_from_files ["CustomBehaviourOne"]
     functions = Enum.map node.docs, fn(doc) -> doc.id end
-    assert functions == ["hello/1"]
-    assert hd(node.docs).type == :callback
-    assert hd(node.docs).signature == "hello(integer)"
+    assert functions == ["greet/1", "hello/1"]
+    [greet, hello] = node.docs
+    assert hello.type == :callback
+    assert hello.signature == "hello(integer)"
+    assert greet.type == :callback
+    assert greet.signature == "greet(arg0)"
   end
 
   test "retrieves macro callbacks from behaviours" do

--- a/test/fixtures/behaviour.ex
+++ b/test/fixtures/behaviour.ex
@@ -5,6 +5,7 @@ defmodule CustomBehaviourOne do
   This is a sample callback.
   """
   defcallback hello(integer) :: integer
+  defcallback greet(integer | string) :: integer
 end
 
 defmodule CustomBehaviourTwo do


### PR DESCRIPTION
When a callback is defined, an attempt is made to derive the argument
type from the name. If the typespec has more than one type option then
the argument name is given as "|"

An explicit check for this format is now in place, and the "arg#{i}"
case is used.