### PR TITLE
Avoid warnings after split of Kernel.Typespec into {Kernel,Code}.Typespec

### DIFF
--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -82,7 +82,6 @@ defmodule ExDoc.Retriever do
 
   alias ExDoc.GroupMatcher
   alias ExDoc.Retriever.Error
-  alias Kernel.Typespec
 
   @doc """
   Extract documentation from all modules in the specified directory or directories.
@@ -243,7 +242,7 @@ defmodule ExDoc.Retriever do
 
     specs = module_info.specs
             |> Map.get(function, [])
-            |> Enum.map(&Typespec.spec_to_ast(name, &1))
+            |> Enum.map(&spec_to_quoted(name, &1))
 
     specs =
       if type == :defmacro do
@@ -327,7 +326,7 @@ defmodule ExDoc.Retriever do
     {:attribute, anno, :callback, {^function, specs}} =
       Enum.find(abst_code, &match?({:attribute, _, :callback, {^function, _}}, &1))
     line  = anno_line(anno) || doc_line
-    specs = Enum.map(specs, &Typespec.spec_to_ast(name, &1))
+    specs = Enum.map(specs, &spec_to_quoted(name, &1))
 
     name_and_arity =
       case kind do
@@ -478,7 +477,7 @@ defmodule ExDoc.Retriever do
 
   # Returns a dict of {name, arity} -> spec.
   defp get_specs(module) do
-    Enum.into(Typespec.beam_specs(module) || [], %{})
+    Enum.into(fetch_specs(module) || [], %{})
   end
 
   # Returns a dict of {name, arity} -> behaviour.
@@ -491,7 +490,7 @@ defmodule ExDoc.Retriever do
 
   defp callbacks_defined_by(module) do
     module
-    |> Kernel.Typespec.beam_callbacks()
+    |> fetch_callbacks()
     |> Kernel.||([]) # In case the module source is not available
     |> Keyword.keys
   end
@@ -528,7 +527,7 @@ defmodule ExDoc.Retriever do
       Enum.find(abst_code, &match?({:attribute, _, type, {^name, _, args}}
                                      when type in [:opaque, :type] and length(args) == arity, &1))
 
-    spec = process_type_ast(Typespec.type_to_ast(spec), type)
+    spec = spec |> type_to_quoted() |> process_type_ast(type)
     line = anno_line(anno) || doc_line
 
     annotations = if type == :opaque, do: ["opaque"], else: []
@@ -568,4 +567,40 @@ defmodule ExDoc.Retriever do
   # Cut off the body of an opaque type while leaving it on a normal type.
   defp process_type_ast({:::, _, [d|_]}, :opaque), do: d
   defp process_type_ast(ast, _), do: ast
+
+  # Since Elixir 1.7.0-dev, functions from Kernel.Typespec related with the
+  # runtime aspects, such as reading from .beam files, were moved to Code.Typespec
+  if Version.compare(System.version(), "1.7.0-dev") == :lt do
+    defp spec_to_quoted(name, spec), do: Kernel.Typespec.spec_to_ast(name, spec)
+  else
+    defp spec_to_quoted(name, spec), do: Code.Typespec.spec_to_quoted(name, spec)
+  end
+
+  if Version.compare(System.version, "1.7.0-dev") == :lt do
+    defp fetch_specs(module), do: Kernel.Typespec.beam_specs(module)
+  else
+    defp fetch_specs(module) do
+      case Code.Typespec.fetch_specs(module) do
+        {:ok, specs} -> specs
+        :error -> nil
+      end
+    end
+  end
+
+  if Version.compare(System.version, "1.7.0-dev") == :lt do
+    defp type_to_quoted(type), do: Kernel.Typespec.type_to_ast(type)
+  else
+    defp type_to_quoted(type), do: Code.Typespec.type_to_quoted(type)
+  end
+
+  if Version.compare(System.version(), "1.7.0-dev") == :lt do
+    defp fetch_callbacks(module), do: Kernel.Typespec.beam_callbacks(module)
+  else
+    defp fetch_callbacks(module) do
+      case Code.Typespec.fetch_callbacks(module) do
+        {:ok, callbacks} -> callbacks
+        :error -> nil
+      end
+    end
+  end
 end

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -570,37 +570,37 @@ defmodule ExDoc.Retriever do
 
   # Since Elixir 1.7.0-dev, functions from Kernel.Typespec related with the
   # runtime aspects, such as reading from .beam files, were moved to Code.Typespec
-  if Version.compare(System.version(), "1.7.0-dev") == :lt do
-    defp spec_to_quoted(name, spec), do: Kernel.Typespec.spec_to_ast(name, spec)
-  else
+  if Code.ensure_loaded?(Code.Typespec) do
     defp spec_to_quoted(name, spec), do: Code.Typespec.spec_to_quoted(name, spec)
+  else
+    defp spec_to_quoted(name, spec), do: Kernel.Typespec.spec_to_ast(name, spec)
   end
 
-  if Version.compare(System.version, "1.7.0-dev") == :lt do
-    defp fetch_specs(module), do: Kernel.Typespec.beam_specs(module)
-  else
+  if Code.ensure_loaded?(Code.Typespec) do
     defp fetch_specs(module) do
       case Code.Typespec.fetch_specs(module) do
         {:ok, specs} -> specs
         :error -> nil
       end
     end
+  else
+    defp fetch_specs(module), do: Kernel.Typespec.beam_specs(module)
   end
 
-  if Version.compare(System.version, "1.7.0-dev") == :lt do
-    defp type_to_quoted(type), do: Kernel.Typespec.type_to_ast(type)
-  else
+  if Code.ensure_loaded?(Code.Typespec) do
     defp type_to_quoted(type), do: Code.Typespec.type_to_quoted(type)
+  else
+    defp type_to_quoted(type), do: Kernel.Typespec.type_to_ast(type)
   end
 
-  if Version.compare(System.version(), "1.7.0-dev") == :lt do
-    defp fetch_callbacks(module), do: Kernel.Typespec.beam_callbacks(module)
-  else
+  if Code.ensure_loaded?(Code.Typespec) do
     defp fetch_callbacks(module) do
       case Code.Typespec.fetch_callbacks(module) do
         {:ok, callbacks} -> callbacks
         :error -> nil
       end
     end
+  else
+    defp fetch_callbacks(module), do: Kernel.Typespec.beam_callbacks(module)
   end
 end


### PR DESCRIPTION
The idea behind this PR is avoid this kind of warnings under Elixir 1.7.0-dev:

```console
λ mix test
Compiling 3 files (.ex)
Excluding tags: [no_formatter: true]

..warning: Kernel.Typespec.beam_specs/1 is deprecated, please use Code.Typespec.fetch_specs/1 instead
  (elixir) lib/kernel/typespec.ex:48: Kernel.Typespec.beam_specs/1
  (ex_doc) lib/ex_doc/retriever.ex:481: ExDoc.Retriever.get_specs/1
  (ex_doc) lib/ex_doc/retriever.ex:195: ExDoc.Retriever.get_module_info/2
  (ex_doc) lib/ex_doc/retriever.ex:166: ExDoc.Retriever.generate_node/3
  (elixir) lib/enum.ex:1314: Enum."-map/2-lists^map/1-0-"/2
  (ex_doc) lib/ex_doc/retriever.ex:116: ExDoc.Retriever.docs_from_modules/2
  test/ex_doc/formatter/epub/templates_test.exs:30: ExDoc.Formatter.EPUB.TemplatesTest.get_module_page/1
  test/ex_doc/formatter/epub/templates_test.exs:66: ExDoc.Formatter.EPUB.TemplatesTest."test module_page outputs summaries"/1
  (ex_unit) lib/ex_unit/runner.ex:312: ExUnit.Runner.exec_test/1
  (stdlib) timer.erl:166: :timer.tc/1
  (ex_unit) lib/ex_unit/runner.ex:251: anonymous fn/4 in ExUnit.Runner.spawn_test/3
```