### PR TITLE
Markdown modules are now 100% responsible for code

### DIFF
--- a/lib/ex_doc/markdown.ex
+++ b/lib/ex_doc/markdown.ex
@@ -29,7 +29,7 @@ defmodule ExDoc.Markdown do
   Converts the given markdown document to HTML.
   """
   def to_html(text, opts \\ []) when is_binary(text) do
-    pretty_codeblocks(get_markdown_processor().to_html(text, opts))
+    get_markdown_processor().to_html(text, opts)
   end
 
   @doc """

--- a/lib/ex_doc/markdown/cmark.ex
+++ b/lib/ex_doc/markdown/cmark.ex
@@ -15,6 +15,6 @@ defmodule ExDoc.Markdown.Cmark do
   Generate HTML output. Cmark takes no options.
   """
   def to_html(text, _opts) do
-    Cmark.to_html(text)
+    Cmark.to_html(text)  |> ExDoc.Markdown.pretty_codeblocks
   end
 end

--- a/lib/ex_doc/markdown/earmark.ex
+++ b/lib/ex_doc/markdown/earmark.ex
@@ -32,6 +32,6 @@ defmodule ExDoc.Markdown.Earmark do
              file: Keyword.get(opts, :file),
              breaks: Keyword.get(opts, :breaks, false),
              smartypants: Keyword.get(opts, :smartypants, true))
-    Earmark.as_html!(text, options)
+    Earmark.as_html!(text, options) |> ExDoc.Markdown.pretty_codeblocks
   end
 end


### PR DESCRIPTION
Code blocks are now handled by the markdown modules,
and ExDoc doesn't do any post-processing.

The modules bundled with ExDoc were updated to reflect this.

The goal of this change is to make it easier to use alternative Markdown
implementations.

This might break compatibility for people that are already usin Markdown
extensions.

The code for the Hoedown module wasn't changed because it already handled the postprocessing of code blocks itself.

All unit tests pass, and my visual integration test with Earmark on a real project showed no differences.