### PR TITLE
Downcase generated id from header to be consistent with GitHub format.

### DIFF
--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -205,6 +205,7 @@ defmodule ExDoc.Formatter.HTML do
     header
     |> String.strip()
     |> String.replace(~r/\W+/, "-")
+    |> String.downcase()
   end
 
   defp process_logo_metadata(config) do

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -140,7 +140,7 @@ defmodule ExDoc.Formatter.HTMLTest do
     assert content =~ ~s("exceptions":[])
     assert content =~ ~s("protocols":[])
     assert content =~ ~s("extras":[{"id":"api-reference","title":"API Reference","headers":[]},)
-    assert content =~ ~s({"id":"readme","title":"README","headers":[{"id":" Header sample","anchor":"Header-sample"}]})
+    assert content =~ ~s({"id":"readme","title":"README","headers":[{"id":" Header sample","anchor":"header-sample"}]})
   end
 
   test "run generates the api reference file" do
@@ -161,7 +161,7 @@ defmodule ExDoc.Formatter.HTMLTest do
 
     content = File.read!("#{output_dir}/readme.html")
     assert content =~ ~r{<title>README [^<]*</title>}
-    assert content =~ ~r{<h2 id="Header-sample"> Header sample</h2>}
+    assert content =~ ~r{<h2 id="header-sample"> Header sample</h2>}
     assert content =~ ~r{<a href="RandomError.html"><code>RandomError</code>}
     assert content =~ ~r{<a href="CustomBehaviourImpl.html#hello/1"><code>CustomBehaviourImpl.hello/1</code>}
     assert content =~ ~r{<a href="TypesAndSpecs.Sub.html"><code>TypesAndSpecs.Sub</code></a>}


### PR DESCRIPTION
Often, the markdown documents to be included in the generated docs are meant to be viewable on GitHub, especially README.md used as the default page on GitHub.

When attempting to do intra-document linking e.g. `[Examples][#examples]` to link to the Examples header in the same document, it works on GitHub rendered page, but fails on the generated HTML docs, due to the different capitalization of the required URL fragment/id attribute.

ex_docs preserves the capitalization of the header text when generating the `id` attribute while GitHub downcases them, making it incompatible with each other. 

Since it's unlikely we can get GitHub to change, given it will break all existing public #fragment links, the choice is for ex_doc to adopt GitHub's format for universal compatibility.

Here's the pull request to address this.