### PR TITLE
Allow apps to be excluded from umbrella app docs

### DIFF
--- a/lib/ex_doc/config.ex
+++ b/lib/ex_doc/config.ex
@@ -40,8 +40,7 @@ defmodule ExDoc.Config do
             source_url: nil,
             source_url_pattern: nil,
             title: nil,
-            version: nil,
-            ignored_apps: []
+            version: nil
 
   @type t :: %__MODULE__{
           assets: nil | String.t(),
@@ -69,7 +68,6 @@ defmodule ExDoc.Config do
           source_url: nil | String.t(),
           source_url_pattern: nil | String.t(),
           title: nil | String.t(),
-          version: nil | String.t(),
-          ignored_apps: list()
+          version: nil | String.t()
         }
 end

--- a/lib/ex_doc/config.ex
+++ b/lib/ex_doc/config.ex
@@ -40,7 +40,8 @@ defmodule ExDoc.Config do
             source_url: nil,
             source_url_pattern: nil,
             title: nil,
-            version: nil
+            version: nil,
+            ignored_apps: []
 
   @type t :: %__MODULE__{
           assets: nil | String.t(),
@@ -68,6 +69,7 @@ defmodule ExDoc.Config do
           source_url: nil | String.t(),
           source_url_pattern: nil | String.t(),
           title: nil | String.t(),
-          version: nil | String.t()
+          version: nil | String.t(),
+          ignored_apps: list()
         }
 end

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -264,10 +264,9 @@ defmodule Mix.Tasks.Docs do
   defp umbrella_compile_paths(ignored_apps) do
     build = Mix.Project.build_path()
 
-    for {app, _} <- Mix.Project.apps_paths() do
-      unless(Enum.member?(ignored_apps, app)) do
-        Path.join([build, "lib", Atom.to_string(app), "ebin"])
-      end
+    for {app, _} <- Mix.Project.apps_paths(),
+        app not in ignored_apps do
+      Path.join([build, "lib", Atom.to_string(app), "ebin"])
     end
   end
 

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -161,13 +161,12 @@ defmodule Mix.Tasks.Docs do
   ## Umbrella project
 
   ExDoc can be used in an umbrella project and generates a single documentation
-  for all child apps.
+  for all child apps. You can use the `:ignore_apps` configuration to exclude
+  certain projects in the umbrella from documentation.
 
   Generating documentation per each child app can be achieved by running:
 
       mix cmd mix docs
-
-  As said, ignoring documentation for nested projects can be achieved by utilizing the `:ignore_apps` configuration.
 
   See `mix help cmd` for more information.
   """

--- a/test/mix/tasks/docs_test.exs
+++ b/test/mix/tasks/docs_test.exs
@@ -111,7 +111,7 @@ defmodule Mix.Tasks.DocsTest do
     end)
   end
 
-  test "supports umbrella project with ignored_apps" do
+  test "supports umbrella project with ignore_apps" do
     Mix.Project.in_project(:umbrella, "test/fixtures/umbrella", fn _mod ->
       [
         {"umbrella", "dev",
@@ -119,9 +119,9 @@ defmodule Mix.Tasks.DocsTest do
            formatter: "html",
            deps: _,
            source_beam: _,
-           ignored_apps: ["foo"]
+           ignore_apps: [:foo]
          ]}
-      ] = run([], app: :umbrella, apps_path: "apps/", docs: [ignored_apps: ["foo"]])
+      ] = run([], app: :umbrella, apps_path: "apps/", docs: [ignore_apps: [:foo]])
     end)
   end
 end

--- a/test/mix/tasks/docs_test.exs
+++ b/test/mix/tasks/docs_test.exs
@@ -11,80 +11,117 @@ defmodule Mix.Tasks.DocsTest do
 
   test "inflects values from app and version" do
     assert [{"ex_doc", "0.1.0", [formatter: "html", deps: _, source_beam: _]}] =
-           run([], [app: :ex_doc, version: "0.1.0"])
+             run([], app: :ex_doc, version: "0.1.0")
   end
 
   test "accepts multiple formatters from CLI" do
-    assert [{"ex_doc", "0.1.0", [formatter: "html", deps: _, source_beam: _]},
-            {"ex_doc", "0.1.0", [formatter: "epub", deps: _, source_beam: _]}] =
-           run(["-f", "html", "-f", "epub"], [app: :ex_doc, version: "0.1.0"])
+    assert [
+             {"ex_doc", "0.1.0", [formatter: "html", deps: _, source_beam: _]},
+             {"ex_doc", "0.1.0", [formatter: "epub", deps: _, source_beam: _]}
+           ] = run(["-f", "html", "-f", "epub"], app: :ex_doc, version: "0.1.0")
   end
 
   test "accepts multiple formatters from config" do
-    assert [{"ex_doc", "0.1.0", [formatter: "html", deps: _, source_beam: _, formatters: _]},
-            {"ex_doc", "0.1.0", [formatter: "epub", deps: _, source_beam: _, formatters: _]}] =
-           run([], [app: :ex_doc, version: "0.1.0", docs: [formatters: ["html", "epub"]]])
+    assert [
+             {"ex_doc", "0.1.0", [formatter: "html", deps: _, source_beam: _, formatters: _]},
+             {"ex_doc", "0.1.0", [formatter: "epub", deps: _, source_beam: _, formatters: _]}
+           ] = run([], app: :ex_doc, version: "0.1.0", docs: [formatters: ["html", "epub"]])
   end
 
   test "uses the given name" do
     assert [{"ExDoc", "0.1.0", [formatter: "html", deps: _, source_beam: _]}] =
-           run([], [app: :ex_doc, version: "0.1.0", name: "ExDoc"])
+             run([], app: :ex_doc, version: "0.1.0", name: "ExDoc")
   end
 
   test "accepts modules in :main" do
-    assert [{"ex_doc", "dev", [formatter: "html", deps: _, main: "Sample", source_beam: _, ]}] =
-           run([], [app: :ex_doc, docs: [main: Sample]])
+    assert [{"ex_doc", "dev", [formatter: "html", deps: _, main: "Sample", source_beam: _]}] =
+             run([], app: :ex_doc, docs: [main: Sample])
   end
 
   test "accepts files in :main" do
     assert [{"ex_doc", "dev", [formatter: "html", deps: _, source_beam: _, main: "another"]}] =
-           run([], [app: :ex_doc, docs: [main: "another"]])
+             run([], app: :ex_doc, docs: [main: "another"])
   end
 
   test "accepts output in :output" do
     assert [{"ex_doc", "dev", [formatter: "html", deps: _, source_beam: _, output: "hello"]}] =
-           run([], [app: :ex_doc, docs: [output: "hello"]])
+             run([], app: :ex_doc, docs: [output: "hello"])
   end
 
   test "parses output with lower preference than options" do
     assert [{"ex_doc", "dev", [formatter: "html", deps: _, source_beam: _, output: "world"]}] =
-           run(~w(-o world), [app: :ex_doc, docs: [output: "world"]])
+             run(~w(-o world), app: :ex_doc, docs: [output: "world"])
   end
 
   test "includes dependencies" do
     assert [{"ex_doc", "dev", [formatter: "html", deps: deps, source_beam: _]}] =
-           run([], [app: :ex_doc, docs: []])
+             run([], app: :ex_doc, docs: [])
+
     assert List.keyfind(deps, Application.app_dir(:earmark), 0) ==
-           {Application.app_dir(:earmark), "https://hexdocs.pm/earmark/#{Application.spec(:earmark, :vsn)}/"}
+             {Application.app_dir(:earmark),
+              "https://hexdocs.pm/earmark/#{Application.spec(:earmark, :vsn)}/"}
   end
 
   test "allows custom dependency paths" do
     assert [{"ex_doc", "dev", [formatter: "html", deps: deps, source_beam: _]}] =
-           run([], [app: :ex_doc, docs: [deps: [earmark: "foo"]]])
+             run([], app: :ex_doc, docs: [deps: [earmark: "foo"]])
+
     assert List.keyfind(deps, Application.app_dir(:earmark), 0) ==
-           {Application.app_dir(:earmark), "foo"}
+             {Application.app_dir(:earmark), "foo"}
   end
 
   test "accepts lazy docs" do
     assert [{"ex_doc", "dev", [formatter: "html", deps: _, source_beam: _, main: "another"]}] =
-           run([], [app: :ex_doc, docs: fn -> [main: "another"] end])
+             run([], app: :ex_doc, docs: fn -> [main: "another"] end)
   end
 
   test "accepts options from root" do
     # accepted options are: `app`, `name`, `source_url`, `homepage_url`, `version`
-    assert [{"ExDoc", "1.2.3-dev",
-             [formatter: "html",
-              deps: _, source_beam: _,
-              homepage_url: "http://elixir-lang.org",
-              source_url: "https://github.com/elixir-lang/ex_doc",
-              ]}] =
-           run([], [app: :ex_doc,
-                    name: "ExDoc",
-                    source_url: "https://github.com/elixir-lang/ex_doc",
-                    homepage_url: "http://elixir-lang.org",
-                    version: "1.2.3-dev",
-                   ])
+    assert [
+             {"ExDoc", "1.2.3-dev",
+              [
+                formatter: "html",
+                deps: _,
+                source_beam: _,
+                homepage_url: "http://elixir-lang.org",
+                source_url: "https://github.com/elixir-lang/ex_doc"
+              ]}
+           ] =
+             run([],
+               app: :ex_doc,
+               name: "ExDoc",
+               source_url: "https://github.com/elixir-lang/ex_doc",
+               homepage_url: "http://elixir-lang.org",
+               version: "1.2.3-dev"
+             )
 
-    assert [{"ex_doc", "dev", _}] = run([], [app: :ex_doc])
+    assert [{"ex_doc", "dev", _}] = run([], app: :ex_doc)
+  end
+
+  test "supports umbrella project" do
+    Mix.Project.in_project(:umbrella, "test/fixtures/umbrella", fn _mod ->
+      [
+        {"umbrella", "dev",
+         [
+           formatter: "html",
+           deps: _,
+           source_beam: _
+         ]}
+      ] = run([], app: :umbrella, apps_path: "apps/", docs: [])
+    end)
+  end
+
+  test "supports umbrella project with ignored_apps" do
+    Mix.Project.in_project(:umbrella, "test/fixtures/umbrella", fn _mod ->
+      [
+        {"umbrella", "dev",
+         [
+           formatter: "html",
+           deps: _,
+           source_beam: _,
+           ignored_apps: ["foo"]
+         ]}
+      ] = run([], app: :umbrella, apps_path: "apps/", docs: [ignored_apps: ["foo"]])
+    end)
   end
 end


### PR DESCRIPTION
Allowing to exclude docs from umbrella app docs utilizing `ignored_apps: [your selected apps]`.

I also have created tests for umbrella projects and tests for this specific case.

This PR is related to this [issue](https://github.com/elixir-lang/ex_doc/issues/867).