### PR TITLE
Add xref exclude to `mix.exs` for `Cmark` and `Markdown`.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,8 @@ defmodule ExDoc.Mixfile do
      source_url: "https://github.com/elixir-lang/ex_doc/",
      test_coverage: [tool: ExCoveralls],
      preferred_cli_env: [coveralls: :test],
-     description: "ExDoc is a documentation generation tool for Elixir"]
+     description: "ExDoc is a documentation generation tool for Elixir",
+     xref: [exclude: [Cmark, Markdown]]]
   end
 
   def application do


### PR DESCRIPTION
On latest elixir master:

```
==> ex_doc
Compiling 12 files (.ex)
warning: function Cmark.to_html/1 is undefined (module Cmark is not available)
  lib/ex_doc/markdown/cmark.ex:18

warning: function Markdown.to_html/2 is undefined (module Markdown is not available)
  lib/ex_doc/markdown/hoedown.ex:29

Generated ex_doc app
```