### PR TITLE
Remove stale references to hoedown

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,5 +141,4 @@ Check the [LICENSE](LICENSE) file for more information.
 [elixir-lang]: http://elixir-lang.org/
 [cmark]: https://github.com/jgm/cmark
 [cmark.ex]: https://github.com/asaaki/cmark.ex
-[devinus/markdown]: http://github.com/devinus/markdown
 [hex-writing-docs]: https://hexdocs.pm/elixir/writing-documentation.html

--- a/lib/ex_doc/markdown.ex
+++ b/lib/ex_doc/markdown.ex
@@ -159,9 +159,6 @@ defmodule ExDoc.Markdown do
     * Add {:earmark, ">= 0.0.0"} to your mix.exs deps
       to use an Elixir-based markdown processor
 
-    * Add {:markdown, github: "devinus/markdown"} to your mix.exs deps
-      to use a C-based markdown processor
-
     * Add {:cmark, ">= 0.5"} to your mix.exs deps
       to use another C-based markdown processor
     """

--- a/lib/ex_doc/markdown.ex
+++ b/lib/ex_doc/markdown.ex
@@ -102,7 +102,6 @@ defmodule ExDoc.Markdown do
   @callback configure(any) :: :ok
 
   @markdown_processors [
-    ExDoc.Markdown.Hoedown,
     ExDoc.Markdown.Earmark,
     ExDoc.Markdown.Cmark
   ]

--- a/mix.lock
+++ b/mix.lock
@@ -9,7 +9,6 @@
   "jsx": {:hex, :jsx, "2.8.2", "7acc7d785b5abe8a6e9adbde926a24e481f29956dd8b4df49e3e4e7bcc92a018", [:mix, :rebar3], [], "hexpm"},
   "makeup": {:hex, :makeup, "0.5.1", "966c5c2296da272d42f1de178c1d135e432662eca795d6dc12e5e8787514edf7", [:mix], [{:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.8.0", "1204a2f5b4f181775a0e456154830524cf2207cf4f9112215c05e0b76e4eca8b", [:mix], [{:makeup, "~> 0.5.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "markdown": {:git, "https://github.com/devinus/markdown.git", "d065dbcc4e242a85ca2516fdadd0082712871fd8", []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.2.2", "d526b23bdceb04c7ad15b33c57c4526bf5f50aaa70c7c141b4b4624555c68259", [:mix], [], "hexpm"},


### PR DESCRIPTION
This includes the remaining references to devinus/markdown,
which was a hoedown dependency.

Built-in hoedown support was removed in 0.18.0 (56829970).