### PR TITLE
chore(ExDoc.Retriever): pattern match :| for types

### DIFF
--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -262,9 +262,9 @@ defmodule ExDoc.Retriever do
     |> Enum.take(-arity)
     |> Enum.with_index()
     |> Enum.map(fn
-      {{:::, _, [left, _]}, i}         -> to_var(left, i)
-      {ast, i} when elem(ast, 0) == :| -> to_var({}, i)
-      {left, i}                        -> to_var(left, i)
+      {{:::, _, [left, _]}, i} -> to_var(left, i)
+      {{:|, _, _}, i}          -> to_var({}, i)
+      {left, i}                -> to_var(left, i)
     end)
   end
 


### PR DESCRIPTION
@josevalim You merged my last pull request just as I was amending this. Sorry.