### PR TITLE
before_closing_*_tag works on EPUB too

### DIFF
--- a/lib/ex_doc.ex
+++ b/lib/ex_doc.ex
@@ -23,10 +23,13 @@ defmodule ExDoc do
       Map.fetch!(@default, field)
     end
 
+    def before_closing_head_tag(_), do: ""
+    def before_closing_body_tag(_), do: ""
+
     defstruct [
       assets: nil,
-      before_closing_head_tag: "",
-      before_closing_body_tag: "",
+      before_closing_head_tag: &__MODULE__.before_closing_head_tag/1,
+      before_closing_body_tag: &__MODULE__.before_closing_body_tag/1,
       canonical: nil,
       debug: false,
       deps: [],
@@ -53,8 +56,8 @@ defmodule ExDoc do
 
      @type t :: %__MODULE__{
        assets: nil | String.t,
-       before_closing_head_tag: String.t,
-       before_closing_body_tag: String.t,
+       before_closing_head_tag: term,
+       before_closing_body_tag: term,
        canonical: nil | String.t,
        debug: boolean(),
        deps: [{ebin_path :: String.t, doc_url :: String.t}],

--- a/lib/ex_doc.ex
+++ b/lib/ex_doc.ex
@@ -56,8 +56,8 @@ defmodule ExDoc do
 
      @type t :: %__MODULE__{
        assets: nil | String.t,
-       before_closing_head_tag: term,
-       before_closing_body_tag: term,
+       before_closing_head_tag: (atom() -> String.t),
+       before_closing_body_tag: (atom() -> String.t),
        canonical: nil | String.t,
        debug: boolean(),
        deps: [{ebin_path :: String.t, doc_url :: String.t}],

--- a/lib/ex_doc/formatter/epub/templates/extra_template.eex
+++ b/lib/ex_doc/formatter/epub/templates/extra_template.eex
@@ -1,4 +1,5 @@
 <%= head_template(config, %{title: title}) %>
     <%= content %>
+    <%= config.before_closing_body_tag.(:epub) %>
   </body>
 </html>

--- a/lib/ex_doc/formatter/epub/templates/head_template.eex
+++ b/lib/ex_doc/formatter/epub/templates/head_template.eex
@@ -7,5 +7,6 @@
     <meta name="generator" content="ExDoc v<%= ExDoc.version %>" />
     <link type="text/css" rel="stylesheet" href="<%= H.asset_rev "#{config.output}/OEBPS", "dist/epub*.css" %>" />
     <script src="<%= H.asset_rev "#{config.output}/OEBPS", "dist/app*.js" %>"></script>
+    <%= config.before_closing_head_tag.(:epub) %>
   </head>
   <body>

--- a/lib/ex_doc/formatter/epub/templates/module_template.eex
+++ b/lib/ex_doc/formatter/epub/templates/module_template.eex
@@ -70,5 +70,6 @@
         end %>
       </section>
     <% end %>
+    <%= config.before_closing_body_tag.(:epub) %>
   </body>
 </html>

--- a/lib/ex_doc/formatter/epub/templates/nav_template.eex
+++ b/lib/ex_doc/formatter/epub/templates/nav_template.eex
@@ -18,5 +18,6 @@
         <%= nav_item_template "Mix Tasks", nodes.tasks %>
       </ol>
     </nav>
+    <%= config.before_closing_body_tag.(:epub) %>
   </body>
 </html>

--- a/lib/ex_doc/formatter/epub/templates/title_template.eex
+++ b/lib/ex_doc/formatter/epub/templates/title_template.eex
@@ -6,5 +6,6 @@
         <div><img src="assets/logo<%= Path.extname(logo) %>" alt="Logo"/></div>
       <% end %>
     </div>
+    <%= config.before_closing_body_tag.(:epub) %>
   </body>
 </html>

--- a/lib/ex_doc/formatter/html/templates/footer_template.eex
+++ b/lib/ex_doc/formatter/html/templates/footer_template.eex
@@ -16,6 +16,6 @@
 </section>
 </div>
   <script src="<%= asset_rev config.output, "dist/app*.js" %>"></script>
-  <%= config.before_closing_body_tag %>
+  <%= config.before_closing_body_tag.(:html) %>
   </body>
 </html>

--- a/lib/ex_doc/formatter/html/templates/head_template.eex
+++ b/lib/ex_doc/formatter/html/templates/head_template.eex
@@ -11,7 +11,7 @@
       <link rel="canonical" href="<%= config.canonical %>" />
     <% end %>
     <script src="<%= asset_rev config.output, "dist/sidebar_items*.js" %>"></script>
-    <%= config.before_closing_head_tag %>
+    <%= config.before_closing_head_tag.(:html) %>
   </head>
   <body data-type="<%= sidebar_type(page.type) %>">
     <script>try { if(localStorage.getItem('night-mode')) document.body.className += ' night-mode'; } catch (e) { }</script>

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -54,13 +54,17 @@ defmodule Mix.Tasks.Docs do
       directory in the output path. Its entries may be referenced in your docs
       under "assets/ASSET.EXTENSION"; defaults to no assets directory.
 
-    * `:before_closing_body_tag` - Literal HTML to be included just before the closing body tag (`</body>`)
-      Useful to inject custom assets, such as Javascript. 
-      Only works with the HTML formatter.
+    * `:before_closing_body_tag` - a function that takes as argument an atom specifying
+      the formatter being used (`:html` or `:epub`) and returns a literal HTML string
+      to be included just before the closing body tag (`</body>`).
+      The atom given as argument can be used to include different content in both formats.
+      Useful to inject custom assets, such as Javascript.
 
-    * `:before_closing_head_tag` - Literal HTML to be included just before the closing head tag (`</head>`);
-      Useful to inject custom assets, such as CSS.
-      Only works with the HTML formatter.
+    * `:before_closing_head_tag` - a function that takes as argument an atom specifying
+      the formatter being used (`:html` or `:epub`) and returns a literal HTML string
+      to be included just before the closing head tag (`</head>`).
+      The atom given as argument can be used to include different content in both formats.
+      Useful to inject custom assets, such as CSS stylesheets.
 
     * `:canonical` - String that defines the preferred URL with the rel="canonical"
       element; defaults to no canonical path.

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -20,8 +20,16 @@ defmodule ExDoc.Formatter.HTMLTest do
     File.read!(file)
   end
 
-  @before_closing_head_tag "UNIQUE:<dont-escape>&copy;BEFORE-CLOSING-HEAD-TAG</dont-escape>"
-  @before_closing_body_tag "UNIQUE:<dont-escape>&copyBEFORE-CLOSING-BODY-TAG</dont-escape>"
+  @before_closing_head_tag_content_html "UNIQUE:<dont-escape>&copy;BEFORE-CLOSING-HEAD-TAG-HTML</dont-escape>"
+  @before_closing_body_tag_content_html "UNIQUE:<dont-escape>&copy;BEFORE-CLOSING-BODY-TAG-HTML</dont-escape>"
+  @before_closing_head_tag_content_epub "UNIQUE:<dont-escape>&copy;BEFORE-CLOSING-HEAD-TAG-EPUB</dont-escape>"
+  @before_closing_body_tag_content_epub "UNIQUE:<dont-escape>&copy;BEFORE-CLOSING-BODY-TAG-EPUB</dont-escape>"
+
+  defp before_closing_head_tag(:html), do: @before_closing_head_tag_content_html
+  defp before_closing_head_tag(:epub), do: @before_closing_head_tag_content_epub
+
+  defp before_closing_body_tag(:html), do: @before_closing_body_tag_content_html
+  defp before_closing_body_tag(:epub), do: @before_closing_body_tag_content_epub
 
   defp doc_config do
     [project: "Elixir",
@@ -33,8 +41,8 @@ defmodule ExDoc.Formatter.HTMLTest do
      source_beam: beam_dir(),
      logo: "test/fixtures/elixir.png",
      extras: ["test/fixtures/README.md"],
-     before_closing_head_tag: @before_closing_head_tag,
-     before_closing_body_tag: @before_closing_body_tag]
+     before_closing_head_tag: &before_closing_head_tag/1,
+     before_closing_body_tag: &before_closing_body_tag/1]
   end
 
   defp doc_config(config) do
@@ -213,8 +221,8 @@ defmodule ExDoc.Formatter.HTMLTest do
     generate_docs(doc_config())
 
     content = File.read!("#{output_dir()}/api-reference.html")
-    assert content =~ ~r[#{@before_closing_head_tag}\s*</head>]
-    assert content =~ ~r[#{@before_closing_body_tag}\s*</body>]
+    assert content =~ ~r[#{@before_closing_head_tag_content_html}\s*</head>]
+    assert content =~ ~r[#{@before_closing_body_tag_content_html}\s*</body>]
   end
 
   test "before_closing_*_tags are placed in the right place - generated pages" do
@@ -222,8 +230,8 @@ defmodule ExDoc.Formatter.HTMLTest do
     generate_docs(config)
     
     content = File.read!("#{output_dir()}/readme.html")
-    assert content =~ ~r[#{@before_closing_head_tag}\s*</head>]
-    assert content =~ ~r[#{@before_closing_body_tag}\s*</body>]
+    assert content =~ ~r[#{@before_closing_head_tag_content_html}\s*</head>]
+    assert content =~ ~r[#{@before_closing_body_tag_content_html}\s*</body>]
   end
 
   test "run generates pages with custom names" do


### PR DESCRIPTION
All tests pass (which means the extra content is actually being included), and he output is good on visual inspection on my reader. If this is merged, we should make a release so that it can be used for hex packages.