### PR TITLE
Add support for optional behaviour callbacks

### DIFF
--- a/lib/ex_doc/formatter/html/templates/detail_template.eex
+++ b/lib/ex_doc/formatter/html/templates/detail_template.eex
@@ -9,6 +9,9 @@
        <i class="icon-code"></i>
      </a>
     <% end %>
+    <%= if Map.get(node, :annotations) && Map.get(node.annotations, :optional?) do %>
+      <span class="note">(optional)</span>
+    <% end %>
   </div>
   <%= if specs = get_specs(node) do %>
     <div class="specs">

--- a/lib/ex_doc/formatter/html/templates/summary_item_template.eex
+++ b/lib/ex_doc/formatter/html/templates/summary_item_template.eex
@@ -1,6 +1,9 @@
 <div class="summary-row">
   <div class="summary-signature">
     <a href="#<%=enc_h link_id(node) %>"><%=h node.signature %></a>
+    <%= if Map.get(node, :annotations) && Map.get(node.annotations, :optional?) do %>
+      <span class="note">(optional)</span>
+    <% end %>
   </div>
   <%= if node.doc do %>
     <div class="summary-synopsis"><%= to_html(synopsis(node.doc)) %></div>


### PR DESCRIPTION
This PR is supposed to add support for `@optional_callbacks`, that will be introduced in 1.3.0 (and close #541). I'm not sure what the process of rolling this out would look like: do we wait for when 1.3 will be released? I think this changes are harmless when `@optional_callbacks` is not supported.

Also, I really don't like this solution's implementation because:

1. we get to reimplement something very very similar to `Kernel.Typespec.beam_callbacks/1`: should we introduce `Kernel.Typespec.beam_optional_callbacks/1` in Elixir itself?
2. this solution displays optional callbacks in a separate section ("Optional callbacks") than regular callbacks, but ideally I think we should just mark callbacks as optional (e.g., with `(optional)` near the signature); sadly, I lack the design skills for that 😛 

You may be wondering why I opened this PR if I don't like it :), but I did just because the 1.3 release is very very close and I would love to see some kind of support (even if rudimentary) for optional callbacks in the docs for 1.3. Also, we can use this PR to get the conversation started on an implementation :)