### PR TITLE
Handle __struct__/0 by displaying the struct instead

### DIFF
--- a/test/ex_doc/retriever_test.exs
+++ b/test/ex_doc/retriever_test.exs
@@ -51,7 +51,13 @@ defmodule ExDoc.RetrieverTest do
 
   test "docs_from_files returns the doc info for each module function" do
     [module_node] = docs_from_files ["CompiledWithDocs"]
-    [example, example_1, example_without_docs] = module_node.docs
+    [struct, example, example_1, example_without_docs] = module_node.docs
+
+    assert struct.id == "__struct__/0"
+    assert struct.doc == "Some struct"
+    assert struct.type == :def
+    assert struct.defaults == []
+    assert struct.signature == "%CompiledWithDocs{}"
 
     assert example.id   == "example/2"
     assert example.doc  == "Some example"
@@ -63,7 +69,7 @@ defmodule ExDoc.RetrieverTest do
     assert example_1.type == :defmacro
     assert example_1.defaults == []
 
-    assert example_without_docs.source_url == "http://example.com/test/fixtures/compiled_with_docs.ex\#L15"
+    assert example_without_docs.source_url == "http://example.com/test/fixtures/compiled_with_docs.ex\#L18"
     assert example_without_docs.doc == nil
     assert example_without_docs.defaults == []
   end

--- a/test/fixtures/compiled_with_docs.ex
+++ b/test/fixtures/compiled_with_docs.ex
@@ -6,6 +6,9 @@ defmodule CompiledWithDocs do
       CompiledWithDocs.example
   """
 
+  @doc "Some struct"
+  defstruct [:field]
+
   @doc "Some example"
   def example(foo, bar \\ Baz), do: bar.baz(foo)
 


### PR DESCRIPTION
First shot at #667.

With this commit, we 

* annotate `__struct__/0` functions (like we do with macros and optional callbacks)
* display them as `%Task{}` instead of `__struct__/0` (for the `Task` example of course)

I am still showing them as `__struct__/0` in their anchor and in the sidebar, I am not sure how to proceed: for example, the anchor is URL-encoded as hell if we show `%Task{}`. Thoughts?
