### PR TITLE
Fix Elixir module matcher RegEx

### DIFF
--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -462,7 +462,7 @@ defmodule ExDoc.Formatter.HTML.Autolink do
   """
   def elixir_modules(bin, modules, module_id \\ nil,
                      extension \\ ".html", lib_dirs \\ elixir_lib_dirs()) when is_binary(bin) do
-    regex = ~r{(?<!\[)`\s*(([A-Z][A-Za-z_\d]+\.?)+)\s*`(?!\])}
+    regex = ~r{(?<!\[)(?<!``)`\s*(([A-Z][A-Za-z_\d]+\.?)+)\s*`(?!\])}
 
     Regex.replace(regex, bin, fn all, match ->
       cond do

--- a/test/ex_doc/formatter/html/autolink_test.exs
+++ b/test/ex_doc/formatter/html/autolink_test.exs
@@ -164,6 +164,8 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
     assert Autolink.elixir_modules("`MyModule.Nested`", ["MyModule.Nested"], "MyModule.Nested") == "[`MyModule.Nested`](MyModule.Nested.html#content)"
     assert Autolink.elixir_modules("`MyModule.Nested.Deep`", ["MyModule.Nested.Deep"], "MyModule.Nested.Deep") ==
       "[`MyModule.Nested.Deep`](MyModule.Nested.Deep.html#content)"
+    assert Autolink.elixir_modules("```\nThis is a test.\n```\n\nSee `MyModule`.", ["MyModule"], "MyModule") ==
+      "```\nThis is a test.\n```\n\nSee [`MyModule`](MyModule.html#content)."
   end
 
   test "autolink modules in elixir" do


### PR DESCRIPTION
This PR adds a negative lookbehind for multiline codeblocks, to fix an issue where a module name in an inline codeblock after a multiline codeblock didn't get correctly matched, due to the regex matching from the multiline codeblock to the inline codeblock.

Before: https://regex101.com/r/Du8vUp/1
After: https://regex101.com/r/Zit4pj/1