### PR TITLE
Strip nesting html tags in headers. Closes #705

### DIFF
--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -144,10 +144,12 @@ defmodule ExDoc.Formatter.HTML.Templates do
   end
 
   @h2_regex  ~r/<h2.*?>(.+)<\/h2>/m
+  @clean_html_regex ~r/<(?:[^>=]|='[^']*'|="[^"]*"|=[^'"][^\s>]*)*>/
   defp extract_headers(content) do
     @h2_regex
     |> Regex.scan(content, capture: :all_but_first)
     |> List.flatten()
+    |> Enum.map(&(String.replace(&1, @clean_html_regex, "")))
     |> Enum.map(&{&1, header_to_id(&1)})
   end
 
@@ -209,7 +211,7 @@ defmodule ExDoc.Formatter.HTML.Templates do
   @spec header_to_id(String.t) :: String.t
   def header_to_id(header) do
     header
-    |> String.replace(~r/<.+>/, "")
+    |> String.replace(@clean_html_regex, "")
     |> String.replace(~r/&#\d+;/, "")
     |> String.replace(~r/&[A-Za-z0-9]+;/, "")
     |> String.replace(~r/\W+/u, "-")

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -49,7 +49,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
     assert Templates.header_to_id(" ☃ ") == ""
     assert Templates.header_to_id(" &sup2; ") == ""
     assert Templates.header_to_id(" &#9180; ") == ""
-    assert Templates.header_to_id("Git Options (<code class=\"inline\">:git</code>)") == "git-options"
+    assert Templates.header_to_id("Git Options (<code class=\"inline\">:git</code>)") == "git-options-git"
   end
 
   test "synopsis" do

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -183,7 +183,7 @@ defmodule ExDoc.Formatter.HTMLTest do
 
     content = File.read!("#{output_dir()}/readme.html")
     assert content =~ ~r{<title>README [^<]*</title>}
-    assert content =~ ~r{<h2 id="header-sample" class="section-heading">.*<a href="#header-sample" class="hover-link"><i class="icon-link"></i></a>.*Header sample.*</h2>}ms
+    assert content =~ ~r{<h2 id="header-sample" class="section-heading">.*<a href="#header-sample" class="hover-link"><i class="icon-link"></i></a>.*<code>Header</code> sample.*</h2>}ms
     assert content =~ ~r{<h2 id="more-than" class="section-heading">.*<a href="#more-than" class="hover-link"><i class="icon-link"></i></a>.*more &gt; than.*</h2>}ms
     assert content =~ ~r{<a href="RandomError.html"><code>RandomError</code>}
     assert content =~ ~r{<a href="CustomBehaviourImpl.html#hello/1"><code>CustomBehaviourImpl.hello/1</code>}

--- a/test/fixtures/README.md
+++ b/test/fixtures/README.md
@@ -2,7 +2,7 @@
 `CustomBehaviourImpl.hello/1`
 `TypesAndSpecs.Sub`
 
-## Header sample
+## `Header` sample
 
 hello
 


### PR DESCRIPTION
I cannot run tests locally as it seems cmark depends on `make` tool and i have no means to build it on windows :(