### PR TITLE
Stop escaping linked h2s

### DIFF
--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -147,7 +147,7 @@ defmodule ExDoc.Formatter.HTML do
       output_file_name = "#{options.output_file_name}.html"
       config = set_canonical_url(config, output_file_name)
       html = Templates.extra_template(config, title, modules,
-                                      exceptions, protocols, link_headers(content))
+                                      exceptions, protocols, content)
 
       output = "#{options.output}/#{output_file_name}"
 
@@ -193,10 +193,6 @@ defmodule ExDoc.Formatter.HTML do
     |> Regex.scan(content, capture: :all_but_first)
     |> List.flatten()
     |> Enum.map(&{&1, Templates.header_to_id(&1)})
-  end
-
-  defp link_headers(content) do
-    Templates.link_headings(content, @h2_regex)
   end
 
   defp input_to_title(input) do

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -178,10 +178,10 @@ defmodule ExDoc.Formatter.HTML.Templates do
   @spec header_to_id(String.t) :: String.t
   def header_to_id(header) do
     header
+    |> String.replace(~r/<.+>/, "")
     |> String.replace(~r/\W+/u, "-")
     |> String.strip(?-)
     |> String.downcase()
-    |> h()
   end
 
   @doc """
@@ -200,7 +200,7 @@ defmodule ExDoc.Formatter.HTML.Templates do
     """
     <h2 id="#{prefix}#{id}" class="section-heading">
       <a href="##{prefix}#{id}" class="hover-link"><i class="icon-link"></i></a>
-      #{h(title)}
+      #{title}
     </h2>
     """
   end

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -179,6 +179,8 @@ defmodule ExDoc.Formatter.HTML.Templates do
   def header_to_id(header) do
     header
     |> String.replace(~r/<.+>/, "")
+    |> String.replace(~r/&#\d+;/, "")
+    |> String.replace(~r/&[A-Za-z0-9]+;/, "")
     |> String.replace(~r/\W+/u, "-")
     |> String.strip(?-)
     |> String.downcase()

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -190,8 +190,10 @@ defmodule ExDoc.Formatter.HTML.Templates do
   Link secondary headings found with `regex` with in the given `content`.
   IDs are prefixed with `prefix`.
   """
+  @h2_regex ~r/<h2.*?>(.+)<\/h2>/m
+
   @spec link_headings(String.t, Regex.t, String.t) :: String.t
-  def link_headings(content, regex, prefix \\ "") do
+  def link_headings(content, regex \\ @h2_regex, prefix \\ "") do
     Regex.replace(regex, content, fn match, title ->
       link_heading(match, title, header_to_id(title), prefix)
     end)
@@ -207,7 +209,6 @@ defmodule ExDoc.Formatter.HTML.Templates do
     """
   end
 
-  @h2_regex ~r/<h2.*?>(.+)<\/h2>/m
   defp link_moduledoc_headings(content) do
     link_headings(content, @h2_regex, "module-")
   end

--- a/lib/ex_doc/formatter/html/templates/extra_template.eex
+++ b/lib/ex_doc/formatter/html/templates/extra_template.eex
@@ -1,5 +1,5 @@
 <%= head_template(config, %{title: title, type: :extra}) %>
 <%= sidebar_template(config, modules, exceptions, protocols) %>
 
-<%= to_html(content) %>
+<%= content |> to_html() |> link_headings() %>
 <%= footer_template(config) %>

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -127,6 +127,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
     assert Templates.header_to_id("José") == "josé"
     assert Templates.header_to_id(" a - b ") == "a-b"
     assert Templates.header_to_id(" ☃ ") == ""
+    assert Templates.header_to_id("Git Options (<code class=\"inline\">:git</code>)") == "git-options"
   end
 
   test "module_page outputs the types and function specs" do

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -111,7 +111,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
     assert content =~ ~r{<h1>\n\s*<small class="visible-xs">Elixir v1.0.1</small>\n\s*CompiledWithDocs\s*}
     refute content =~ ~r{<small>module</small>}
     assert content =~ ~r{moduledoc.*Example.*CompiledWithDocs\.example.*}ms
-    assert content =~ ~r{<h2 id="module-example-unicode" class="section-heading">.*<a href="#module-example-unicode" class="hover-link">.*<i class="icon-link"></i>.*</a>.*Example.*</h2>}ms
+    assert content =~ ~r{<h2 id="module-example-unicode-escaping" class="section-heading">.*<a href="#module-example-unicode-escaping" class="hover-link">.*<i class="icon-link"></i>.*</a>.*Example.*</h2>}ms
     assert content =~ ~r{example/2.*Some example}ms
     assert content =~ ~r{example_without_docs/0.*<section class="docstring">.*</section>}ms
     assert content =~ ~r{example_1/0.*Another example}ms
@@ -127,6 +127,8 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
     assert Templates.header_to_id("José") == "josé"
     assert Templates.header_to_id(" a - b ") == "a-b"
     assert Templates.header_to_id(" ☃ ") == ""
+    assert Templates.header_to_id(" &sup2; ") == ""
+    assert Templates.header_to_id(" &#9180; ") == ""
     assert Templates.header_to_id("Git Options (<code class=\"inline\">:git</code>)") == "git-options"
   end
 

--- a/test/ex_doc/retriever_test.exs
+++ b/test/ex_doc/retriever_test.exs
@@ -30,7 +30,7 @@ defmodule ExDoc.RetrieverTest do
 
   test "docs_from_files returns the moduledoc info" do
     [node] = docs_from_files ["CompiledWithDocs"]
-    assert node.moduledoc == "moduledoc\n\n\#\# Example ☃ Unicode\n    CompiledWithDocs.example\n"
+    assert node.moduledoc == "moduledoc\n\n\#\# Example ☃ Unicode > escaping\n    CompiledWithDocs.example\n"
   end
 
   test "docs_from_files returns nil if there's no moduledoc info" do

--- a/test/fixtures/compiled_with_docs.ex
+++ b/test/fixtures/compiled_with_docs.ex
@@ -2,7 +2,7 @@ defmodule CompiledWithDocs do
   @moduledoc """
   moduledoc
 
-  ## Example ☃ Unicode
+  ## Example ☃ Unicode > escaping
       CompiledWithDocs.example
   """
 


### PR DESCRIPTION
Ensure that moduledocs and extra pages use the markdown HTML entity escaping.

Remove HTML entities from header IDs.

Fixes #587 