### PR TITLE
Change font stack, based on availability on different platforms

### DIFF
--- a/assets/less/variables.less
+++ b/assets/less/variables.less
@@ -23,7 +23,7 @@
 @nightFnHeaderBg: #3A4152;
 
 // Font Families
-@serifFontFamily: 'Merriweather', serif;
+@serifFontFamily: 'Merriweather', 'Book Antiqua', Georgia, 'Century Schoolbook', serif;
 @sansFontFamily: 'Lato', sans-serif;
 @monoFontFamily: 'Inconsolata', Menlo, Courier, monospace;
 


### PR DESCRIPTION
The font stack has been chosen carefully to be supported (99%+) on Windows, Mac and Linux assuming Merriweather fails to load.

To some extent (as much as I think is reasonable) closes: #695 