### PR TITLE
Fix callback signature when arguments are typed as functions

### DIFF
--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -369,6 +369,8 @@ defmodule ExDoc.Retriever do
 
   defp to_var({name, meta, _}, _) when is_atom(name),
     do: {name, meta, nil}
+  defp to_var([{:->, _, _} | _], _),
+    do: {:function, [], nil}
   defp to_var({:<<>>, _, _}, _),
     do: {:binary, [], nil}
   defp to_var({:%{}, _, _}, _),


### PR DESCRIPTION
Closes #690. Not sure I should add a test for this since the whole thing of getting the signature from the typespec is only tested "on the side" (for example [here](https://github.com/elixir-lang/ex_doc/blob/527e0602598f7e283fa15d8aad9876b63334f9dd/test/ex_doc/retriever_test.exs#L181)) and it would mean fiddling with the fixtures behaviours.