### PR TITLE
List both functions and macros under "Functions"

### DIFF
--- a/lib/ex_doc/formatter/epub/templates.ex
+++ b/lib/ex_doc/formatter/epub/templates.ex
@@ -30,8 +30,7 @@ defmodule ExDoc.Formatter.EPUB.Templates do
   @doc """
   Creates a chapter which contains all the details about an individual module.
 
-  This chapter can include the following sections: *functions*, *macros*,
-  *types*, *callbacks*.
+  This chapter can include the following sections: *functions*, *types*, *callbacks*.
   """
   EEx.function_from_file(:def, :module_template,
                          Path.expand("templates/module_template.eex", __DIR__),

--- a/lib/ex_doc/formatter/epub/templates/module_template.eex
+++ b/lib/ex_doc/formatter/epub/templates/module_template.eex
@@ -22,7 +22,6 @@
         </h1>
         <%= H.summary_template "types", summary_map.types %>
         <%= H.summary_template "functions", summary_map.functions %>
-        <%= H.summary_template "macros", summary_map.macros %>
         <%= H.summary_template "callbacks", summary_map.callbacks %>
       </section>
     <% end %>
@@ -53,20 +52,6 @@
         </h1>
         <%= for function_node <- summary_map.functions do
           H.detail_template(function_node, module)
-        end %>
-      </section>
-    <% end %>
-
-    <%= if summary_map.macros != [] do %>
-      <section id="macros" class="details-list">
-        <h1 class="section-heading">
-          <a class="hover-link" href="#macros">
-            <i class="icon-link"></i>
-          </a>
-          Macros
-        </h1>
-        <%= for macro_node <- summary_map.macros do
-          H.detail_template(macro_node, module)
         end %>
       </section>
     <% end %>

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -178,8 +178,7 @@ defmodule ExDoc.Formatter.HTML.Templates do
 
   def group_summary(module_node) do
     %{types: module_node.typespecs,
-      functions: Enum.filter(module_node.docs, & &1.type in [:def]),
-      macros: Enum.filter(module_node.docs, & &1.type in [:defmacro]),
+      functions: Enum.filter(module_node.docs, & &1.type in [:def, :defmacro]),
       callbacks: Enum.filter(module_node.docs, & &1.type in [:callback, :macrocallback])}
   end
 

--- a/lib/ex_doc/formatter/html/templates/module_template.eex
+++ b/lib/ex_doc/formatter/html/templates/module_template.eex
@@ -30,7 +30,6 @@
           </h1>
           <%= summary_template "types", summary_map.types %>
           <%= summary_template "functions", summary_map.functions %>
-          <%= summary_template "macros", summary_map.macros %>
           <%= summary_template "callbacks", summary_map.callbacks %>
         </section>
       <% end %>
@@ -61,20 +60,6 @@
           </h1>
           <%= for function_node <- summary_map.functions do
             detail_template(function_node, module)
-          end %>
-        </section>
-      <% end %>
-
-      <%= if summary_map.macros != [] do %>
-        <section id="macros" class="details-list">
-          <h1 class="section-heading">
-            <a class="hover-link" href="#macros">
-              <i class="icon-link"></i>
-            </a>
-            Macros
-          </h1>
-          <%= for macro_node <- summary_map.macros do
-            detail_template(macro_node, module)
           end %>
         </section>
       <% end %>

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -243,6 +243,13 @@ defmodule ExDoc.Retriever do
             |> Enum.map(&Typespec.spec_to_ast(name, &1))
             |> Enum.reverse()
 
+    annotations = case type do
+      :defmacro ->
+        ["macro"]
+      _ ->
+        []
+    end
+
     %ExDoc.FunctionNode{
       id: "#{name}/#{arity}",
       name: name,
@@ -254,7 +261,8 @@ defmodule ExDoc.Retriever do
       specs: specs,
       source_path: source.path,
       source_url: source_link(source, line),
-      type: type
+      type: type,
+      annotations: annotations
     }
   end
 

--- a/test/ex_doc/formatter/epub/templates_test.exs
+++ b/test/ex_doc/formatter/epub/templates_test.exs
@@ -56,7 +56,7 @@ defmodule ExDoc.Formatter.EPUB.TemplatesTest do
     assert content =~ ~r{moduledoc.*Example.*CompiledWithDocs\.example.*}ms
     assert content =~ ~r{example/2.*Some example}ms
     assert content =~ ~r{example_without_docs/0.*<section class="docstring">.*</section>}ms
-    assert content =~ ~r{example_1/0.*Another example}ms
+    assert content =~ ~r{example_1/0.*<span class="note">\(macro\)</span>}ms
 
     assert content =~ ~s{<div class="detail" id="example_1/0">}
     assert content =~ ~s{example(foo, bar \\\\ Baz)}

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -117,7 +117,6 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
 
     assert content =~ ~r("modules":\[\{"id":"CompiledWithDocs","title":"CompiledWithDocs")ms
     assert content =~ ~r("id":"CompiledWithDocs".*"functions":.*"example/2")ms
-    assert content =~ ~r("id":"CompiledWithDocs".*"macros":.*"example_1/0")ms
     assert content =~ ~r("id":"CompiledWithDocs".*"functions":.*"example_without_docs/0")ms
     assert content =~ ~r("id":"CompiledWithDocs.Nested")ms
   end
@@ -137,7 +136,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
     # Summaries
     assert content =~ ~r{example/2.*Some example}ms
     assert content =~ ~r{example_without_docs/0.*<section class="docstring">.*</section>}ms
-    assert content =~ ~r{example_1/0.*Another example}ms
+    assert content =~ ~r{example_1/0.*<span class="note">\(macro\)</span>}ms
 
     # Source
     assert content =~ ~r{<a href="#{source_url()}/blob/master/test/fixtures/compiled_with_docs.ex#L10"[^>]*>\n\s*<i class="icon-code"></i>\n\s*</a>}ms


### PR DESCRIPTION
Per #646, this removes the top-level distinction between functions and
macros in the sidebar. Macros are listed alongside functions and include
an additional "(macro)" annotation tag:

<img width="570" alt="screen shot 2016-12-21 at 9 49 31 am" src="https://cloud.githubusercontent.com/assets/10311/21400188/ca5a230e-c763-11e6-8378-921264be5c15.png">