### PR TITLE
Fix ligature issue on Firefox and Safari

### DIFF
--- a/assets/less/content.less
+++ b/assets/less/content.less
@@ -4,6 +4,8 @@
   font-family: @serifFontFamily;
   font-size: 1em;
   line-height: 1.6875em;
+  font-feature-settings: "liga" 0;
+  -webkit-font-variant-ligatures: no-common-ligatures;
 
   @import './content/general';
   @import './content/summary';


### PR DESCRIPTION
I've added `font-feature-settings` for Firefox and `-webkit-font-variant-ligatures` for Safari to fix the problem of "invisible Fs" when `f` and `i` appear together in the docs. Fixes #511.