### PR TITLE
Unsafe variables and string() type

### DIFF
--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -30,30 +30,30 @@ defmodule ExDoc.Formatter.HTML.Autolink do
   defp all_docs(module, modules) do
     locals = Enum.map module.docs, &(doc_prefix(&1) <> &1.id)
 
-    if module.moduledoc do
-      moduledoc =
+    moduledoc =
+      if module.moduledoc do
         module.moduledoc
         |> local_doc(locals)
         |> project_doc(modules, module.id)
-    end
+      end
 
     docs = for node <- module.docs do
-      if node.doc do
-        doc =
+      doc =
+        if node.doc do
           node.doc
           |> local_doc(locals)
           |> project_doc(modules, module.id)
-      end
+        end
       %{node | doc: doc}
     end
 
     typedocs = for node <- module.typespecs do
-      if node.doc do
-        doc =
+      doc =
+        if node.doc do
           node.doc
           |> local_doc(locals)
           |> project_doc(modules, module.id)
-      end
+        end
       %{node | doc: doc}
     end
 

--- a/test/fixtures/behaviour.ex
+++ b/test/fixtures/behaviour.ex
@@ -5,7 +5,7 @@ defmodule CustomBehaviourOne do
   This is a sample callback.
   """
   defcallback hello(integer) :: integer
-  defcallback greet(integer | string) :: integer
+  defcallback greet(integer | String.t) :: integer
 end
 
 defmodule CustomBehaviourTwo do


### PR DESCRIPTION
* Avoid warnings on variables defined inside a conditional (Elixir v1.0.2-dev)
* Avoid `string()` type, for strings, use `String.t()` instead. 