### PR TITLE
Remove version name from epub formatter

### DIFF
--- a/lib/ex_doc/formatter/epub.ex
+++ b/lib/ex_doc/formatter/epub.ex
@@ -51,7 +51,7 @@ defmodule ExDoc.Formatter.EPUB do
     output =
       config.output
       |> Path.expand()
-      |> Path.join("#{config.project}-v#{config.version}")
+      |> Path.join("#{config.project}")
     %{config | output: output}
   end
 

--- a/test/ex_doc/formatter/epub_test.exs
+++ b/test/ex_doc/formatter/epub_test.exs
@@ -48,7 +48,7 @@ defmodule ExDoc.Formatter.EPUBTest do
   defp generate_docs_and_unzip(options) do
     generate_docs(options)
     unzip_dir = String.to_charlist("#{doc_config()[:output]}")
-    "#{doc_config()[:output]}/#{doc_config()[:project]}-v#{doc_config()[:version]}.epub"
+    "#{doc_config()[:output]}/#{doc_config()[:project]}.epub"
     |> String.to_charlist
     |> :zip.unzip([cwd: unzip_dir])
   end
@@ -92,14 +92,14 @@ defmodule ExDoc.Formatter.EPUBTest do
 
   test "run generates an EPUB file in the default directory" do
     generate_docs(doc_config())
-    assert File.regular?("#{output_dir()}/#{doc_config()[:project]}-v#{doc_config()[:version]}.epub")
+    assert File.regular?("#{output_dir()}/#{doc_config()[:project]}.epub")
   end
 
   test "run generates an EPUB file in specified output directory" do
     config = doc_config([output: "#{output_dir()}/another_dir", main: "RandomError"])
     generate_docs(config)
 
-    assert File.regular?("#{output_dir()}/another_dir/#{doc_config()[:project]}-v#{doc_config()[:version]}.epub")
+    assert File.regular?("#{output_dir()}/another_dir/#{doc_config()[:project]}.epub")
   end
 
   test "run generates an EPUB file with a standardized structure" do


### PR DESCRIPTION
Previously, the epub formatter defaulted to a filename in the following format:

> Phoenix-v1.3.0.epub

This commit changes it to:

> Phoenix.epub

When published to hexdocs, the version will already be specified in the url.
This means if the epub file is linked to in the docs, it will not be updated
each time there is a new version.