### PR TITLE
Warn when redirecting to a non-existent file

### DIFF
--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -37,11 +37,11 @@ defmodule ExDoc.Formatter.HTML do
       generate_sidebar_items(nodes_map, extras, config) ++
       generate_extras(nodes_map, extras, config) ++
       generate_logo(assets_dir, config) ++
-      generate_index(config) ++
       generate_not_found(nodes_map, config) ++
       generate_list(nodes_map.modules, nodes_map, config) ++
       generate_list(nodes_map.exceptions, nodes_map, config) ++
-      generate_list(nodes_map.protocols, nodes_map, config)
+      generate_list(nodes_map.protocols, nodes_map, config) ++
+      generate_index(config)
 
     generate_build(static_files ++ generated_files, build)
     config.output |> Path.join("index.html") |> Path.relative_to_cwd()
@@ -263,6 +263,9 @@ defmodule ExDoc.Formatter.HTML do
   end
 
   defp generate_redirect(filename, config, redirect_to) do
+    unless File.regular?("#{config.output}/#{redirect_to}") do
+      IO.puts :stderr, "warning: #{filename} redirects to #{redirect_to}, which does not exist"
+    end
     content = Templates.redirect_template(config, redirect_to)
     File.write!("#{config.output}/#{filename}", content)
   end

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -1,5 +1,6 @@
 defmodule ExDoc.Formatter.HTMLTest do
   use ExUnit.Case, async: true
+  import ExUnit.CaptureIO
 
   setup do
     File.rm_rf(output_dir())
@@ -234,6 +235,16 @@ defmodule ExDoc.Formatter.HTMLTest do
     assert_raise ArgumentError,
                  ~S("main" cannot be set to "index", otherwise it will recursively link to itself),
                  fn -> generate_docs(config) end
+  end
+
+  test "run warns when generating an index.html file with an invalid redirect" do
+    output = capture_io(:stderr, fn ->
+      generate_docs(doc_config(main: "Unknown"))
+    end)
+
+    assert output == "warning: index.html redirects to Unknown.html, which does not exist\n"
+    assert File.regular?("#{output_dir()}/index.html")
+    refute File.regular?("#{output_dir()}/Unknown.html")
   end
 
   test "run generates assets" do


### PR DESCRIPTION
This makes it a little more obvious when `main:` references an invalid
document or node.