### PR TITLE
Fixes #528, autolink regexp now allows digits in function names.

### DIFF
--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -202,7 +202,7 @@ defmodule ExDoc.Formatter.HTML.Autolink do
   will get translated to the new href of the function.
   """
   def local_doc(bin, locals) when is_binary(bin) do
-    ~r{(?<!\[)`\s*(([a-z_!\\?>\\|=&<!~+\\.\\+*^@-]+)/\d+)\s*`(?!\])}
+    ~r{(?<!\[)`\s*(([a-z\d_!\\?>\\|=&<!~+\\.\\+*^@-]+)/\d+)\s*`(?!\])}
     |> Regex.scan(bin)
     |> Enum.uniq()
     |> List.flatten()


### PR DESCRIPTION
Note that the regexp is updated in a way that theoretically allows digits at the front of a function name. In practice this will of course not happen because Elixir itself will reject variable/function names that start with numbers (which the regexp results are filtered against on line 209 in autolink.ex).

I've done it this way because I think the regexp will stay more readable like this. The same is also true for underscores and `?` and `!` by the way, that already were this way.


:smiley: 