### PR TITLE
Updated README.md with docs from test folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ def deps do
 end
 ```
 
+Consider using `[:dev, :test]` if you wish to fetch docs from modules under `test` folder.
+
 After adding ExDoc as a dependency, run `mix deps.get` to install it.
 
 ExDoc will automatically pull in information from your projects, like the application and version. However, you may want to set `:name`, `:source_url` and `:homepage_url` to have a nicer output from ExDoc, such as:
@@ -38,7 +40,7 @@ def project do
 end
 ```
 
-Now you are ready to generate your project documentation with `mix docs`.
+Now you are ready to generate your project documentation with `mix docs`. Use `MIX_ENV=test mix docs` for additional docs from `test` folder.
 
 To see all options available when generating docs, run `mix help docs`. You may have to run `mix docs` or `mix compile` first.
 


### PR DESCRIPTION
Relates to #738 

Since @josevalim answered 
> We only generate documentation from compiled files in the current environment. Given test/support/graphql_case.ex is compiled only in test, you probably want to do MIX_ENV=test mix docs

It's not obivious to fetch deps for test environment (as guys like me just copy-paste samples of code to project), so some minor README update