### PR TITLE
Local Callbacks (#588)

### DIFF
--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -202,7 +202,7 @@ defmodule ExDoc.Formatter.HTML.Autolink do
   will get translated to the new href of the function.
   """
   def local_doc(bin, locals) when is_binary(bin) do
-    ~r{(?<!\[)`\s*(([a-z\d_!\\?>\\|=&<!~+\\.\\+*^@-]+)/\d+)\s*`(?!\])}
+    ~r{(?<!\[)`\s*(([ct]:)?([a-z\d_!\\?>\\|=&<!~+\\.\\+*^@-]+)/\d+)\s*`(?!\])}
     |> Regex.scan(bin)
     |> Enum.uniq()
     |> List.flatten()

--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -202,7 +202,7 @@ defmodule ExDoc.Formatter.HTML.Autolink do
   will get translated to the new href of the function.
   """
   def local_doc(bin, locals) when is_binary(bin) do
-    ~r{(?<!\[)`\s*(([ct]:)?([a-z\d_!\\?>\\|=&<!~+\\.\\+*^@-]+)/\d+)\s*`(?!\])}
+    ~r{(?<!\[)`\s*((c:)?([a-z\d_!\\?>\\|=&<!~+\\.\\+*^@-]+)/\d+)\s*`(?!\])}
     |> Regex.scan(bin)
     |> Enum.uniq()
     |> List.flatten()

--- a/test/ex_doc/formatter/html/autolink_test.exs
+++ b/test/ex_doc/formatter/html/autolink_test.exs
@@ -18,6 +18,12 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
       "[`funny_name\?/1`](#funny_name\?/1) and [`funny_name!/2`](#funny_name!/2)"
   end
 
+  test "autolink to local callbacks" do
+    # `split_function` must also return locally defined callbacks
+    # format should be: "c:<fun>/<arity>"
+    assert Autolink.local_doc("`c:fun/2`", ["c:fun/2"]) == "[`fun/2`](#c:fun/2)"
+  end
+
   test "autolink doesn't create links for undefined functions in docs" do
     assert Autolink.local_doc("`example/1`", ["example/2"]) == "`example/1`"
     assert Autolink.local_doc("`example/1`", []) == "`example/1`"


### PR DESCRIPTION
This is a pull request for #588. The missing piece was the optional callback header `c:` was missing in the regular expression digesting the code pieces. 