### PR TITLE
Don't abort by timeout of Task.await

### DIFF
--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -99,7 +99,7 @@ defmodule ExDoc.Formatter.HTML do
       |> Enum.map(&Task.async(fn ->
           generate_extra(&1, output, module_nodes, modules, exceptions, protocols, config)
          end))
-      |> Enum.map(&Task.await/1)
+      |> Enum.map(&Task.await(&1, :infinity))
     [{"api-reference", "API Reference", []}|extras]
   end
 
@@ -118,7 +118,7 @@ defmodule ExDoc.Formatter.HTML do
   end
 
   defp generate_extra(input, output, module_nodes, modules, exceptions, protocols, config) do
-     output_file_name = input |> input_to_title |> title_to_filename
+    output_file_name = input |> input_to_title |> title_to_filename
 
     options = %{
       output_file_name: output_file_name,
@@ -246,7 +246,7 @@ defmodule ExDoc.Formatter.HTML do
     |> Enum.map(&Task.async(fn ->
         generate_module_page(&1, modules, exceptions, protocols, output, config)
        end))
-    |> Enum.map(&Task.await/1)
+    |> Enum.map(&Task.await(&1, :infinity))
   end
 
   defp generate_module_page(node, modules, exceptions, protocols, output, config) do

--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -14,7 +14,7 @@ defmodule ExDoc.Formatter.HTML.Autolink do
     aliases = Enum.map modules, &(&1.module)
     modules
     |> Enum.map(&Task.async(fn -> process_module(&1, modules, aliases) end))
-    |> Enum.map(&Task.await/1)
+    |> Enum.map(&Task.await(&1, :infinity))
   end
 
   defp process_module(module, modules, aliases) do


### PR DESCRIPTION
We are using ex_doc (v0.11.1) to generate docs for several projects with our CI server. Unfortunately our CI server's CPU resource is fairly poor and uses NFS volume. Recently we find that our `mix docs` job is failing due to timeout of `Task.await`. Some of our modules contain macro-generated many `def`s.
Stacktrace:
```
** (exit) exited in: Task.await(%Task{pid: #PID<0.1480.0>, ref: #Reference<0.0.1.26455>}, 5000)
    ** (EXIT) time out
    (elixir) lib/task.ex:274: Task.await/2
    (elixir) lib/enum.ex:1043: anonymous fn/3 in Enum.map/2
    (elixir) lib/enum.ex:1387: Enum."-reduce/3-lists^foldl/2-0-"/3
    (elixir) lib/enum.ex:1043: Enum.map/2
    lib/ex_doc/formatter/html.ex:23: ExDoc.Formatter.HTML.run/2
    lib/mix/tasks/docs.ex:96: Mix.Tasks.Docs.run/3
    (mix) lib/mix/cli.ex:55: Mix.CLI.run_task/2
```

In this PR I simply changed the timeout of `Task.await` from default (5000 millisec) to `:infinity`.
Thanks in advance!