### PR TITLE
Update general.less to better support nested list

### DIFF
--- a/assets/less/content/general.less
+++ b/assets/less/content/general.less
@@ -54,6 +54,10 @@ ul {
   li {
     line-height: 1.5em;
   }
+  
+  li > p {
+    margin: 0;
+  }
 }
 
 


### PR DESCRIPTION
The nested list are written like this:

```
- Installation
- Why?
- Description
    - QueryConfig
    - Serializer
        - DataTransform
        - AttributeTransform
- Examples
```

Problem is, for each "root" element which has a nested list, a `p` element is inserted. This makes the rendered list looks a bit weird. Note that the GitHub markdown renderer doesn’t insert extra `p` element on nested list.

**Before**:

![image](https://cloud.githubusercontent.com/assets/464900/15745201/8c981634-289e-11e6-8ab1-e19c4039a83f.png)

**After**:

![image](https://cloud.githubusercontent.com/assets/464900/15745206/95f4d884-289e-11e6-8d78-739868f824ee.png)

