### PR TITLE
Autolinking to types

### DIFF
--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -302,10 +302,7 @@ defmodule ExDoc.Formatter.HTML.Autolink do
 
 
   defp split_function(bin) do
-    [modules, arity] = case String.split(bin, "/") do
-      [m, a] -> [m, a]
-      [m]    -> [m, ""]
-    end
+    [modules, arity] = String.split(bin, "/")
     {mod, name} =
       modules
       |> String.replace(~r{([^\.])\.}, "\\1 ") # this handles the case of the ".." function

--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -203,22 +203,17 @@ defmodule ExDoc.Formatter.HTML.Autolink do
   will get translated to the new href of the function.
   """
   def local_doc(bin, locals) when is_binary(bin) do
-    fun_re = ~r{((c:)?([a-z\d_!\\?>\\|=&<!~+\\.\\+*^@-]+)/\d+)} |> Regex.source
-    type_re = ~r{(t:([a-z\d_!\\?]+))} |> Regex.source
-    ~r{(?<!\[)`\s*(#{fun_re}|#{type_re})\s*`(?!\])}
+    fun_re = ~r{(([ct]:)?([a-z\d_!\\?>\\|=&<!~+\\.\\+*^@-]+)/\d+)} |> Regex.source
+    ~r{(?<!\[)`\s*(#{fun_re})\s*`(?!\])}
     |> Regex.scan(bin)
     |> Enum.uniq()
     |> List.flatten()
     |> Enum.filter(&(&1 in locals))
     |> Enum.reduce(bin, fn (x, acc) ->
          {prefix, _, function_name, arity} = split_function(x)
-         arity = case arity do
-           "" -> ""  # no arity: x is a type
-           a -> "/" <> a
-         end
-         escaped = Regex.escape(x)
+           escaped = Regex.escape(x)
          Regex.replace(~r/(?<!\[)`(\s*#{escaped}\s*)`(?!\])/, acc,
-           "[`#{function_name}#{arity}`](##{prefix}#{enc_h function_name}#{arity})")
+           "[`#{function_name}/#{arity}`](##{prefix}#{enc_h function_name}/#{arity})")
        end)
   end
 
@@ -254,22 +249,17 @@ defmodule ExDoc.Formatter.HTML.Autolink do
   """
   def project_functions(bin, project_funs) when is_binary(bin) do
     module_re = ~r{(([A-Z][A-Za-z_\d]+)\.)+} |> Regex.source
-    fun_re = ~r{(c:)?(#{module_re}([a-z\d_!\\?>\\|=&<!~+\\.\\+*^@-]+)/\d+)} |> Regex.source
-    type_re = ~r{(t:#{module_re}([a-z\d_!\\?]+))} |> Regex.source
-    ~r{(?<!\[)`\s*(#{fun_re}|#{type_re})\s*`(?!\])}
+    fun_re = ~r{([ct]:)?(#{module_re}([a-z\d_!\\?>\\|=&<!~+\\.\\+*^@-]+)/\d+)} |> Regex.source
+    ~r{(?<!\[)`\s*(#{fun_re})\s*`(?!\])}
     |> Regex.scan(bin)
     |> Enum.uniq()
     |> List.flatten()
     |> Enum.filter(&(&1 in project_funs))
     |> Enum.reduce(bin, fn (x, acc) ->
          {prefix, mod_str, function_name, arity} = split_function(x)
-         arity = case arity do
-           "" -> "" # no arity: x is a type
-           a -> "/" <> a
-         end
          escaped = Regex.escape(x)
          Regex.replace(~r/(?<!\[)`(\s*#{escaped}\s*)`(?!\])/, acc,
-           "[`#{mod_str}.#{function_name}#{arity}`](#{mod_str}.html##{prefix}#{enc_h function_name}#{arity})")
+           "[`#{mod_str}.#{function_name}/#{arity}`](#{mod_str}.html##{prefix}#{enc_h function_name}/#{arity})")
        end)
   end
 

--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -273,7 +273,7 @@ defmodule ExDoc.Formatter.HTML.Autolink do
   will get translated to the new href of the module.
   """
   def project_modules(bin, modules, module_id \\ nil) when is_binary(bin) do
-    ~r{(?<!\[)`\s*(([A-Z][A-Za-z]+\.?)+)\s*`(?!\])}
+    ~r{(?<!\[)`\s*(([A-Z][A-Za-z_\d]+\.?)+)\s*`(?!\])}
     |> Regex.scan(bin)
     |> Enum.uniq()
     |> List.flatten()

--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -202,16 +202,22 @@ defmodule ExDoc.Formatter.HTML.Autolink do
   will get translated to the new href of the function.
   """
   def local_doc(bin, locals) when is_binary(bin) do
-    ~r{(?<!\[)`\s*((c:)?([a-z\d_!\\?>\\|=&<!~+\\.\\+*^@-]+)/\d+)\s*`(?!\])}
+    fun_re = ~r{((c:)?([a-z\d_!\\?>\\|=&<!~+\\.\\+*^@-]+)/\d+)} |> Regex.source
+    type_re = ~r{(t:([a-z\d_!\\?]+))} |> Regex.source
+    ~r{(?<!\[)`\s*(#{fun_re}|#{type_re})\s*`(?!\])}
     |> Regex.scan(bin)
     |> Enum.uniq()
     |> List.flatten()
     |> Enum.filter(&(&1 in locals))
     |> Enum.reduce(bin, fn (x, acc) ->
          {prefix, _, function_name, arity} = split_function(x)
+         arity = case arity do
+           "" -> ""
+           a -> "/" <> a
+         end
          escaped = Regex.escape(x)
          Regex.replace(~r/(?<!\[)`(\s*#{escaped}\s*)`(?!\])/, acc,
-           "[`#{function_name}/#{arity}`](##{prefix}#{enc_h function_name}/#{arity})")
+           "[`#{function_name}#{arity}`](##{prefix}#{enc_h function_name}#{arity})")
        end)
   end
 

--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -28,7 +28,8 @@ defmodule ExDoc.Formatter.HTML.Autolink do
   end
 
   defp all_docs(module, modules) do
-    locals = Enum.map module.docs, &(doc_prefix(&1) <> &1.id)
+    locals = Enum.map(module.docs, &(doc_prefix(&1) <> &1.id)) ++
+      Enum.map(module.typespecs, &("t:" <> &1.id))
 
     moduledoc =
       if module.moduledoc do
@@ -226,6 +227,9 @@ defmodule ExDoc.Formatter.HTML.Autolink do
   """
   def project_doc(bin, modules, module_id \\ nil) when is_binary(bin) do
     project_funs = for m <- modules, d <- m.docs, do: doc_prefix(d) <> m.id <> "." <> d.id
+    project_types = for m <- modules, d <- m.typespecs, do: doc_prefix(d) <> m.id <> "." <> d.id
+    project_funs = project_funs ++ project_types
+
     project_modules =
       modules
       |> Enum.map(&module_to_string/1)

--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -211,7 +211,7 @@ defmodule ExDoc.Formatter.HTML.Autolink do
     |> Enum.filter(&(&1 in locals))
     |> Enum.reduce(bin, fn (x, acc) ->
          {prefix, _, function_name, arity} = split_function(x)
-           escaped = Regex.escape(x)
+         escaped = Regex.escape(x)
          Regex.replace(~r/(?<!\[)`(\s*#{escaped}\s*)`(?!\])/, acc,
            "[`#{function_name}/#{arity}`](##{prefix}#{enc_h function_name}/#{arity})")
        end)

--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -212,7 +212,7 @@ defmodule ExDoc.Formatter.HTML.Autolink do
     |> Enum.reduce(bin, fn (x, acc) ->
          {prefix, _, function_name, arity} = split_function(x)
          arity = case arity do
-           "" -> ""
+           "" -> ""  # no arity: x is a type
            a -> "/" <> a
          end
          escaped = Regex.escape(x)

--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -288,9 +288,17 @@ defmodule ExDoc.Formatter.HTML.Autolink do
     {"", mod, fun, arity} = split_function(bin)
     {"c:", mod, fun, arity}
   end
+  defp split_function("t:" <> bin) do
+    {"", mod, fun, arity} = split_function(bin)
+    {"t:", mod, fun, arity}
+  end
+
 
   defp split_function(bin) do
-    [modules, arity] = String.split(bin, "/")
+    [modules, arity] = case String.split(bin, "/") do
+      [m, a] -> [m, a]
+      [m]    -> [m, ""]
+    end
     {mod, name} =
       modules
       |> String.replace(~r{([^\.])\.}, "\\1 ") # this handles the case of the ".." function

--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -222,7 +222,7 @@ defmodule ExDoc.Formatter.HTML.Autolink do
   """
   def project_doc(bin, modules, module_id \\ nil) when is_binary(bin) do
     project_funs = for m <- modules, d <- m.docs, do: doc_prefix(d) <> m.id <> "." <> d.id
-    project_types = for m <- modules, d <- m.typespecs, do: doc_prefix(d) <> m.id <> "." <> d.id
+    project_types = for m <- modules, d <- m.typespecs, do: "t:" <> m.id <> "." <> d.id
     project_funs = project_funs ++ project_types
 
     project_modules =

--- a/test/ex_doc/formatter/html/autolink_test.exs
+++ b/test/ex_doc/formatter/html/autolink_test.exs
@@ -24,6 +24,10 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
     assert Autolink.local_doc("`c:fun/2`", ["c:fun/2"]) == "[`fun/2`](#c:fun/2)"
   end
 
+  test "autolink to local types" do
+    assert Autolink.local_doc("`t:my_type`", ["t:my_type"]) == "[`my_type`](#t:my_type)"
+  end
+
   test "autolink doesn't create links for undefined functions in docs" do
     assert Autolink.local_doc("`example/1`", ["example/2"]) == "`example/1`"
     assert Autolink.local_doc("`example/1`", []) == "`example/1`"

--- a/test/ex_doc/formatter/html/autolink_test.exs
+++ b/test/ex_doc/formatter/html/autolink_test.exs
@@ -25,7 +25,10 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
   end
 
   test "autolink to local types" do
-    assert Autolink.local_doc("`t:my_type`", ["t:my_type"]) == "[`my_type`](#t:my_type)"
+    assert Autolink.local_doc("`t:my_type/0`", ["t:my_type/0"]) == "[`my_type/0`](#t:my_type/0)"
+    assert Autolink.local_doc("`t:my_type/1`", ["t:my_type/1"]) == "[`my_type/1`](#t:my_type/1)"
+    # links to types without arity don't work
+    assert Autolink.local_doc("`t:my_type`", ["t:my_type/0"]) == "`t:my_type`"
   end
 
   test "autolink doesn't create links for undefined functions in docs" do
@@ -115,8 +118,10 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
 
   test "autolink to types in the project" do
     # use the same approach for project_functions as for local_docs
-    assert Autolink.project_functions("`t:MyModule.my_type`",
-      ["t:MyModule.my_type"]) ==  "[`MyModule.my_type`](MyModule.html#t:my_type)"
+    assert Autolink.project_functions("`t:MyModule.my_type/0`",
+      ["t:MyModule.my_type/0"]) ==  "[`MyModule.my_type/0`](MyModule.html#t:my_type/0)"
+      assert Autolink.project_functions("`t:MyModule.my_type`",
+        ["t:MyModule.my_type/0"]) ==  "`t:MyModule.my_type`"
   end
 
   # erlang functions

--- a/test/ex_doc/formatter/html/autolink_test.exs
+++ b/test/ex_doc/formatter/html/autolink_test.exs
@@ -113,6 +113,12 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
     assert Autolink.project_modules("`MyModule.Nested`", ["MyModule.DiffNested"]) == "`MyModule.Nested`"
   end
 
+  test "autolink to types in the project" do
+    # use the same approach for project_functions as for local_docs
+    assert Autolink.project_functions("`t:MyModule.my_type`",
+      ["t:MyModule.my_type"]) ==  "[`MyModule.my_type`](MyModule.html#t:my_type)"
+  end
+
   # erlang functions
 
   @erlang_docs "http://www.erlang.org/doc/man/"


### PR DESCRIPTION
Evaluating the `t:` prefix to a type with function syntax. The implementation took a little detour, because it took a while to realize that links to types without arity shall not work. Essentially, this make the code easier. 

I added also a better matching Module regex, since numbers and underscores are valid characters in module names. 