### PR TITLE
In case function has no docs, use the ones from callback

### DIFF
--- a/test/ex_doc/retriever_test.exs
+++ b/test/ex_doc/retriever_test.exs
@@ -196,6 +196,10 @@ defmodule ExDoc.RetrieverTest do
       "A doc for this so it doesn't use 'Callback implementation for'"
     assert Enum.at(docs, 1).doc ==
       "Callback implementation for `c:CustomBehaviourOne.greet/1`."
+    assert Enum.at(docs, 2).doc ==
+      "This is a sample callback.\n\n" <>
+      "Documentation for callback `c:CustomBehaviourOne.hello/1`.\n\n" <>
+      "With description\n"
   end
 
   ## PROTOCOLS

--- a/test/fixtures/behaviour.ex
+++ b/test/fixtures/behaviour.ex
@@ -4,6 +4,8 @@ defmodule CustomBehaviourOne do
 
   @doc """
   This is a sample callback.
+
+  With description
   """
   @callback hello(integer) :: integer
   @callback greet(integer | String.t) :: integer


### PR DESCRIPTION
As discussed over on IRC. A function that is not explicitly annotated with `@doc false` and doesn't have docs, but the callback does - will include callback docs.