### PR TITLE
Lock Firefox version to 54.0 for Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,5 @@ cache:
   directories:
     - node_modules
     - deps
+addons:
+  firefox: "54.0"


### PR DESCRIPTION
On Aug 31st 2017 Travis CI updated their default Linux version to 14.04
https://blog.travis-ci.com/2017-08-31-trusty-as-default-status

As a result, Firefox was updated to Firefox 55, which has headless
support, however, this version of Firefox does not appear to be working
with Travis CI. There is an issue being tracked at:
https://github.com/travis-ci/travis-ci/issues/8242

For now, the easiest fix is to lock the Firefox version.