### PR TITLE
Take advantage of extra space on large screens by widening sidebar

### DIFF
--- a/assets/js/sidebar.js
+++ b/assets/js/sidebar.js
@@ -11,13 +11,24 @@ const sidebar = $('.sidebar')
 
 const bodyClass = 'sidebar-closed'
 const duration = 300
-const width = '300px'
 const displayProps = [
   '-webkit-flex',
   '-ms-flexbox',
   '-ms-flex',
   'flex'
 ]
+
+function getWidth () {
+  const docWidth = $(document).width()
+  if (docWidth >= 1800) {
+    return '425px'
+  } else if (docWidth >= 1600) {
+    return '375px'
+  }
+  return '300px'
+}
+
+let width = getWidth()
 
 function closeSidebar () {
   sidebar.animate({
@@ -35,6 +46,8 @@ function closeSidebar () {
 }
 
 function openSidebar (immediate) {
+  width = getWidth()
+
   body.removeClass(bodyClass)
   displayProps.forEach(prop => {
     sidebar.css({display: prop})
@@ -49,7 +62,9 @@ function openSidebar (immediate) {
     '-ms-flex-basis': width,
     'flex-basis': width,
     width: width
-  }, duration)
+  }, duration, function () {
+    sidebar.attr('style', '')
+  })
 }
 
 function toggleSidebar () {

--- a/assets/less/sidebar.less
+++ b/assets/less/sidebar.less
@@ -216,3 +216,33 @@
     }
   }
 }
+
+// Wider sidebar on large displays
+
+@media screen and (min-width: 1600px) {
+  .sidebar {
+    .flex(0, 1, 375px);
+
+    .sidebar-toggle {
+      left: 350px;
+    }
+
+    .sidebar-search .sidebar-searchInput {
+      width: 250px;
+    }
+  }
+}
+
+@media screen and (min-width: 1800px) {
+  .sidebar {
+    .flex(0, 1, 425px);
+
+    .sidebar-toggle {
+      left: 400px;
+    }
+
+    .sidebar-search .sidebar-searchInput {
+      width: 275px;
+    }
+  }
+}


### PR DESCRIPTION
Solves #492 

This solution uses media queries and an extra JS function to cater to different screen widths.

While working on this feature, I encountered several different ways this could be done.

I started by just adding a couple CSS media queries on the sidebar, which works great until you show/hide the sidebar. Because the width of the sidebar is statically set in the JS file that animates it, as soon as you toggle the sidebar, the new CSS gets overridden.

The solution I went with for this PR is to add CSS media queries, and change the width variable in JS to change based on screen width. After the sidebar is opened, the inline styles that get added are removed so the CSS takes over again. This probably isn't the absolute *best* solution, but it works and it's simple.

Here are some other potential ideas if we decide this isn't good enough:

1. **Refactor to use CSS animations.** This solution would probably be the best, but would also take the most amount of work.
2. **Disable the show/hide ability on larger screens.** If your screen is big enough to have this much extra whitespace, you probably don't have much of a need to hide the sidebar. This would be a really quick, simple, and reliably solution.