### PR TITLE
Fixed crash when no logo

### DIFF
--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -28,6 +28,8 @@ defmodule ExDoc.Formatter.HTML do
     config =
       if config.logo do
         process_logo_metadata(config)
+      else
+        config
       end
 
     generate_api_reference(modules, exceptions, protocols, output, config)


### PR DESCRIPTION
Looks like a result of fixing the 1.3.0 warnings commit.