### PR TITLE
Define new types

### DIFF
--- a/lib/ex_doc.ex
+++ b/lib/ex_doc.ex
@@ -28,6 +28,26 @@ defmodule ExDoc do
       title: nil,
       version: nil
     ]
+
+     @type t :: %__MODULE__{
+       canonical: nil | String.t,
+       extra_section: nil | String.t,
+       extras: list(),
+       formatter: String.t,
+       formatter_opts: list(),
+       homepage_url: nil | String.t,
+       logo: nil | Path.t,
+       main: nil | String.t,
+       output: Path.t,
+       project: nil | String.t,
+       retriever: :atom,
+       source_beam: nil | String.t,
+       source_root: nil | String.t,
+       source_url: nil | String.t,
+       source_url_pattern: nil | String.t,
+       title: nil | String.t,
+       version: nil | String.t
+     }
   end
 
   @ex_doc_version Mix.Project.config[:version]
@@ -50,7 +70,7 @@ defmodule ExDoc do
   end
 
   # Builds configuration by merging `options`, and normalizing the options.
-  @spec build_config(String.t, String.t, Keyword.t) :: %ExDoc.Config{}
+  @spec build_config(String.t, String.t, Keyword.t) :: ExDoc.Config.t
   defp build_config(project, version, options) do
     options = normalize_options(options)
     preconfig = %Config{

--- a/lib/ex_doc/formatter/epub.ex
+++ b/lib/ex_doc/formatter/epub.ex
@@ -9,7 +9,7 @@ defmodule ExDoc.Formatter.EPUB do
   @doc """
   Generate EPUB documentation for the given modules
   """
-  @spec run(list, %ExDoc.Config{}) :: String.t
+  @spec run(list, ExDoc.Config.t) :: String.t
   def run(module_nodes, config) when is_map(config) do
     output = Path.expand(config.output)
     File.rm_rf!(output)

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -11,7 +11,7 @@ defmodule ExDoc.Formatter.HTML do
   @doc """
   Generate HTML documentation for the given modules
   """
-  @spec run(list, %ExDoc.Config{}) :: String.t
+  @spec run(list, ExDoc.Config.t) :: String.t
   def run(module_nodes, config) when is_map(config) do
     config = normalize_config(config)
     output = Path.expand(config.output)

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -5,6 +5,16 @@ defmodule ExDoc.ModuleNode do
 
   defstruct id: nil, module: nil, moduledoc: nil,
     docs: [], typespecs: [], source: nil, type: nil
+
+  @type t :: %__MODULE__{
+    id: nil | String.t,
+    module: nil | String.t,
+    moduledoc: nil | String.t,
+    docs: list(),
+    typespecs: list(),
+    source: nil | String.t,
+    type: nil | String.t
+  }
 end
 
 defmodule ExDoc.FunctionNode do
@@ -15,6 +25,18 @@ defmodule ExDoc.FunctionNode do
   defstruct id: nil, name: nil, arity: 0, doc: [],
     source: nil, type: nil, signature: nil, specs: [],
     annotations: []
+
+  @type t :: %__MODULE__{
+    id: nil | String.t,
+    name: nil | String.t,
+    arity: non_neg_integer,
+    doc: list(),
+    source: nil | String.t,
+    type: nil | String.t,
+    signature: nil | String.t,
+    specs: list(),
+    annotations: list()
+  }
 end
 
 defmodule ExDoc.TypeNode do
@@ -24,6 +46,16 @@ defmodule ExDoc.TypeNode do
 
   defstruct id: nil, name: nil, arity: 0, type: nil,
     spec: nil, doc: nil, signature: nil
+
+  @type t :: %__MODULE__{
+    id: nil | String.t,
+    name: nil | String.t,
+    arity: non_neg_integer,
+    type: nil | String.t,
+    spec: nil | String.t,
+    doc: nil | String.t,
+    signature: nil | String.t
+  }
 end
 
 defmodule ExDoc.Retriever.Error do
@@ -44,7 +76,7 @@ defmodule ExDoc.Retriever do
   @doc """
   Extract documentation from all modules in the specified directory
   """
-  @spec docs_from_dir(Path.t, %ExDoc.Config{}) :: [%ExDoc.ModuleNode{}]
+  @spec docs_from_dir(Path.t, ExDoc.Config.t) :: [ExDoc.ModuleNode.t]
   def docs_from_dir(dir, config) when is_binary(dir) do
     files = Path.wildcard Path.expand("Elixir.*.beam", dir)
     docs_from_files(files, config)
@@ -53,7 +85,7 @@ defmodule ExDoc.Retriever do
   @doc """
   Extract documentation from all modules in the specified list of files
   """
-  @spec docs_from_files([Path.t], %ExDoc.Config{}) :: [%ExDoc.ModuleNode{}]
+  @spec docs_from_files([Path.t], ExDoc.Config.t) :: [ExDoc.ModuleNode.t]
   def docs_from_files(files, config) when is_list(files) do
     files
     |> Enum.map(&filename_to_module(&1))
@@ -63,7 +95,7 @@ defmodule ExDoc.Retriever do
   @doc """
   Extract documentation from all modules in the list `modules`
   """
-  @spec docs_from_modules([atom], %ExDoc.Config{}) :: [%ExDoc.ModuleNode{}]
+  @spec docs_from_modules([atom], ExDoc.Config.t) :: [ExDoc.ModuleNode.t]
   def docs_from_modules(modules, config) when is_list(modules) do
     modules
     |> Enum.map(&get_module(&1, config))


### PR DESCRIPTION
The idea behind this PR is to use `ExDoc.Config.t` instead of `%ExDoc.Config{}` when we're referring to that struct. The same behavior for `ExDoc.{Module,Function,Type}Node.t`. wdyt?