### PR TITLE
fix: remove extra term() argument at start of macro spec

### DIFF
--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -241,11 +241,12 @@ defmodule ExDoc.Retriever do
             |> Enum.map(&Typespec.spec_to_ast(name, &1))
             |> Enum.reverse()
 
-    specs = if type == :defmacro do
-      Enum.map(specs, &remove_first_macro_arg/1)
-    else
-      specs
-    end
+    specs =
+      if type == :defmacro do
+        Enum.map(specs, &remove_first_macro_arg/1)
+      else
+        specs
+      end
 
     annotations =
       case {type, name, arity} do
@@ -281,9 +282,9 @@ defmodule ExDoc.Retriever do
     }
   end
 
-  defp remove_first_macro_arg(
-    {:::, info, [{name, info2, [_term_arg | rest_args]}, return]}
-  ), do: {:::, info, [{name, info2, rest_args}, return]}
+  defp remove_first_macro_arg({:::, info, [{name, info2, [_term_arg | rest_args]}, return]}) do
+    {:::, info, [{name, info2, rest_args}, return]}
+  end
 
   defp get_defaults(signature, name, arity) do
     case Enum.count(signature, &match?({:\\, _, [_, _]}, &1)) do

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -241,6 +241,12 @@ defmodule ExDoc.Retriever do
             |> Enum.map(&Typespec.spec_to_ast(name, &1))
             |> Enum.reverse()
 
+    specs = if type == :defmacro do
+      Enum.map(specs, &remove_first_macro_arg/1)
+    else
+      specs
+    end
+
     annotations =
       case {type, name, arity} do
         {:defmacro, _, _} ->
@@ -274,6 +280,10 @@ defmodule ExDoc.Retriever do
       annotations: annotations
     }
   end
+
+  defp remove_first_macro_arg(
+    {:::, info, [{name, info2, [_term_arg | rest_args]}, return]}
+  ), do: {:::, info, [{name, info2, rest_args}, return]}
 
   defp get_defaults(signature, name, arity) do
     case Enum.count(signature, &match?({:\\, _, [_, _]}, &1)) do

--- a/test/ex_doc/retriever_test.exs
+++ b/test/ex_doc/retriever_test.exs
@@ -102,7 +102,7 @@ defmodule ExDoc.RetrieverTest do
     assert macro.id   == "macro_spec/1"
     assert macro.doc  == nil
     assert macro.type == :defmacro
-    assert Macro.to_string(macro.specs) == "[macro_spec(term(), any()) :: {:ok, any()}]"
+    assert Macro.to_string(macro.specs) == "[macro_spec(any()) :: {:ok, any()}]"
   end
 
   test "docs_from_files returns the spec info for each non-private module type" do


### PR DESCRIPTION
fixes: #755