### PR TITLE
Remove unneeded enc_h

### DIFF
--- a/lib/ex_doc/formatter/html/templates/detail_template.eex
+++ b/lib/ex_doc/formatter/html/templates/detail_template.eex
@@ -1,4 +1,4 @@
-<div class="detail" id="<%=enc_h link_id(node) %>">
+<div class="detail" id="<%= link_id(node) %>">
   <div class="detail-header">
     <a href="#<%=enc_h link_id(node) %>" class="detail-link" title="Link to this <%= pretty_type(node) %>">
       <i class="icon-link"></i>

--- a/lib/ex_doc/formatter/html/templates/type_detail_template.eex
+++ b/lib/ex_doc/formatter/html/templates/type_detail_template.eex
@@ -1,4 +1,4 @@
-<div id="<%=enc_h link_id(node) %>" class="type-detail">
+<div id="<%= link_id(node) %>" class="type-detail">
   <pre><code class="elixir"><%= node.spec %></code></pre>
   <%= if node.doc do %>
     <div class="typespec-doc"><%= to_html(node.doc) %></div>


### PR DESCRIPTION
Should fix #509 

It appears that the id's should not be URI encoded and valid id's are any UTF-8 except for space characters:

http://stackoverflow.com/questions/70579/what-are-valid-values-for-the-id-attribute-in-html
> HTML 5 is even more permissive, saying only that an id must contain at least one character and may not contain any space characters.

http://stackoverflow.com/questions/10474972/named-anchor-a-with-name-same-as-a-div-id-conflict
> If this step was not skipped and there is an element in the DOM that has an ID exactly equal to decoded fragid, then the first such element in tree order is the indicated part of the document; stop the algorithm here.