### PR TITLE
Link directly to page if sidebar item has no subitems

### DIFF
--- a/assets/js/template-helpers/isEmptyNode.js
+++ b/assets/js/template-helpers/isEmptyNode.js
@@ -1,0 +1,19 @@
+export default function (node, options) {
+  var nodeItems = [
+    node.types,
+    node.functions,
+    node.macros,
+    node.callbacks,
+    node.headers
+  ].filter(Array.isArray);
+
+  if (flatten(nodeItems).length === 0){
+    return options.fn(this);
+  } else {
+    return options.inverse(this);
+  }
+}
+
+function flatten(array) {
+  return array.reduce(function(a, b){ return a.concat(b);}, [])
+}

--- a/assets/js/templates/sidebar-items.handlebars
+++ b/assets/js/templates/sidebar-items.handlebars
@@ -8,76 +8,79 @@
     {{!-- When visiting a module page, the link to this module page
     in the menu should not link to a new page, instead should link
     to the top of the page itself. --}}
+    {{#isEmptyNode node}}
+      <a href="{{node.id}}.html" title="{{node.title}}">{{node.title}}</a>
+    {{else}}
+      <a href="{{node.id}}.html" title="{{node.title}}" class="expand">{{node.title}}</a>
 
-    <a href="{{node.id}}.html" title="{{node.title}}" class="expand">{{node.title}}</a>
-
-    <ul>
-      <li>
-        <a href="{{node.id}}.html#content">Top</a>
-      </li>
-
-      {{#isArray node.headers}}
-        {{#each node.headers}}
-          <li>
-            <a href="{{node.id}}.html#{{{anchor}}}">{{id}}</a>
-          </li>
-        {{/each}}
-      {{else}}
-        {{#showSummary node}}
+      <ul>
         <li>
-          <a href="{{node.id}}.html#summary">Summary</a>
+          <a href="{{node.id}}.html#content">Top</a>
         </li>
-        {{/showSummary}}
-        {{#if node.types}}
-          <li class="docs">
-            <a href="{{node.id}}.html#types" class="expand">Types</a>
-            <ul class="types-list deflist">
-              {{#each node.types}}
-                <li>
-                  <a href="{{node.id}}.html#{{anchor}}">{{id}}</a>
-                </li>
-              {{/each}}
-            </ul>
-          </li>
-        {{/if}}
-        {{#if node.functions}}
-          <li class="docs">
-            <a href="{{node.id}}.html#functions" class="expand">Functions</a>
-            <ul class="functions-list deflist">
-              {{#each node.functions}}
-                <li>
-                  <a href="{{node.id}}.html#{{anchor}}">{{id}}</a>
-                </li>
-              {{/each}}
-            </ul>
-          </li>
-        {{/if}}
-        {{#if node.macros}}
-          <li class="docs">
-            <a href="{{node.id}}.html#macros" class="expand">Macros</a>
-            <ul class="macros-list deflist">
-              {{#each node.macros}}
-                <li>
-                  <a href="{{node.id}}.html#{{anchor}}" class="deflink">{{id}}</a>
-                </li>
-              {{/each}}
-            </ul>
-          </li>
-        {{/if}}
-        {{#if node.callbacks}}
-          <li class="docs">
-            <a href="{{node.id}}.html#callbacks" class="expand">Callbacks</a>
-            <ul class="callbacks-list deflist">
-              {{#each node.callbacks}}
-                <li>
-                  <a href="{{node.id}}.html#{{anchor}}" class="deflink">{{id}}</a>
-                </li>
-              {{/each}}
-            </ul>
-          </li>
-        {{/if}}
-      {{/isArray}}
-    </ul>
+
+        {{#isArray node.headers}}
+          {{#each node.headers}}
+            <li>
+              <a href="{{node.id}}.html#{{{anchor}}}">{{id}}</a>
+            </li>
+          {{/each}}
+        {{else}}
+          {{#showSummary node}}
+            <li>
+              <a href="{{node.id}}.html#summary">Summary</a>
+            </li>
+          {{/showSummary}}
+          {{#if node.types}}
+            <li class="docs">
+              <a href="{{node.id}}.html#types" class="expand">Types</a>
+              <ul class="types-list deflist">
+                {{#each node.types}}
+                  <li>
+                    <a href="{{node.id}}.html#{{anchor}}">{{id}}</a>
+                  </li>
+                {{/each}}
+              </ul>
+            </li>
+          {{/if}}
+          {{#if node.functions}}
+            <li class="docs">
+              <a href="{{node.id}}.html#functions" class="expand">Functions</a>
+              <ul class="functions-list deflist">
+                {{#each node.functions}}
+                  <li>
+                    <a href="{{node.id}}.html#{{anchor}}">{{id}}</a>
+                  </li>
+                {{/each}}
+              </ul>
+            </li>
+          {{/if}}
+          {{#if node.macros}}
+            <li class="docs">
+              <a href="{{node.id}}.html#macros" class="expand">Macros</a>
+              <ul class="macros-list deflist">
+                {{#each node.macros}}
+                  <li>
+                    <a href="{{node.id}}.html#{{anchor}}" class="deflink">{{id}}</a>
+                  </li>
+                {{/each}}
+              </ul>
+            </li>
+          {{/if}}
+          {{#if node.callbacks}}
+            <li class="docs">
+              <a href="{{node.id}}.html#callbacks" class="expand">Callbacks</a>
+              <ul class="callbacks-list deflist">
+                {{#each node.callbacks}}
+                  <li>
+                    <a href="{{node.id}}.html#{{anchor}}" class="deflink">{{id}}</a>
+                  </li>
+                {{/each}}
+              </ul>
+            </li>
+          {{/if}}
+        {{/isArray}}
+      </ul>
+    {{/isEmptyNode}}
   </li>
 {{/each}}
 </ul>


### PR DESCRIPTION
# Summary

For sidebar items with no subitems, link directly to the page. 

## Issue
Hex docs show a "Top" sub header even if there are no other contents.  As an example, go to the [Phoenix Hex documentation](https://hexdocs.pm/phoenix/Phoenix.html), click **Guides** then **Installation** and you'll see something like:

<img width="328" alt="screenshot 2018-05-30 13 49 05" src="https://user-images.githubusercontent.com/3220620/40746811-3e6e9df2-6410-11e8-9e36-d3ddc3bdedee.png">

In order to actually view the page, you have to click Top. This feels unnecessary.

## Solution

Check if there are any contents in each sidebar item, specifically for:
+ types
+ functions
+ macros
+ callbacks
+ headers

If there are no items link directly to the page.

# Screenshots
## Currently
<img width="444" alt="screenshot 2018-05-30 13 42 13" src="https://user-images.githubusercontent.com/3220620/40746609-bed7c7da-640f-11e8-82b0-30a38616c8eb.png">

![current_sidebar](https://user-images.githubusercontent.com/3220620/40747241-86d68838-6411-11e8-8a16-98007fcaaa96.gif)


## With Top removed

<img width="394" alt="screenshot 2018-05-30 13 44 00" src="https://user-images.githubusercontent.com/3220620/40747286-ac98b9ba-6411-11e8-8e4b-6e99c8a5dd0f.png">

![new_sidebar](https://user-images.githubusercontent.com/3220620/40746947-a338684e-6410-11e8-9ab0-3bc07196dff9.gif)

# Testing

Verified by generating docs for the ex_docs repo. 