### PR TITLE
Support SVG

### DIFF
--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -275,7 +275,7 @@ defmodule ExDoc.Formatter.HTML do
       |> Path.extname()
       |> String.downcase()
 
-    if extname in ~w(.png .jpg) do
+    if extname in ~w(.png .jpg .svg) do
       filename = Path.join(dir, "logo#{extname}")
       target = Path.join(output, filename)
       File.mkdir_p!(Path.dirname(target))


### PR DESCRIPTION
# Description

The HTML fortmater may now accept SVG format

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A
First add the .svg logo file path to `logo:`, like `logo: "priv/static/images/logo.svg"`
Run `mix docs`, and go to output location
You may see that the is behaving as any png and jpg, but svg is lighter and scalable