### PR TITLE
Fix incorrect moduledoc for :extras

### DIFF
--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -79,7 +79,7 @@ defmodule Mix.Tasks.Docs do
     * `:extras` - List of keywords, each key must indicate the path to additional
       Markdown pages, the value for each keyword (optional) gives you more control
       about the PATH and the title of the output files; default: `[]`. Example:
-      `["README.md", "CONTRIBUTING.md": [filename: "contributing", title: "Contributing"]]`
+      `["README.md", {"CONTRIBUTING.md", [filename: "contributing", title: "Contributing"]}]`
 
     * `:filter_prefix` - Include only modules that match the given prefix in
       the generated documentation. Example: "MyApp.Core"


### PR DESCRIPTION
Sorry for the consecutive PR. Just found another spot where the example in the `@moduledoc` is not working. The `CONTRIBUTING.md` part below is not a valid keyword.

```
["README.md", "CONTRIBUTING.md": [filename: "contributing", title: "Contributing"]]
```

This PR changes it to:

```
["README.md", {"CONTRIBUTING.md", [filename: "contributing", title: "Contributing"]}]
```

I made sure to finish my work with ex_doc before submitting this PR. So this should be the last one for now.