### PR TITLE
Use canonical URLs

### DIFF
--- a/lib/ex_doc.ex
+++ b/lib/ex_doc.ex
@@ -10,6 +10,7 @@ defmodule ExDoc do
     You can find more details about this options in the `ExDoc.CLI` module.
     """
     defstruct [
+      canonical: nil,
       extra_section: nil,
       extras: [],
       formatter: "html",

--- a/lib/ex_doc/cli.ex
+++ b/lib/ex_doc/cli.ex
@@ -11,7 +11,7 @@ defmodule ExDoc.CLI do
     {opts, args, _} = OptionParser.parse(args,
                aliases: [o: :output, f: :formatter, c: :config, r: :source_root,
                          u: :source_url, m: :main, p: :homepage_url, l: :logo,
-                         e: :extra, v: :version],
+                         e: :extra, v: :version, a: :canonical],
                switches: [extra: :keep])
 
     cond do
@@ -103,6 +103,7 @@ defmodule ExDoc.CLI do
       -c, --config        Give configuration through a file instead of command line
       -o, --output        Path to output docs, default: "doc"
       -f, --formatter     Docs formatter to use, default: "html"
+      -a, --canonical     Indicate the preferred URL with rel="canonical" link element, default: nil
       -r, --source-root   Path to the source code root, default: "."
       -u, --source-url    URL to the source code
           --source-ref    Branch/commit/tag used for source link inference, default: "master"

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -58,13 +58,17 @@ defmodule ExDoc.Formatter.HTML do
   end
 
   defp generate_api_reference(modules, exceptions, protocols, output, config) do
+    file_name = "api-reference.html"
+    config = set_canonical_url(config, file_name)
     content = Templates.api_reference_template(config, modules, exceptions, protocols)
-    File.write!("#{output}/api-reference.html", content)
+    File.write!("#{output}/#{file_name}", content)
   end
 
   defp generate_not_found(modules, exceptions, protocols, output, config) do
+    file_name = "404.html"
+    config = set_canonical_url(config, file_name)
     content = Templates.not_found_template(config, modules, exceptions, protocols)
-    File.write!("#{output}/404.html", content)
+    File.write!("#{output}/#{file_name}", content)
   end
 
   defp generate_sidebar_items(modules, exceptions, protocols, extras, output) do
@@ -141,10 +145,12 @@ defmodule ExDoc.Formatter.HTML do
 
       title = options[:title] || extract_title(content) || input_to_title(options[:input])
 
+      output_file_name = "#{options.output_file_name}.html"
+      config = set_canonical_url(config, output_file_name)
       html = Templates.extra_template(config, title, modules,
                                       exceptions, protocols, link_headers(content))
 
-      output = "#{options.output}/#{options.output_file_name}.html"
+      output = "#{options.output}/#{output_file_name}"
 
       if File.regular? output do
         IO.puts "warning: file #{Path.basename output} already exists"
@@ -255,13 +261,28 @@ defmodule ExDoc.Formatter.HTML do
   end
 
   defp generate_module_page(node, modules, exceptions, protocols, output, config) do
+    file_name = "#{node.id}.html"
+    config = set_canonical_url(config, file_name)
     content = Templates.module_page(node, modules, exceptions, protocols, config)
-    File.write!("#{output}/#{node.id}.html", content)
+    File.write!("#{output}/#{file_name}", content)
   end
 
   defp templates_path(patterns) do
     Enum.into(patterns, [], fn {pattern, dir} ->
       {Path.expand("html/templates/#{pattern}", __DIR__), dir}
     end)
+  end
+
+  defp set_canonical_url(config, file_name) do
+    if config.canonical do
+      canonical_url =
+        config.canonical
+        |> String.rstrip(?/)
+        |> Path.join(file_name)
+
+      Map.put(config, :canonical, canonical_url)
+    else
+      config
+    end
   end
 end

--- a/lib/ex_doc/formatter/html/templates/head_template.eex
+++ b/lib/ex_doc/formatter/html/templates/head_template.eex
@@ -7,6 +7,9 @@
     <meta name="generator" content="ExDoc v<%= ExDoc.version %>">
     <title><%= page.title %> – <%= config.project %> v<%= config.version %></title>
     <link rel="stylesheet" href="<%= asset_rev config.output, "dist/app*.css" %>" />
+    <%= if config.canonical do %>
+      <link rel="canonical" href="<%= config.canonical %>" />
+    <% end %>
     <script src="dist/sidebar_items.js"></script>
   </head>
   <body data-type="<%= sidebar_type(page.type) %>">

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.Docs do
   @recursive true
 
   @moduledoc """
-  Uses ExDoc to generate a static web page from the pboject documentation.
+  Uses ExDoc to generate a static web page from the project documentation.
 
   ## Command line options
 
@@ -64,6 +64,9 @@ defmodule Mix.Tasks.Docs do
 
     * `:extra_section` - String that define the section title of the additional
       Markdown pages; default: "PAGES". Example: "GUIDES"
+
+    * `:canonical` - String that define the preferred URL with the rel="canonical"
+      element; default: nil
   """
 
   @doc false

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -223,6 +223,23 @@ defmodule ExDoc.Formatter.HTMLTest do
                  fn -> generate_docs(config) end
   end
 
+  test "run creates a preferred URL with link element when canonical options is specified" do
+    config = doc_config(extras: ["test/fixtures/README.md"], canonical: "http://elixir-lang.org/docs/stable/elixir/")
+    generate_docs(config)
+    content = File.read!("#{output_dir}/api-reference.html")
+    assert content =~ ~r{<link rel="canonical" href="http://elixir-lang.org/docs/stable/elixir/}
+
+    content = File.read!("#{output_dir}/readme.html")
+    assert content =~ ~r{<link rel="canonical" href="http://elixir-lang.org/docs/stable/elixir/}
+  end
+
+  test "run do not create a preferred URL with link element when canonical is nil" do
+    config = doc_config(canonical: nil)
+    generate_docs(config)
+    content = File.read!("#{output_dir}/api-reference.html")
+    refute content =~ ~r{<link rel="canonical" href="}
+  end
+
   test "Generate some assets" do
     output = doc_config[:output]
     ExDoc.Formatter.HTML.generate_assets([{"test/fixtures/elixir.png", "images"}], output)


### PR DESCRIPTION
Indicate the preferred URL with `rel="canonical"` link element, this is useful to avoid multiple versions in search results. Fixes #499