### PR TITLE
focus on content element on document ready

### DIFF
--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -156,6 +156,18 @@ function fixLinks () {
   CONTENT.find('a').has('img').addClass('no-underline')
 }
 
+/**
+ * Focus on the content element.
+ *
+ * This is required so that the space bar (and similar key bindings)
+ * work as soon as you visit a module's documentation. Without this,
+ * the user would be forced to first click on the content element
+ * before these keybindings worked.
+ */
+function fixSpacebar () {
+  CONTENT.attr('tabindex', -1).focus()
+}
+
 // Public Methods
 // --------------
 
@@ -165,4 +177,5 @@ export function initialize () {
   collapse()
   identifyCurrentHash()
   fixLinks()
+  fixSpacebar()
 }


### PR DESCRIPTION
This fixes an issue (#523) where hitting the space bar after loading a module's documentation doesn't work.

I set the tabindex through JS rather than changing the template because I felt like it would be clearer to a reader since the whole thing is in one place.