### PR TITLE
Add plugins support to Earmark processor

### DIFF
--- a/lib/ex_doc/markdown/earmark.ex
+++ b/lib/ex_doc/markdown/earmark.ex
@@ -32,6 +32,10 @@ defmodule ExDoc.Markdown.Earmark do
     * `:smartypants` - boolean. Turns on smartypants processing, so quotes become curly,
       two or three hyphens become en and em dashes, and so on. True by default
 
+    * `:plugins` - map of strings to modules. Register custom plugins to be used with
+      Earmark. See [Plugins](http://github.com/pragdave/earmark#plugins) for details on
+      how to write custom plugins.
+
   """
   def to_html(text, opts) do
     options =
@@ -40,7 +44,8 @@ defmodule ExDoc.Markdown.Earmark do
              line: Keyword.get(opts, :line, 1),
              file: Keyword.get(opts, :file),
              breaks: Keyword.get(opts, :breaks, false),
-             smartypants: Keyword.get(opts, :smartypants, true))
+             smartypants: Keyword.get(opts, :smartypants, true),
+             plugins: Keyword.get(opts, :plugins, %{}))
     text |> Earmark.as_html!(options) |> ExDoc.Markdown.pretty_codeblocks()
   end
 end


### PR DESCRIPTION
Wanted to add a [task list](https://help.github.com/articles/about-task-lists/) to the docs in a personal project, but found that Earmark does not support them. I want to write a custom plugin to do it, though it doesn't seem to be possible to enable the plugin through ex_doc. This PR should fix that.