### PR TITLE
support doc of @macrocallback

### DIFF
--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -305,6 +305,9 @@ defmodule ExDoc.Retriever do
     end
   end
 
+  defp actual_def(name, arity, :macrocallback) do
+    actual_def(name, arity, :defmacro)
+  end
   defp actual_def(name, arity, :defmacro) do
     {String.to_atom("MACRO-" <> to_string(name)), arity + 1}
   end


### PR DESCRIPTION
I try to generate docs for ecto master, but it failed. I found it's related to `@macrocallback`, so I fixed it. I didn't test this because ex_doc needs to support Elixir 1.0 for the moment, but this should work.