### PR TITLE
Removing "crypto:rand_bytes/1" compiler warning

### DIFF
--- a/lib/ex_doc/markdown/pandoc.ex
+++ b/lib/ex_doc/markdown/pandoc.ex
@@ -28,7 +28,7 @@ defmodule ExDoc.Markdown.Pandoc do
   defp text_to_file(text) do
     id =
       4
-      |> :crypto.rand_bytes()
+      |> :crypto.strong_rand_bytes()
       |> Base.encode16()
     unique_name = "tmpdoc_#{id}.md"
     tmp_path = Path.join(System.tmp_dir, unique_name)


### PR DESCRIPTION
Changing deprecated crypto:rand_bytes/1 for crypto:strong_rand_bytes/1