### PR TITLE
Fix flash of unstyled content

### DIFF
--- a/lib/ex_doc/formatter/html/templates/head_template.eex
+++ b/lib/ex_doc/formatter/html/templates/head_template.eex
@@ -13,4 +13,4 @@
     <script src="dist/sidebar_items.js"></script>
   </head>
   <body data-type="<%= sidebar_type(page.type) %>">
-    <script>if(localStorage.getItem('night-mode')) document.body.className += 'night-mode';</script>
+    <script>if(localStorage.getItem('night-mode')) document.body.className += ' night-mode';</script>

--- a/lib/ex_doc/formatter/html/templates/head_template.eex
+++ b/lib/ex_doc/formatter/html/templates/head_template.eex
@@ -13,3 +13,4 @@
     <script src="dist/sidebar_items.js"></script>
   </head>
   <body data-type="<%= sidebar_type(page.type) %>">
+    <script>if(localStorage.getItem('night-mode')) document.body.className += 'night-mode';</script>


### PR DESCRIPTION
When loading the page in night mode there is a small delay that causes the page to flash white while the javascript loads.  This is obviously more problematic the longer page is and as such affects documentation more than most.