### PR TITLE
Camelize config[:app] when used in project name

### DIFF
--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -121,7 +121,7 @@ defmodule Mix.Tasks.Docs do
       Mix.raise "Extraneous arguments on the command line"
     end
 
-    project = to_string(config[:name] || config[:app])
+    project = to_string(config[:name] || Macro.camelize(to_string(config[:app])))
     version = config[:version] || "dev"
     options =
       config

--- a/test/mix/tasks/docs_test.exs
+++ b/test/mix/tasks/docs_test.exs
@@ -10,19 +10,19 @@ defmodule Mix.Tasks.DocsTest do
   end
 
   test "inflects values from app and version" do
-    assert [{"ex_doc", "0.1.0", [formatter: "html", deps: _, source_beam: _]}] =
+    assert [{"ExDoc", "0.1.0", [formatter: "html", deps: _, source_beam: _]}] =
            run([], [app: :ex_doc, version: "0.1.0"])
   end
 
   test "accepts multiple formatters from CLI" do
-    assert [{"ex_doc", "0.1.0", [formatter: "html", deps: _, source_beam: _]},
-            {"ex_doc", "0.1.0", [formatter: "epub", deps: _, source_beam: _]}] =
+    assert [{"ExDoc", "0.1.0", [formatter: "html", deps: _, source_beam: _]},
+            {"ExDoc", "0.1.0", [formatter: "epub", deps: _, source_beam: _]}] =
            run(["-f", "html", "-f", "epub"], [app: :ex_doc, version: "0.1.0"])
   end
 
   test "accepts multiple formatters from config" do
-    assert [{"ex_doc", "0.1.0", [formatter: "html", deps: _, source_beam: _, formatters: _]},
-            {"ex_doc", "0.1.0", [formatter: "epub", deps: _, source_beam: _, formatters: _]}] =
+    assert [{"ExDoc", "0.1.0", [formatter: "html", deps: _, source_beam: _, formatters: _]},
+            {"ExDoc", "0.1.0", [formatter: "epub", deps: _, source_beam: _, formatters: _]}] =
            run([], [app: :ex_doc, version: "0.1.0", docs: [formatters: ["html", "epub"]]])
   end
 
@@ -32,41 +32,41 @@ defmodule Mix.Tasks.DocsTest do
   end
 
   test "accepts modules in :main" do
-    assert [{"ex_doc", "dev", [formatter: "html", deps: _, main: "Sample", source_beam: _, ]}] =
+    assert [{"ExDoc", "dev", [formatter: "html", deps: _, main: "Sample", source_beam: _, ]}] =
            run([], [app: :ex_doc, docs: [main: Sample]])
   end
 
   test "accepts files in :main" do
-    assert [{"ex_doc", "dev", [formatter: "html", deps: _, source_beam: _, main: "another"]}] =
+    assert [{"ExDoc", "dev", [formatter: "html", deps: _, source_beam: _, main: "another"]}] =
            run([], [app: :ex_doc, docs: [main: "another"]])
   end
 
   test "accepts output in :output" do
-    assert [{"ex_doc", "dev", [formatter: "html", deps: _, source_beam: _, output: "hello"]}] =
+    assert [{"ExDoc", "dev", [formatter: "html", deps: _, source_beam: _, output: "hello"]}] =
            run([], [app: :ex_doc, docs: [output: "hello"]])
   end
 
   test "parses output with lower preference than options" do
-    assert [{"ex_doc", "dev", [formatter: "html", deps: _, source_beam: _, output: "world"]}] =
+    assert [{"ExDoc", "dev", [formatter: "html", deps: _, source_beam: _, output: "world"]}] =
            run(~w(-o world), [app: :ex_doc, docs: [output: "world"]])
   end
 
   test "includes dependencies" do
-    assert [{"ex_doc", "dev", [formatter: "html", deps: deps, source_beam: _]}] =
+    assert [{"ExDoc", "dev", [formatter: "html", deps: deps, source_beam: _]}] =
            run([], [app: :ex_doc, docs: []])
     assert List.keyfind(deps, Application.app_dir(:earmark), 0) ==
            {Application.app_dir(:earmark), "https://hexdocs.pm/earmark/#{Application.spec(:earmark, :vsn)}/"}
   end
 
   test "allows custom dependency paths" do
-    assert [{"ex_doc", "dev", [formatter: "html", deps: deps, source_beam: _]}] =
+    assert [{"ExDoc", "dev", [formatter: "html", deps: deps, source_beam: _]}] =
            run([], [app: :ex_doc, docs: [deps: [earmark: "foo"]]])
     assert List.keyfind(deps, Application.app_dir(:earmark), 0) ==
            {Application.app_dir(:earmark), "foo"}
   end
 
   test "accepts lazy docs" do
-    assert [{"ex_doc", "dev", [formatter: "html", deps: _, source_beam: _, main: "another"]}] =
+    assert [{"ExDoc", "dev", [formatter: "html", deps: _, source_beam: _, main: "another"]}] =
            run([], [app: :ex_doc, docs: fn -> [main: "another"] end])
   end
 
@@ -85,12 +85,12 @@ defmodule Mix.Tasks.DocsTest do
                     version: "1.2.3-dev",
                    ])
 
-    assert [{"ex_doc", "dev", _}] = run([], [app: :ex_doc])
+    assert [{"ExDoc", "dev", _}] = run([], [app: :ex_doc])
   end
 
   test "supports umbrella project" do
     Mix.Project.in_project(:umbrella, "test/fixtures/umbrella", fn _mod ->
-      assert [{"umbrella", "dev", [formatter: "html", deps: deps, source_beam: _]}] =
+      assert [{"Umbrella", "dev", [formatter: "html", deps: deps, source_beam: _]}] =
              run([], [app: :umbrella, apps_path: "apps/"])
 
       assert List.keyfind(deps, Application.app_dir(:foo), 0) ==
@@ -98,5 +98,15 @@ defmodule Mix.Tasks.DocsTest do
       assert List.keyfind(deps, Application.app_dir(:bar), 0) ==
              {Application.app_dir(:bar), "https://hexdocs.pm/bar/0.1.0/"}
     end)
+  end
+
+  test "check project name" do
+    assert [{"foo_bar", _, _}] = run([], [name: :foo_bar])
+    assert [{"foo_bar", _, _}] = run([], [name: "foo_bar"])
+    assert [{"FooBar", _, _}] = run([], [app: :foo_bar])
+    # :name has precedence over :app
+    assert [{"BarBaz", _, _}] = run([], [app: :foo_bar, name: "BarBaz"])
+    # setting :project, :name, or :app in :docs set the project name
+    assert [{"", _, _}] = run([], [docs: [app: :foo_bar, name: "BarBaz", project: "FizFazz"]])
   end
 end


### PR DESCRIPTION
So if no :name is provided in config, it set the project name
based on the camelized version of :app

ie. `app: :ex_doc`
will generate a project named "ExDoc"