### PR TITLE
Fix project name wrapping

### DIFF
--- a/assets/less/sidebar.less
+++ b/assets/less/sidebar.less
@@ -62,7 +62,7 @@
     margin: 0;
     padding: 0;
     max-width: 230px;
-    word-break: break-all;
+    word-wrap: break-word;
   }
 
   .sidebar-projectVersion {


### PR DESCRIPTION
Changes project name wrapping to use normal word wrapping
instead of break-all. This prevents a long project name from
being wrapped mid-word while still allowing long words to
be wrapped properly.

Fixes #696