### PR TITLE
Use [rel="noopener"] on external links

### DIFF
--- a/lib/ex_doc/formatter/html/templates/footer_template.eex
+++ b/lib/ex_doc/formatter/html/templates/footer_template.eex
@@ -2,11 +2,11 @@
         <p>
           <span class="line">
             Built using
-            <a href="https://github.com/elixir-lang/ex_doc" title="ExDoc" rel="help" target="_blank">ExDoc</a> (v<%= ExDoc.version %>),
+            <a href="https://github.com/elixir-lang/ex_doc" title="ExDoc" target="_blank" rel="help noopener">ExDoc</a> (v<%= ExDoc.version %>),
           </span>
           <span class="line">
             designed by
-            <a href="https://twitter.com/dignifiedquire" target="_blank" title="@dignifiedquire">Friedel Ziegelmayer</a>.
+            <a href="https://twitter.com/dignifiedquire" target="_blank" rel="noopener" title="@dignifiedquire">Friedel Ziegelmayer</a>.
             </span>
         </p>
       </footer>


### PR DESCRIPTION
`[rel="noopener"]` is added to external links having `[target="_blank"]`  to deny access to `window.opener`. [Here](https://developers.google.com/web/tools/lighthouse/audits/noopener) is a quick rundown on why it is important.