### PR TITLE
Pushing Earmark dependency to 1.2.5

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule ExDoc.Mixfile do
 
   defp deps do
     [
-      {:earmark, "~> 1.1"},
+      {:earmark, "~> 1.2.5"},
       {:makeup_elixir, "~> 0.7"},
       {:cmark, "~> 0.5", only: :test},
       {:excoveralls, "~> 0.3", only: :test}

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule ExDoc.Mixfile do
 
   defp deps do
     [
-      {:earmark, "~> 1.2.5"},
+      {:earmark, "~> 1.2"},
       {:makeup_elixir, "~> 0.7"},
       {:cmark, "~> 0.5", only: :test},
       {:excoveralls, "~> 0.3", only: :test}


### PR DESCRIPTION
Not sure this is useful, but I saw some warning and given that 1.7 is out it might be a good idea to force a modern version of `Earmark`.