### PR TITLE
Automatically detect GitLab source URL patterns

### DIFF
--- a/lib/ex_doc.ex
+++ b/lib/ex_doc.ex
@@ -127,6 +127,10 @@ defmodule ExDoc do
     append_slash(url) <> "blob/#{ref}/%{path}#L%{line}"
   end
 
+  defp guess_url(url = <<"https://gitlab.com/", _ :: binary>>, ref) do
+    append_slash(url) <> "blob/#{ref}/%{path}#L%{line}"
+  end
+
   defp guess_url(url = <<"https://bitbucket.org/", _ :: binary>>, ref) do
     append_slash(url) <> "src/#{ref}/%{path}#cl-%{line}"
   end

--- a/lib/ex_doc/cli.ex
+++ b/lib/ex_doc/cli.ex
@@ -126,7 +126,7 @@ defmodule ExDoc.CLI do
     ExDoc by default provide links to the source code implementation as
     long as `--source-url` or `--source-url-pattern` is provided. If you
     provide `--source-url`, ExDoc will inflect the url pattern automatically
-    for GitHub and Bitbucket URLs. For example:
+    for GitHub, GitLab, and Bitbucket URLs. For example:
 
         --source-url "https://github.com/elixir-lang/ecto"
 

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -44,6 +44,10 @@ defmodule ExDoc.Formatter.HTMLTest do
     content = File.read!("#{output_dir()}/CompiledWithDocs.html")
     assert content =~ "https://github.com/elixir-lang/ex_doc/blob/master/test/fixtures/compiled_with_docs.ex#L13"
 
+    generate_docs doc_config(source_url: "https://gitlab.com/elixir-lang/ex_doc", source_root: File.cwd!)
+    content = File.read!("#{output_dir()}/CompiledWithDocs.html")
+    assert content =~ "https://gitlab.com/elixir-lang/ex_doc/blob/master/test/fixtures/compiled_with_docs.ex#L13"
+
     generate_docs doc_config(source_url: "https://bitbucket.org/elixir-lang/ex_doc", source_root: File.cwd!)
     content = File.read!("#{output_dir()}/CompiledWithDocs.html")
     assert content =~ "https://bitbucket.org/elixir-lang/ex_doc/src/master/test/fixtures/compiled_with_docs.ex#cl-13"


### PR DESCRIPTION
GitLab has become quite popular, and its source URL scheme is identical
to GitHub's. That makes it useful and easy to support by default.