### PR TITLE
Do not highlight function or type name left of ::

### DIFF
--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -90,9 +90,9 @@ defmodule ExDoc.Formatter.HTML.Autolink do
 
   def typespec({:when, _, [{:::, _, [left, {:|, _, _} = center]}, right]} = ast, typespecs, aliases, lib_dirs) do
     if short_typespec?(ast) do
-      typespec_to_string(ast, typespecs, aliases, lib_dirs)
+      normalize_left(ast, typespecs, aliases, lib_dirs)
     else
-      typespec_to_string(left, typespecs, aliases, lib_dirs) <>
+      normalize_left(left, typespecs, aliases, lib_dirs) <>
       " ::\n  " <> typespec_with_new_line(center, typespecs, aliases, lib_dirs) <>
       " when " <> String.slice(typespec_to_string(right, typespecs, aliases, lib_dirs), 1..-2)
     end
@@ -100,15 +100,15 @@ defmodule ExDoc.Formatter.HTML.Autolink do
 
   def typespec({:::, _, [left, {:|, _, _} = center]} = ast, typespecs, aliases, lib_dirs) do
     if short_typespec?(ast) do
-      typespec_to_string(ast, typespecs, aliases, lib_dirs)
+      normalize_left(ast, typespecs, aliases, lib_dirs)
     else
-      typespec_to_string(left, typespecs, aliases, lib_dirs) <>
+      normalize_left(left, typespecs, aliases, lib_dirs) <>
       " ::\n  " <> typespec_with_new_line(center, typespecs, aliases, lib_dirs)
     end
   end
 
   def typespec(other, typespecs, aliases, lib_dirs) do
-    typespec_to_string(other, typespecs, aliases, lib_dirs)
+    normalize_left(other, typespecs, aliases, lib_dirs)
   end
 
   defp typespec_with_new_line({:|, _, [left, right]}, typespecs, aliases, lib_dirs) do
@@ -120,6 +120,22 @@ defmodule ExDoc.Formatter.HTML.Autolink do
     typespec_to_string(other, typespecs, aliases, lib_dirs)
   end
 
+  defp normalize_left({:::, _, [{name, _, args}, right]}, typespecs, aliases, lib_dirs) do
+    placeholder = {:::, [], [{:_, [], args}, right]}
+    "_" <> rest = typespec_to_string(placeholder, typespecs, aliases, lib_dirs)
+    Atom.to_string(name) <> rest
+  end
+
+  defp normalize_left({:when, _, [{:::, _, [{name, _, args}, center]}, right]}, typespecs, aliases, lib_dirs) do
+    placeholder = {:when, [], [{:::, [], [{:_, [], args}, center]}, right]}
+    "_" <> rest = typespec_to_string(placeholder, typespecs, aliases, lib_dirs)
+    Atom.to_string(name) <> rest
+  end
+
+  defp normalize_left(ast, typespecs, aliases, lib_dirs) do
+    typespec_to_string(ast, typespecs, aliases, lib_dirs)
+  end
+
   defp typespec_to_string(ast, typespecs, aliases, lib_dirs) do
     Macro.to_string(ast, fn
       {name, _, args}, string when is_atom(name) and is_list(args) ->
@@ -129,7 +145,7 @@ defmodule ExDoc.Formatter.HTML.Autolink do
           n = enc_h("#{name}")
           ~s[<a href="#t:#{n}/#{arity}">#{h(string)}</a>]
         else
-         string
+          string
         end
       {{ :., _, [alias, name] }, _, args}, string when is_atom(name) and is_list(args) ->
         string = strip_parens(string, args)

--- a/test/ex_doc/formatter/epub/templates_test.exs
+++ b/test/ex_doc/formatter/epub/templates_test.exs
@@ -61,13 +61,12 @@ defmodule ExDoc.Formatter.EPUB.TemplatesTest do
     mb = "http://elixir-lang.org/docs/stable"
 
     public_html =
-      ~S[<a href="#t:public/1">public(t)</a> :: {t, ] <>
+      ~S[public(t) :: {t, ] <>
       ~s[<a href="#{mb}/elixir/String.html#t:t/0">String.t</a>, ] <>
       ~S[<a href="TypesAndSpecs.Sub.html#t:t/0">TypesAndSpecs.Sub.t</a>, ] <>
       ~S[<a href="#t:opaque/0">opaque</a>, :ok | :error}]
 
-    ref_html = ~S[<a href="#t:ref/0">ref</a> :: ] <>
-               ~S[{:binary.part, <a href="#t:public/1">public(any)</a>}]
+    ref_html = ~S[ref :: {:binary.part, <a href="#t:public/1">public(any)</a>}]
 
     assert content =~ ~s[<a href="#t:public/1">public(t)</a>]
     refute content =~ ~s[<a href="#t:private/0">private</a>]

--- a/test/ex_doc/formatter/html/autolink_test.exs
+++ b/test/ex_doc/formatter/html/autolink_test.exs
@@ -191,8 +191,31 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
     assert Autolink.typespec(quote(do: bar(foo(1))), [foo: 1], []) ==
            ~s[bar(<a href="#t:foo/1">foo(1)</a>)]
 
+    assert Autolink.typespec(quote(do: (bar(foo(1)) when bat: foo(1))), [foo: 1], []) ==
+           ~s[bar(<a href="#t:foo/1">foo(1)</a>) when bat: <a href=\"#t:foo/1\">foo(1)</a>]
+
     assert Autolink.typespec(quote(do: bar(foo(1))), [], []) ==
            ~s[bar(foo(1))]
+  end
+
+  test "autolink same type and function name" do
+    assert Autolink.typespec(quote(do: foo() :: foo()), [foo: 0], [], []) ==
+           ~s[foo :: <a href="#t:foo/0">foo</a>]
+
+    assert Autolink.typespec(quote(do: foo(1) :: foo(1)), [foo: 1], [], []) ==
+           ~s[foo(1) :: <a href="#t:foo/1">foo(1)</a>]
+
+    assert Autolink.typespec(quote(do: (foo(1) :: foo(1) when bat: foo(1))), [foo: 1], [], []) ==
+           ~s[foo(1) :: <a href=\"#t:foo/1\">foo(1)</a> when bat: <a href=\"#t:foo/1\">foo(1)</a>]
+
+    assert Autolink.typespec(quote(do: bar(foo(1)) :: foo(1)), [foo: 1], [], []) ==
+           ~s[bar(<a href=\"#t:foo/1\">foo(1)</a>) :: <a href=\"#t:foo/1\">foo(1)</a>]
+
+    assert Autolink.typespec(quote(do: (bar(foo(1)) :: foo(1) when bat: foo(1))), [foo: 1], [], []) ==
+           ~s[bar(<a href=\"#t:foo/1\">foo(1)</a>) :: <a href=\"#t:foo/1\">foo(1)</a> when bat: <a href=\"#t:foo/1\">foo(1)</a>]
+
+    assert Autolink.typespec(quote(do: bar(foo :: foo(1)) :: foo(1)), [foo: 1], [], []) ==
+           ~s[bar(foo :: <a href=\"#t:foo/1\">foo(1)</a>) :: <a href=\"#t:foo/1\">foo(1)</a>]
   end
 
   test "add new lines on |" do

--- a/test/ex_doc/formatter/html/autolink_test.exs
+++ b/test/ex_doc/formatter/html/autolink_test.exs
@@ -180,6 +180,14 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
 
   # typespec
 
+  test "operators" do
+    assert Autolink.typespec(quote(do: +number :: number), [], [], []) ==
+           ~s[+number :: number]
+
+    assert Autolink.typespec(quote(do: number + number :: number), [], [], []) ==
+           ~s[number + number :: number]
+  end
+
   test "strip parens in typespecs" do
     assert Autolink.typespec(quote(do: foo({}, bar())), [], []) == ~s[foo({}, bar)]
   end

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -145,13 +145,12 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
     mb = "http://elixir-lang.org/docs/stable"
 
     public_html =
-      ~S[<a href="#t:public/1">public(t)</a> :: {t, ] <>
+      ~S[public(t) :: {t, ] <>
       ~s[<a href="#{mb}/elixir/String.html#t:t/0">String.t</a>, ] <>
       ~S[<a href="TypesAndSpecs.Sub.html#t:t/0">TypesAndSpecs.Sub.t</a>, ] <>
       ~S[<a href="#t:opaque/0">opaque</a>, :ok | :error}]
 
-    ref_html = ~S[<a href="#t:ref/0">ref</a> :: ] <>
-               ~S[{:binary.part, <a href="#t:public/1">public(any)</a>}]
+    ref_html = ~S[ref :: {:binary.part, <a href="#t:public/1">public(any)</a>}]
 
     assert content =~ ~s[<a href="#t:public/1">public(t)</a>]
     refute content =~ ~s[<a href="#t:private/0">private</a>]


### PR DESCRIPTION
Fixes #607

Before:
![master1](https://cloud.githubusercontent.com/assets/76071/19622557/c9ae73fa-98ac-11e6-9fe0-feec96ea60a7.png)
![master2](https://cloud.githubusercontent.com/assets/76071/19622556/c990cb5c-98ac-11e6-81bd-0bdeefbd5f6c.png)

After:
![fix1](https://cloud.githubusercontent.com/assets/76071/19622560/cfb9116a-98ac-11e6-9941-7c291cd014e4.png)
![fix2](https://cloud.githubusercontent.com/assets/76071/19622561/cfd7c100-98ac-11e6-8775-227e049b53d1.png)

Not sure if the change to types (dropping highlight on type name on left) is desired, but a) the link jumps to the same exact place, b) it seems more consistent as this is how functions are highlighted and c) implementation-wise it was easier to do. It's def. possible to scope this change to just functions though.

Btw, here're the changes this PR would have made on Elixir 1.3.4 docs: https://gist.github.com/wojtekmach/601771cbedac5a47d63c1c47d21d47e5

