### PR TITLE
Fix a `TypeError` at the first attempt to toggle sidebar

### DIFF
--- a/lib/ex_doc/formatter/html/templates/head_template.eex
+++ b/lib/ex_doc/formatter/html/templates/head_template.eex
@@ -12,4 +12,4 @@
     <% end %>
     <script src="dist/sidebar_items.js"></script>
   </head>
-  <body data-type="<%= sidebar_type(page.type) %>">
+  <body data-type="<%= sidebar_type(page.type) %>" class="">


### PR DESCRIPTION
When you click at the sidebar toggle the first time, `body` has no `class` attribute so `jQuery`'s `attr` returns `undefined`. Then a `TypeError`  (`Uncaught TypeError: Cannot read property 'includes' of undefined`) is raised [here](https://github.com/elixir-lang/ex_doc/blob/master/assets/js/sidebar.js#L54).