### PR TITLE
Fix autolinking to opaque type

### DIFF
--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -71,6 +71,7 @@ defmodule ExDoc.Formatter.HTML.Templates do
       :macrocallback -> "c:#{id}"
       :callback      -> "c:#{id}"
       :type          -> "t:#{id}"
+      :opaque        -> "t:#{id}"
       _              -> "#{id}"
     end
   end


### PR DESCRIPTION
Noticed that opaque types aren't correctly auto-linked. See e.g.: `t` here: http://elixir-lang.org/docs/master/elixir/MapSet.html#delete/2