### PR TITLE
use Earmark.as_html!

### DIFF
--- a/lib/ex_doc/markdown/earmark.ex
+++ b/lib/ex_doc/markdown/earmark.ex
@@ -31,6 +31,6 @@ defmodule ExDoc.Markdown.Earmark do
              file: Keyword.get(opts, :file),
              breaks: Keyword.get(opts, :breaks, false),
              smartypants: Keyword.get(opts, :smartypants, true))
-    Earmark.to_html(text, options)
+    Earmark.as_html!(text, options)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule ExDoc.Mixfile do
   end
 
   defp deps do
-    [{:earmark, "~> 1.0"},
+    [{:earmark, "~> 1.1"},
      {:markdown, github: "devinus/markdown", only: :test},
      {:cmark, "~> 0.5", only: :test},
      {:excoveralls, "~> 0.3", only: :test}]


### PR DESCRIPTION
Earmark.to_html was [deprecated as of v1.1](https://github.com/pragdave/earmark/commit/8f8a05f18fcf596b20a97d73a74dcc3745fc802a). This changes to use the new `as_html!` which prints any errors to STDERR automatically.

I noticed the other day when [updating dependencies](https://github.com/mmmries/sqlitex/pull/51) that generating docs would generate a bunch of dependency warnings like this:

```
$ mix docs
warning: usage of `Earmark.to_html` is deprecated.
Use `Earmark.as_html!` instead, or use `Earmark.as_html` which returns a tuple `{html, errors}`
warning: usage of `Earmark.to_html` is deprecated.
Use `Earmark.as_html!` instead, or use `Earmark.as_html` which returns a tuple `{html, errors}`
warning: usage of `Earmark.to_html` is deprecated.
...
```

Seemed like a pretty simple fix to use the new `as_html!` function, but I didn't find any issues addressing this so I figured I would open a PR to see if there is a reason to wait on switching to `as_html!`.