### PR TITLE
Allow horizontal scroll for code snippets on mobile devices

### DIFF
--- a/assets/less/content/code.less
+++ b/assets/less/content/code.less
@@ -32,6 +32,7 @@ code {
 
 pre {
   margin: @baseLineHeight 0;
+  overflow-x: scroll;
 
   &.spec {
       margin: 0;


### PR DESCRIPTION
This change allow mobile devices in portrait to scroll snippets horizontally