### PR TITLE
Fix .main height to 100%

### DIFF
--- a/assets/less/layout.less
+++ b/assets/less/layout.less
@@ -21,6 +21,7 @@ body {
 .main {
   .display(flex);
   justify-content: flex-end;
+  height: 100%;
 }
 
 .sidebar {


### PR DESCRIPTION
When the page content does not fill the full height the sidebar closing/opening animation looks odd.  

**Before:**  
![bevor](http://g.recordit.co/VQoy8fQviT.gif)

**After:**
![after](http://g.recordit.co/ETAGOLdaxq.gif)