### PR TITLE
Setting homepage_url at root level in the config, as shown in the Con…

### DIFF
--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -127,7 +127,8 @@ defmodule Mix.Tasks.Docs do
       config
       |> get_docs_opts()
       |> Keyword.merge(cli_opts)
-      |> normalize_source_url(config)
+      |> normalize_source_url(config)   # accepted at root level config
+      |> normalize_homepage_url(config) # accepted at root level config
       |> normalize_source_beam(config)
       |> normalize_main()
       |> normalize_deps()
@@ -163,6 +164,14 @@ defmodule Mix.Tasks.Docs do
   defp normalize_source_url(options, config) do
     if source_url = config[:source_url] do
       Keyword.put(options, :source_url, source_url)
+    else
+      options
+    end
+  end
+
+  defp normalize_homepage_url(options, config) do
+    if homepage_url = config[:homepage_url] do
+      Keyword.put(options, :homepage_url, homepage_url)
     else
       options
     end

--- a/test/mix/tasks/docs_test.exs
+++ b/test/mix/tasks/docs_test.exs
@@ -70,10 +70,22 @@ defmodule Mix.Tasks.DocsTest do
            run([], [app: :ex_doc, docs: fn -> [main: "another"] end])
   end
 
-  test "accepts source_url from root" do
-    assert [{"ex_doc", "dev", [formatter: "html", deps: _, source_beam: _,
-                               source_url: "http://github.com/elixir-lang/ex_doc"]}] =
-           run([], [app: :ex_doc, source_url: "http://github.com/elixir-lang/ex_doc"])
+  test "accepts options from root" do
+    # accepted options are: `app`, `name`, `source_url`, `homepage_url`, `version`
+    assert [{"ExDoc", "1.2.3-dev",
+             [formatter: "html",
+              deps: _, source_beam: _,
+              homepage_url: "http://elixir-lang.org",
+              source_url: "https://github.com/elixir-lang/ex_doc",
+              ]}] =
+           run([], [app: :ex_doc,
+                    name: "ExDoc",
+                    source_url: "https://github.com/elixir-lang/ex_doc",
+                    homepage_url: "http://elixir-lang.org",
+                    version: "1.2.3-dev",
+                   ])
+
+    assert [{"ex_doc", "dev", _}] = run([], [app: :ex_doc])
   end
 
   test "supports umbrella project" do


### PR DESCRIPTION
…figuration

example en Mix.Tasks.Docs module didn't take effect.

This can be seen can see that for example in Phoenix
https://github.com/phoenixframework/phoenix/blob/v1.2.4/mix.exs#L22
but the logo in the docs, link to the main page: https://hexdocs.pm/phoenix/Phoenix.html

A test is included that checks for all allowed configs at root level:
app, name, source_url, homepage_url, version