### PR TITLE
Add unencoded link target for functions with special chars

### DIFF
--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -120,6 +120,10 @@ defmodule ExDoc.Formatter.HTML.Templates do
     |> h()
   end
 
+  defp is_enc?(binary) do
+    h(binary) != enc_h(binary)
+  end
+
   @doc """
   Create a JS object which holds all the items displayed in the sidebar area
   """

--- a/lib/ex_doc/formatter/html/templates/detail_template.eex
+++ b/lib/ex_doc/formatter/html/templates/detail_template.eex
@@ -1,4 +1,7 @@
 <div class="detail" id="<%=enc_h link_id(module_node.id, module_node.type) %>">
+  <%= if is_enc? link_id(module_node.id, module_node.type) do %>
+    <span id="<%=h link_id(module_node.id, module_node.type) %>"></span>
+  <% end %>
   <%= for default <- get_defaults(module_node) do %>
     <span id="<%=enc_h link_id(default, module_node.type) %>"></span>
   <% end %>


### PR DESCRIPTION
When merged, this will fix #509

Firefox (and probably other browsers) expect the URI of an anchor to be urlencoded
but the actual target to be NOT encoded. Due to this behaviour, links to functions
with special characters won't work.

While RFC3986 is very clear on how URIs have to be formatted, there is no clear
specification on how link targets actually should (or shouldn't) be encoded.
There are lose guidelines for HTML4/HTML5 but they rarely cover special characters.

Since most browsers seem to have adapted to also match encoded anchor targets,
this commit does not change but only extend the current behaviour by adding a
second, unencoded target to the template, similar to what is already done when
linking to a function with optional parameters, which results in target links
with different arity.