### PR TITLE
Fix Mix.Tasks.Docs moduledoc typo

### DIFF
--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -136,7 +136,7 @@ defmodule Mix.Tasks.Docs do
 
       groups_for_extras: [
         "Introduction": Path.wildcard("guides/introduction/*.md"),
-        "Advanced": Path.wildcard("guides/introduction/*.md")
+        "Advanced": Path.wildcard("guides/advanced/*.md")
       ]
 
   Or via a regex:


### PR DESCRIPTION
Spotted a reallyyy small typo error while reading `mix help docs`.