### PR TITLE
Exclude types with `@typedoc false` from generated documentation

### DIFF
--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -507,9 +507,18 @@ defmodule ExDoc.Retriever do
     exported = :lists.flatten(exported)
 
     (Code.get_docs(module_info.name, :type_docs) || [])
-    |> Enum.filter(&elem(&1, 0) in exported)
+    |> Enum.filter(&(elem(&1, 0) in exported && typedoc?(&1)))
     |> Enum.sort_by(&elem(&1, 0))
     |> Enum.map(&get_type(&1, source, module_info.abst_code))
+  end
+
+  # Skip typedocs explicitly marked as false
+  defp typedoc?({_, _, _, false}) do
+    false
+  end
+
+  defp typedoc?({_, _, _, _}) do
+    true
   end
 
   defp get_type(type, source, abst_code) do

--- a/test/fixtures/types_and_specs.ex
+++ b/test/fixtures/types_and_specs.ex
@@ -15,6 +15,8 @@ defmodule TypesAndSpecs do
   @typep private :: any
   @opaque opaque :: {Dict.t}
   @type ref :: {:binary.part, public(any)}
+  @typedoc false
+  @type internal :: any
 
   @spec add(integer, opaque) :: integer
   def add(x, _), do: x + x


### PR DESCRIPTION
This PR fixes the bug when ExDoc included documentation for types with `@typedoc false`.

Closes #857 