### PR TITLE
Refactor templates tests

### DIFF
--- a/test/ex_doc/formatter/epub/templates_test.exs
+++ b/test/ex_doc/formatter/epub/templates_test.exs
@@ -16,7 +16,7 @@ defmodule ExDoc.Formatter.EPUB.TemplatesTest do
     %ExDoc.Config{
       project: "Elixir",
       version: "1.0.1",
-      source_root: File.cwd!,
+      source_root: File.cwd!(),
       source_url_pattern: "#{source_url()}/blob/master/%{path}#L%{line}",
       homepage_url: homepage_url(),
       source_url: source_url(),
@@ -37,64 +37,80 @@ defmodule ExDoc.Formatter.EPUB.TemplatesTest do
   end
 
   ## MODULES
+  describe "module_page" do
+    test "generates only the module name when there's no more info" do
+      module_node = %ExDoc.ModuleNode{
+        module: XPTOModule,
+        doc: nil,
+        id: "XPTOModule",
+        title: "XPTOModule"
+      }
 
-  test "module_page generates only the module name when there's no more info" do
-    module_node = %ExDoc.ModuleNode{module: XPTOModule, doc: nil, id: "XPTOModule", title: "XPTOModule"}
-    content = Templates.module_page(doc_config(), module_node)
+      content = Templates.module_page(doc_config(), module_node)
 
-    assert content =~ ~r{<title>XPTOModule [^<]*</title>}
-    assert content =~ ~r{<h1 id="content">\s*XPTOModule\s*}
-  end
+      assert content =~ ~r{<title>XPTOModule [^<]*</title>}
+      assert content =~ ~r{<h1 id="content">\s*XPTOModule\s*}
+    end
 
-  test "module_page outputs the functions and docstrings" do
-    content = get_module_page([CompiledWithDocs])
+    test "outputs the functions and docstrings" do
+      content = get_module_page([CompiledWithDocs])
 
-    assert content =~ ~r{<title>CompiledWithDocs [^<]*</title>}
-    assert content =~ ~r{<h1 id="content">\s*CompiledWithDocs\s*}
-    assert content =~ ~r{moduledoc.*Example.*<span class="nc">CompiledWithDocs</span><span class="o">\.</span><span class="n">example</span>.*}ms
-    assert content =~ ~r{example/2.*Some example}ms
-    assert content =~ ~r{example_without_docs/0.*<section class="docstring">.*</section>}ms
-    assert content =~ ~r{example_1/0.*<span class="note">\(macro\)</span>}ms
+      assert content =~ ~r{<title>CompiledWithDocs [^<]*</title>}
+      assert content =~ ~r{<h1 id="content">\s*CompiledWithDocs\s*}
 
-    assert content =~ ~s{<div class="detail" id="example_1/0">}
-    assert content =~ ~s{example(foo, bar \\\\ Baz)}
-  end
+      assert content =~
+               ~r{moduledoc.*Example.*<span class="nc">CompiledWithDocs</span><span class="o">\.</span><span class="n">example</span>.*}ms
 
-  test "module_page outputs summaries" do
-    content = get_module_page([CompiledWithDocs])
-    assert content =~ ~r{<div class="summary-signature">\s*<a href="#example_1/0">}
-  end
+      assert content =~ ~r{example/2.*Some example}ms
+      assert content =~ ~r{example_without_docs/0.*<section class="docstring">.*</section>}ms
+      assert content =~ ~r{example_1/0.*<span class="note">\(macro\)</span>}ms
 
-  test "module_page contains links to summary sections when those exist" do
-    content = get_module_page([CompiledWithDocs, CompiledWithDocs.Nested])
-    refute content =~ ~r{types_details}
-  end
+      assert content =~ ~s{<div class="detail" id="example_1/0">}
+      assert content =~ ~s{example(foo, bar \\\\ Baz)}
+    end
 
-  ## BEHAVIOURS
+    test "outputs summaries" do
+      content = get_module_page([CompiledWithDocs])
+      assert content =~ ~r{<div class="summary-signature">\s*<a href="#example_1/0">}
+    end
 
-  test "module_page outputs behavior and callbacks" do
-    content = get_module_page([CustomBehaviourOne])
-    assert content =~ ~r{<h1 id="content">\s*CustomBehaviourOne\s*<small>behaviour</small>\s*</h1>}m
-    assert content =~ ~r{Callbacks}
-    assert content =~ ~r{<div class="detail" id="c:hello/1">}
+    test "contains links to summary sections when those exist" do
+      content = get_module_page([CompiledWithDocs, CompiledWithDocs.Nested])
+      refute content =~ ~r{types_details}
+    end
 
-    content = get_module_page([CustomBehaviourTwo])
-    assert content =~ ~r{<h1 id="content">\s*CustomBehaviourTwo\s*<small>behaviour</small>\s*</h1>}m
-    assert content =~ ~r{Callbacks}
-    assert content =~ ~r{<div class="detail" id="c:bye/1">}
-  end
+    ## BEHAVIOURS
 
-  ## PROTOCOLS
+    test "outputs behavior and callbacks" do
+      content = get_module_page([CustomBehaviourOne])
 
-  test "module_page outputs the protocol type" do
-    content = get_module_page([CustomProtocol])
-    assert content =~ ~r{<h1 id="content">\s*CustomProtocol\s*<small>protocol</small>\s*}m
-  end
+      assert content =~
+               ~r{<h1 id="content">\s*CustomBehaviourOne\s*<small>behaviour</small>\s*</h1>}m
 
-  ## TASKS
+      assert content =~ ~r{Callbacks}
+      assert content =~ ~r{<div class="detail" id="c:hello/1">}
 
-  test "module_page outputs the task type" do
-    content = get_module_page([Mix.Tasks.TaskWithDocs])
-    assert content =~ ~r{<h1 id="content">\s*mix task_with_docs\s*}m
+      content = get_module_page([CustomBehaviourTwo])
+
+      assert content =~
+               ~r{<h1 id="content">\s*CustomBehaviourTwo\s*<small>behaviour</small>\s*</h1>}m
+
+      assert content =~ ~r{Callbacks}
+      assert content =~ ~r{<div class="detail" id="c:bye/1">}
+    end
+
+    ## PROTOCOLS
+
+    test "outputs the protocol type" do
+      content = get_module_page([CustomProtocol])
+      assert content =~ ~r{<h1 id="content">\s*CustomProtocol\s*<small>protocol</small>\s*}m
+    end
+
+    ## TASKS
+
+    test "outputs the task type" do
+      content = get_module_page([Mix.Tasks.TaskWithDocs])
+      assert content =~ ~r{<h1 id="content">\s*mix task_with_docs\s*}m
+    end
   end
 end

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -18,7 +18,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
     default = %ExDoc.Config{
       project: "Elixir",
       version: "1.0.1",
-      source_root: File.cwd!,
+      source_root: File.cwd!(),
       source_url_pattern: "#{source_url()}/blob/master/%{path}#L%{line}",
       homepage_url: homepage_url(),
       source_url: source_url(),
@@ -41,280 +41,350 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
     :ok
   end
 
-  test "header id generation" do
-    assert Templates.header_to_id("“Stale”") == "stale"
-    assert Templates.header_to_id("José") == "josé"
-    assert Templates.header_to_id(" a - b ") == "a-b"
-    assert Templates.header_to_id(" ☃ ") == ""
-    assert Templates.header_to_id(" &sup2; ") == ""
-    assert Templates.header_to_id(" &#9180; ") == ""
-    assert Templates.header_to_id("Git Options (<code class=\"inline\">:git</code>)") == "git-options-git"
-  end
+  describe "header" do
+    test "id generation" do
+      assert Templates.header_to_id("“Stale”") == "stale"
+      assert Templates.header_to_id("José") == "josé"
+      assert Templates.header_to_id(" a - b ") == "a-b"
+      assert Templates.header_to_id(" ☃ ") == ""
+      assert Templates.header_to_id(" &sup2; ") == ""
+      assert Templates.header_to_id(" &#9180; ") == ""
 
-  test "link headers" do
-    assert Templates.link_headings("<h2>Foo</h2><h2>Bar</h2>") == """
-    <h2 id="foo" class="section-heading">
-      <a href="#foo" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
-      Foo
-    </h2>
-    <h2 id="bar" class="section-heading">
-      <a href="#bar" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
-      Bar
-    </h2>
-    """
-
-    assert Templates.link_headings("<h2>Foo</h2>\n<h2>Bar</h2>") == """
-    <h2 id="foo" class="section-heading">
-      <a href="#foo" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
-      Foo
-    </h2>
-
-    <h2 id="bar" class="section-heading">
-      <a href="#bar" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
-      Bar
-    </h2>
-    """
-
-    assert Templates.link_headings("<h2></h2><h2>Bar</h2>") == """
-    <h2></h2><h2 id="bar" class="section-heading">
-      <a href="#bar" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
-      Bar
-    </h2>
-    """
-
-    assert Templates.link_headings("<h2></h2>\n<h2>Bar</h2>") == """
-    <h2></h2>
-    <h2 id="bar" class="section-heading">
-      <a href="#bar" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
-      Bar
-    </h2>
-    """
-
-    assert Templates.link_headings("<h2>Foo</h2><h2></h2>") == String.trim_trailing("""
-    <h2 id="foo" class="section-heading">
-      <a href="#foo" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
-      Foo
-    </h2>
-    <h2></h2>
-    """)
-
-    assert Templates.link_headings("<h2>Foo</h2>\n<h2></h2>") == String.trim_trailing("""
-    <h2 id="foo" class="section-heading">
-      <a href="#foo" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
-      Foo
-    </h2>
-
-    <h2></h2>
-    """)
-
-    assert Templates.link_headings("<h3>Foo</h3>") == """
-    <h3 id="foo" class="section-heading">
-      <a href="#foo" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
-      Foo
-    </h3>
-    """
-  end
-
-  test "sidebar items from headers" do
-    item = %{content: nil, group: nil, id: nil, title: nil}
-    assert Templates.create_sidebar_items(%{}, [%{item | content: "<h2>Foo</h2><h2>Bar</h2>"}]) ==
-      ~s(sidebarNodes={"extras":[{"id":"","title":"","group":"","headers":[{"id":"Foo","anchor":"foo"},{"id":"Bar","anchor":"bar"}]}]})
-
-    assert Templates.create_sidebar_items(%{}, [%{item | content: "<h2>Foo</h2>\n<h2>Bar</h2>"}]) ==
-      ~s(sidebarNodes={"extras":[{"id":"","title":"","group":"","headers":[{"id":"Foo","anchor":"foo"},{"id":"Bar","anchor":"bar"}]}]})
-
-    assert Templates.create_sidebar_items(%{}, [%{item | content: "<h2></h2><h2>Bar</h2>"}]) ==
-      ~s(sidebarNodes={"extras":[{"id":"","title":"","group":"","headers":[{"id":"Bar","anchor":"bar"}]}]})
-
-    assert Templates.create_sidebar_items(%{}, [%{item | content: "<h2></h2>\n<h2>Bar</h2>"}]) ==
-      ~s(sidebarNodes={"extras":[{"id":"","title":"","group":"","headers":[{"id":"Bar","anchor":"bar"}]}]})
-
-    assert Templates.create_sidebar_items(%{}, [%{item | content: "<h2>Foo</h2><h2></h2>"}]) ==
-      ~s(sidebarNodes={"extras":[{"id":"","title":"","group":"","headers":[{"id":"Foo","anchor":"foo"}]}]})
-
-    assert Templates.create_sidebar_items(%{}, [%{item | content: "<h2>Foo</h2>\n<h2></h2>"}]) ==
-      ~s(sidebarNodes={"extras":[{"id":"","title":"","group":"","headers":[{"id":"Foo","anchor":"foo"}]}]})
-  end
-
-  test "synopsis" do
-    assert Templates.synopsis(nil) == nil
-    assert Templates.synopsis("") == ""
-    assert Templates.synopsis(".") == ""
-    assert Templates.synopsis(".::.") == ""
-    assert Templates.synopsis(" .= .: :.") == ".="
-    assert Templates.synopsis(" Description: ") == "Description"
-    assert Templates.synopsis("abcd") == "abcd"
-    assert_raise FunctionClauseError, fn ->
-      Templates.synopsis(:abcd)
+      assert Templates.header_to_id("Git Options (<code class=\"inline\">:git</code>)") ==
+               "git-options-git"
     end
   end
 
-  test "synopsis should not end have trailing periods or semicolons" do
-    doc1 = """
-    Summaries should not be displayed with trailing punctuation . :
+  describe "link" do
+    test "headers" do
+      assert Templates.link_headings("<h2>Foo</h2><h2>Bar</h2>") == """
+             <h2 id="foo" class="section-heading">
+               <a href="#foo" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+               Foo
+             </h2>
+             <h2 id="bar" class="section-heading">
+               <a href="#bar" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+               Bar
+             </h2>
+             """
 
-    ## Example
-    """
+      assert Templates.link_headings("<h2>Foo</h2>\n<h2>Bar</h2>") == """
+             <h2 id="foo" class="section-heading">
+               <a href="#foo" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+               Foo
+             </h2>
 
-    doc2 = """
-    Example function: Summary should not display trailing puntuation :.
+             <h2 id="bar" class="section-heading">
+               <a href="#bar" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+               Bar
+             </h2>
+             """
 
-    ## Example:
-    """
+      assert Templates.link_headings("<h2></h2><h2>Bar</h2>") == """
+             <h2></h2><h2 id="bar" class="section-heading">
+               <a href="#bar" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+               Bar
+             </h2>
+             """
 
-    assert Templates.synopsis(doc1) ==
-      "Summaries should not be displayed with trailing punctuation"
+      assert Templates.link_headings("<h2></h2>\n<h2>Bar</h2>") == """
+             <h2></h2>
+             <h2 id="bar" class="section-heading">
+               <a href="#bar" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+               Bar
+             </h2>
+             """
 
-    assert Templates.synopsis(doc2) ==
-      "Example function: Summary should not display trailing puntuation"
+      assert Templates.link_headings("<h2>Foo</h2><h2></h2>") ==
+               String.trim_trailing("""
+               <h2 id="foo" class="section-heading">
+                 <a href="#foo" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+                 Foo
+               </h2>
+               <h2></h2>
+               """)
+
+      assert Templates.link_headings("<h2>Foo</h2>\n<h2></h2>") ==
+               String.trim_trailing("""
+               <h2 id="foo" class="section-heading">
+                 <a href="#foo" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+                 Foo
+               </h2>
+
+               <h2></h2>
+               """)
+
+      assert Templates.link_headings("<h3>Foo</h3>") == """
+             <h3 id="foo" class="section-heading">
+               <a href="#foo" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+               Foo
+             </h3>
+             """
+    end
+  end
+
+  describe "sidebar" do
+    test "items from headers" do
+      item = %{content: nil, group: nil, id: nil, title: nil}
+
+      assert Templates.create_sidebar_items(%{}, [%{item | content: "<h2>Foo</h2><h2>Bar</h2>"}]) ==
+               ~s(sidebarNodes={"extras":[{"id":"","title":"","group":"","headers":[{"id":"Foo","anchor":"foo"},{"id":"Bar","anchor":"bar"}]}]})
+
+      assert Templates.create_sidebar_items(%{}, [%{item | content: "<h2>Foo</h2>\n<h2>Bar</h2>"}]) ==
+               ~s(sidebarNodes={"extras":[{"id":"","title":"","group":"","headers":[{"id":"Foo","anchor":"foo"},{"id":"Bar","anchor":"bar"}]}]})
+
+      assert Templates.create_sidebar_items(%{}, [%{item | content: "<h2></h2><h2>Bar</h2>"}]) ==
+               ~s(sidebarNodes={"extras":[{"id":"","title":"","group":"","headers":[{"id":"Bar","anchor":"bar"}]}]})
+
+      assert Templates.create_sidebar_items(%{}, [%{item | content: "<h2></h2>\n<h2>Bar</h2>"}]) ==
+               ~s(sidebarNodes={"extras":[{"id":"","title":"","group":"","headers":[{"id":"Bar","anchor":"bar"}]}]})
+
+      assert Templates.create_sidebar_items(%{}, [%{item | content: "<h2>Foo</h2><h2></h2>"}]) ==
+               ~s(sidebarNodes={"extras":[{"id":"","title":"","group":"","headers":[{"id":"Foo","anchor":"foo"}]}]})
+
+      assert Templates.create_sidebar_items(%{}, [%{item | content: "<h2>Foo</h2>\n<h2></h2>"}]) ==
+               ~s(sidebarNodes={"extras":[{"id":"","title":"","group":"","headers":[{"id":"Foo","anchor":"foo"}]}]})
+    end
+  end
+
+  describe "synopsis" do
+    test "functionality" do
+      assert Templates.synopsis(nil) == nil
+      assert Templates.synopsis("") == ""
+      assert Templates.synopsis(".") == ""
+      assert Templates.synopsis(".::.") == ""
+      assert Templates.synopsis(" .= .: :.") == ".="
+      assert Templates.synopsis(" Description: ") == "Description"
+      assert Templates.synopsis("abcd") == "abcd"
+
+      assert_raise FunctionClauseError, fn ->
+        Templates.synopsis(:abcd)
+      end
+    end
+
+    test "should not end have trailing periods or semicolons" do
+      doc1 = """
+      Summaries should not be displayed with trailing punctuation . :
+
+      ## Example
+      """
+
+      doc2 = """
+      Example function: Summary should not display trailing puntuation :.
+
+      ## Example:
+      """
+
+      assert Templates.synopsis(doc1) ==
+               "Summaries should not be displayed with trailing punctuation"
+
+      assert Templates.synopsis(doc2) ==
+               "Example function: Summary should not display trailing puntuation"
+    end
+  end
+
+  ## LISTING
+  describe "site_title" do
+    test "text links to homepage_url when set" do
+      content = Templates.sidebar_template(doc_config(), @empty_nodes_map)
+
+      assert content =~
+               ~r{<a href="#{homepage_url()}" class="sidebar-projectLink">\s*<div class="sidebar-projectDetails">\s*<h1 class="sidebar-projectName">\s*Elixir\s*</h1>\s*<h2 class="sidebar-projectVersion">\s*v1.0.1\s*</h2>\s*</div>\s*</a>}
+    end
+
+    test "text links to main when there is no homepage_url" do
+      config = %ExDoc.Config{
+        project: "Elixir",
+        version: "1.0.1",
+        source_root: File.cwd!(),
+        main: "hello"
+      }
+
+      content = Templates.sidebar_template(config, @empty_nodes_map)
+
+      assert content =~
+               ~r{<a href="hello.html" class="sidebar-projectLink">\s*<div class="sidebar-projectDetails">\s*<h1 class="sidebar-projectName">\s*Elixir\s*</h1>\s*<h2 class="sidebar-projectVersion">\s*v1.0.1\s*</h2>\s*</div>\s*</a>}
+    end
+  end
+
+  describe "list_page" do
+    test "enables nav link when module type have at least one element" do
+      names = [CompiledWithDocs, CompiledWithDocs.Nested]
+      modules = ExDoc.Retriever.docs_from_modules(names, doc_config())
+
+      content =
+        Templates.sidebar_template(doc_config(), %{
+          modules: modules,
+          exceptions: [],
+          protocols: [],
+          tasks: []
+        })
+
+      assert content =~ ~r{<li><a id="modules-list" href="#full-list">Modules</a></li>}
+      refute content =~ ~r{<li><a id="exceptions-list" href="#full-list">Exceptions</a></li>}
+      refute content =~ ~r{<li><a id="protocols-list" href="#full-list">Protocols</a></li>}
+    end
+
+    test "outputs listing for the given nodes" do
+      names = [CompiledWithDocs, CompiledWithDocs.Nested]
+      nodes = ExDoc.Retriever.docs_from_modules(names, doc_config())
+      content = Templates.create_sidebar_items(%{modules: nodes}, [])
+
+      assert content =~ ~r("modules":\[\{"id":"CompiledWithDocs","title":"CompiledWithDocs")ms
+      assert content =~ ~r("id":"CompiledWithDocs".*"functions":.*"example/2")ms
+      assert content =~ ~r("id":"CompiledWithDocs".*"functions":.*"example_without_docs/0")ms
+      assert content =~ ~r("id":"CompiledWithDocs.Nested")ms
+    end
+
+    test "outputs groups for the given nodes" do
+      names = [CompiledWithDocs, CompiledWithDocs.Nested]
+      group_mapping = [groups_for_modules: [Group: [CompiledWithDocs]]]
+      nodes = ExDoc.Retriever.docs_from_modules(names, doc_config(group_mapping))
+      content = Templates.create_sidebar_items(%{modules: nodes}, [])
+
+      assert content =~ ~r("id":"CompiledWithDocs","title":"CompiledWithDocs","group":"Group")ms
+    end
+  end
+
+  ## MODULES
+  describe "module_page" do
+    test "outputs the functions and docstrings" do
+      content = get_module_page([CompiledWithDocs])
+
+      # Title and headers
+      assert content =~ ~r{<title>CompiledWithDocs [^<]*</title>}
+
+      assert content =~
+               ~r{<h1>\s*<small class="visible-xs">Elixir v1.0.1</small>\s*CompiledWithDocs\s*}
+
+      refute content =~ ~r{<small>module</small>}
+
+      assert content =~
+               ~r{moduledoc.*Example.*<span class="nc">CompiledWithDocs</span><span class="o">\.</span><span class="n">example</span>.*}ms
+
+      assert content =~
+               ~r{<h2 id="module-example-unicode-escaping" class="section-heading">.*<a href="#module-example-unicode-escaping" class="hover-link">.*<span class="icon-link" aria-hidden="true"></span>.*</a>.*Example.*</h2>}ms
+
+      assert content =~
+               ~r{<h3 id="module-example-h3-heading" class="section-heading">.*<a href="#module-example-h3-heading" class="hover-link">.*<span class="icon-link" aria-hidden="true"></span>.*</a>.*Example H3 heading.*</h3>}ms
+
+      # Summaries
+      assert content =~ ~r{example/2.*Some example}ms
+      assert content =~ ~r{example_without_docs/0.*<section class="docstring">.*</section>}ms
+      assert content =~ ~r{example_1/0.*<span class="note">\(macro\)</span>}ms
+
+      # Source
+      assert content =~
+               ~r{<a href="#{source_url()}/blob/master/test/fixtures/compiled_with_docs.ex#L14"[^>]*>\s*<span class="icon-code" aria-hidden="true"></span>\s*<span class="sr-only">View Source</span>\s*</a>}ms
+
+      # Functions
+      assert content =~ ~s{<div class="detail" id="example/2">}
+      assert content =~ ~s{<span id="example/1"></span>}
+      assert content =~ ~s{example(foo, bar \\\\ Baz)}
+
+      assert content =~
+               ~r{<a href="#example/2" class="detail-link" title="Link to this function">\s*<span class="icon-link" aria-hidden="true"></span>\s*<span class="sr-only">Link to this function</span>\s*</a>}ms
+    end
+
+    test "outputs deprecation information" do
+      content = get_module_page([CompiledWithDocs])
+
+      assert content =~
+               ~s{<span class="deprecated" title="Use something else instead">deprecated</span>}
+
+      assert content =~
+               ~r{<div class="deprecated">\s*This function is deprecated. Use something else instead.}
+    end
+
+    test "outputs the types and function specs" do
+      content = get_module_page([TypesAndSpecs, TypesAndSpecs.Sub])
+      any = ~s[<a href="https://hexdocs.pm/elixir/typespecs.html#basic-types">any</a>()]
+      integer = ~s[<a href="https://hexdocs.pm/elixir/typespecs.html#basic-types">integer</a>()]
+
+      public_html =
+        ~S[public(t) :: {t, ] <>
+          ~s[<a href="https://hexdocs.pm/elixir/String.html#t:t/0">String.t</a>(), ] <>
+          ~S[<a href="TypesAndSpecs.Sub.html#t:t/0">TypesAndSpecs.Sub.t</a>(), ] <>
+          ~S[<a href="#t:opaque/0">opaque</a>(), :ok | :error}]
+
+      ref_html =
+        ~s[ref() :: {<a href="http://www.erlang.org/doc/man/binary.html#type-part">:binary.part</a>(), <a href="#t:public/1">public</a>(#{
+          any
+        })}]
+
+      assert content =~ ~s[<a href="#t:public/1">public(t)</a>]
+      refute content =~ ~s[<a href="#t:private/0">private</a>]
+      assert content =~ public_html
+      assert content =~ ref_html
+      refute content =~ ~s[<strong>private\(t\)]
+      assert content =~ ~s[A public type]
+      assert content =~ ~s[add(#{integer}, <a href="#t:opaque/0">opaque</a>()) :: #{integer}]
+      refute content =~ ~s[minus(#{integer}, #{integer}) :: #{integer}]
+
+      assert content =~
+               ~s[Basic type: <a href=\"https://hexdocs.pm/elixir/typespecs.html#basic-types\"><code class=\"inline\">atom/0</code></a>.]
+
+      assert content =~
+               ~s[Special form: <a href=\"https://hexdocs.pm/elixir/Kernel.SpecialForms.html#import/2\"><code class=\"inline\">import/2</code></a>.]
+
+      assert content =~ ~r{opaque/0.*<span class="note">\(opaque\)</span>}ms
+    end
+
+    test "outputs summaries" do
+      content = get_module_page([CompiledWithDocs])
+      assert content =~ ~r{<div class="summary-signature">\s*<a href="#example_1/0">}
+    end
+
+    test "contains links to summary sections when those exist" do
+      content = get_module_page([CompiledWithDocs, CompiledWithDocs.Nested])
+      refute content =~ ~r{types}
+    end
+
+    ## BEHAVIOURS
+
+    test "outputs behavior and callbacks" do
+      content = get_module_page([CustomBehaviourOne])
+
+      assert content =~
+               ~r{<h1>\s*<small class="visible-xs">Elixir v1.0.1</small>\s*CustomBehaviourOne\s*<small>behaviour</small>}m
+
+      assert content =~ ~r{Callbacks}
+      assert content =~ ~r{<div class="detail" id="c:hello/1">}
+      assert content =~ ~s[hello(integer)]
+      assert content =~ ~s[greet(arg0)]
+
+      content = get_module_page([CustomBehaviourTwo])
+
+      assert content =~
+               ~r{<h1>\s*<small class="visible-xs">Elixir v1.0.1</small>\s*CustomBehaviourTwo\s*<small>behaviour</small>\s*}m
+
+      assert content =~ ~r{Callbacks}
+      assert content =~ ~r{<div class="detail" id="c:bye/1">}
+    end
+
+    ## PROTOCOLS
+
+    test "outputs the protocol type" do
+      content = get_module_page([CustomProtocol])
+
+      assert content =~
+               ~r{<h1>\s*<small class="visible-xs">Elixir v1.0.1</small>\s*CustomProtocol\s*<small>protocol</small>\s*}m
+    end
+
+    ## TASKS
+
+    test "outputs the task type" do
+      content = get_module_page([Mix.Tasks.TaskWithDocs])
+
+      assert content =~
+               ~r{<h1>\s*<small class="visible-xs">Elixir v1.0.1</small>\s*mix task_with_docs\s*}m
+    end
   end
 
   test "<h3> tags in method `@doc`s are linked" do
     content = get_module_page([CompiledWithDocs])
-    assert content =~ ~r{<h3 id="example_with_h3/0-examples" class="section-heading">.*<a href="#example_with_h3/0-examples" class="hover-link">.*<span class="icon-link" aria-hidden="true"></span>.*</a>.*Examples.*</h3>}ms
-  end
 
-  ## LISTING
-
-  test "site title text links to homepage_url when set" do
-    content = Templates.sidebar_template(doc_config(), @empty_nodes_map)
-    assert content =~ ~r{<a href="#{homepage_url()}" class="sidebar-projectLink">\s*<div class="sidebar-projectDetails">\s*<h1 class="sidebar-projectName">\s*Elixir\s*</h1>\s*<h2 class="sidebar-projectVersion">\s*v1.0.1\s*</h2>\s*</div>\s*</a>}
-  end
-
-  test "site title text links to main when there is no homepage_url" do
-    config = %ExDoc.Config{project: "Elixir", version: "1.0.1",
-                           source_root: File.cwd!, main: "hello",}
-    content = Templates.sidebar_template(config, @empty_nodes_map)
-    assert content =~ ~r{<a href="hello.html" class="sidebar-projectLink">\s*<div class="sidebar-projectDetails">\s*<h1 class="sidebar-projectName">\s*Elixir\s*</h1>\s*<h2 class="sidebar-projectVersion">\s*v1.0.1\s*</h2>\s*</div>\s*</a>}
-  end
-
-  test "list_page enables nav link when module type have at least one element" do
-    names = [CompiledWithDocs, CompiledWithDocs.Nested]
-    modules = ExDoc.Retriever.docs_from_modules(names, doc_config())
-
-    content = Templates.sidebar_template(doc_config(), %{modules: modules, exceptions: [], protocols: [], tasks: []})
-    assert content =~ ~r{<li><a id="modules-list" href="#full-list">Modules</a></li>}
-    refute content =~ ~r{<li><a id="exceptions-list" href="#full-list">Exceptions</a></li>}
-    refute content =~ ~r{<li><a id="protocols-list" href="#full-list">Protocols</a></li>}
-  end
-
-  test "list_page outputs listing for the given nodes" do
-    names = [CompiledWithDocs, CompiledWithDocs.Nested]
-    nodes = ExDoc.Retriever.docs_from_modules(names, doc_config())
-    content = Templates.create_sidebar_items(%{modules: nodes}, [])
-
-    assert content =~ ~r("modules":\[\{"id":"CompiledWithDocs","title":"CompiledWithDocs")ms
-    assert content =~ ~r("id":"CompiledWithDocs".*"functions":.*"example/2")ms
-    assert content =~ ~r("id":"CompiledWithDocs".*"functions":.*"example_without_docs/0")ms
-    assert content =~ ~r("id":"CompiledWithDocs.Nested")ms
-  end
-
-  test "list_page outputs groups for the given nodes" do
-    names = [CompiledWithDocs, CompiledWithDocs.Nested]
-    group_mapping = [groups_for_modules: ["Group": [CompiledWithDocs]]]
-    nodes = ExDoc.Retriever.docs_from_modules(names, doc_config(group_mapping))
-    content = Templates.create_sidebar_items(%{modules: nodes}, [])
-
-    assert content =~ ~r("id":"CompiledWithDocs","title":"CompiledWithDocs","group":"Group")ms
-  end
-
-  ## MODULES
-
-  test "module_page outputs the functions and docstrings" do
-    content = get_module_page([CompiledWithDocs])
-
-    # Title and headers
-    assert content =~ ~r{<title>CompiledWithDocs [^<]*</title>}
-    assert content =~ ~r{<h1>\s*<small class="visible-xs">Elixir v1.0.1</small>\s*CompiledWithDocs\s*}
-    refute content =~ ~r{<small>module</small>}
-    assert content =~ ~r{moduledoc.*Example.*<span class="nc">CompiledWithDocs</span><span class="o">\.</span><span class="n">example</span>.*}ms
-    assert content =~ ~r{<h2 id="module-example-unicode-escaping" class="section-heading">.*<a href="#module-example-unicode-escaping" class="hover-link">.*<span class="icon-link" aria-hidden="true"></span>.*</a>.*Example.*</h2>}ms
-    assert content =~ ~r{<h3 id="module-example-h3-heading" class="section-heading">.*<a href="#module-example-h3-heading" class="hover-link">.*<span class="icon-link" aria-hidden="true"></span>.*</a>.*Example H3 heading.*</h3>}ms
-
-    # Summaries
-    assert content =~ ~r{example/2.*Some example}ms
-    assert content =~ ~r{example_without_docs/0.*<section class="docstring">.*</section>}ms
-    assert content =~ ~r{example_1/0.*<span class="note">\(macro\)</span>}ms
-
-    # Source
-    assert content =~ ~r{<a href="#{source_url()}/blob/master/test/fixtures/compiled_with_docs.ex#L14"[^>]*>\s*<span class="icon-code" aria-hidden="true"></span>\s*<span class="sr-only">View Source</span>\s*</a>}ms
-
-    # Functions
-    assert content =~ ~s{<div class="detail" id="example/2">}
-    assert content =~ ~s{<span id="example/1"></span>}
-    assert content =~ ~s{example(foo, bar \\\\ Baz)}
-    assert content =~ ~r{<a href="#example/2" class="detail-link" title="Link to this function">\s*<span class="icon-link" aria-hidden="true"></span>\s*<span class="sr-only">Link to this function</span>\s*</a>}ms
-  end
-
-  test "module_page outputs deprecation information" do
-    content = get_module_page([CompiledWithDocs])
-    assert content =~ ~s{<span class="deprecated" title="Use something else instead">deprecated</span>}
-    assert content =~ ~r{<div class="deprecated">\s*This function is deprecated. Use something else instead.}
-  end
-
-  test "module_page outputs the types and function specs" do
-    content = get_module_page([TypesAndSpecs, TypesAndSpecs.Sub])
-    any = ~s[<a href="https://hexdocs.pm/elixir/typespecs.html#basic-types">any</a>()]
-    integer = ~s[<a href="https://hexdocs.pm/elixir/typespecs.html#basic-types">integer</a>()]
-
-    public_html =
-      ~S[public(t) :: {t, ] <>
-      ~s[<a href="https://hexdocs.pm/elixir/String.html#t:t/0">String.t</a>(), ] <>
-      ~S[<a href="TypesAndSpecs.Sub.html#t:t/0">TypesAndSpecs.Sub.t</a>(), ] <>
-      ~S[<a href="#t:opaque/0">opaque</a>(), :ok | :error}]
-
-    ref_html = ~s[ref() :: {<a href="http://www.erlang.org/doc/man/binary.html#type-part">:binary.part</a>(), <a href="#t:public/1">public</a>(#{any})}]
-
-    assert content =~ ~s[<a href="#t:public/1">public(t)</a>]
-    refute content =~ ~s[<a href="#t:private/0">private</a>]
-    assert content =~ public_html
-    assert content =~ ref_html
-    refute content =~ ~s[<strong>private\(t\)]
-    assert content =~ ~s[A public type]
-    assert content =~ ~s[add(#{integer}, <a href="#t:opaque/0">opaque</a>()) :: #{integer}]
-    refute content =~ ~s[minus(#{integer}, #{integer}) :: #{integer}]
-    assert content =~ ~s[Basic type: <a href=\"https://hexdocs.pm/elixir/typespecs.html#basic-types\"><code class=\"inline\">atom/0</code></a>.]
-    assert content =~ ~s[Special form: <a href=\"https://hexdocs.pm/elixir/Kernel.SpecialForms.html#import/2\"><code class=\"inline\">import/2</code></a>.]
-    assert content =~ ~r{opaque/0.*<span class="note">\(opaque\)</span>}ms
-  end
-
-  test "module_page outputs summaries" do
-    content = get_module_page([CompiledWithDocs])
-    assert content =~ ~r{<div class="summary-signature">\s*<a href="#example_1/0">}
-  end
-
-  test "module_page contains links to summary sections when those exist" do
-    content = get_module_page([CompiledWithDocs, CompiledWithDocs.Nested])
-    refute content =~ ~r{types}
-  end
-
-  ## BEHAVIOURS
-
-  test "module_page outputs behavior and callbacks" do
-    content = get_module_page([CustomBehaviourOne])
-    assert content =~ ~r{<h1>\s*<small class="visible-xs">Elixir v1.0.1</small>\s*CustomBehaviourOne\s*<small>behaviour</small>}m
-    assert content =~ ~r{Callbacks}
-    assert content =~ ~r{<div class="detail" id="c:hello/1">}
-    assert content =~ ~s[hello(integer)]
-    assert content =~ ~s[greet(arg0)]
-
-    content = get_module_page([CustomBehaviourTwo])
-    assert content =~ ~r{<h1>\s*<small class="visible-xs">Elixir v1.0.1</small>\s*CustomBehaviourTwo\s*<small>behaviour</small>\s*}m
-    assert content =~ ~r{Callbacks}
-    assert content =~ ~r{<div class="detail" id="c:bye/1">}
-  end
-
-  ## PROTOCOLS
-
-  test "module_page outputs the protocol type" do
-    content = get_module_page([CustomProtocol])
-    assert content =~ ~r{<h1>\s*<small class="visible-xs">Elixir v1.0.1</small>\s*CustomProtocol\s*<small>protocol</small>\s*}m
-  end
-
-  ## TASKS
-
-  test "module_page outputs the task type" do
-    content = get_module_page([Mix.Tasks.TaskWithDocs])
-    assert content =~ ~r{<h1>\s*<small class="visible-xs">Elixir v1.0.1</small>\s*mix task_with_docs\s*}m
+    assert content =~
+             ~r{<h3 id="example_with_h3/0-examples" class="section-heading">.*<a href="#example_with_h3/0-examples" class="hover-link">.*<span class="icon-link" aria-hidden="true"></span>.*</a>.*Examples.*</h3>}ms
   end
 end


### PR DESCRIPTION
Refactoring template tests (under` test/**/templates_test.exs`).

Two things were done:
  * Describe blocks were added - the tests starting with the same prefix were grouped, using describe blocks.
  * The code is now formatted with the help of the code formatter.

Changes related to this [issue](https://github.com/elixir-lang/ex_doc/issues/868).