### PR TITLE
add :api_reference option

### DIFF
--- a/lib/ex_doc/config.ex
+++ b/lib/ex_doc/config.ex
@@ -15,7 +15,8 @@ defmodule ExDoc.Config do
   def before_closing_head_tag(_), do: ""
   def before_closing_body_tag(_), do: ""
 
-  defstruct assets: nil,
+  defstruct api_reference: true,
+            assets: nil,
             before_closing_head_tag: &__MODULE__.before_closing_head_tag/1,
             before_closing_body_tag: &__MODULE__.before_closing_body_tag/1,
             canonical: nil,
@@ -43,6 +44,7 @@ defmodule ExDoc.Config do
             version: nil
 
   @type t :: %__MODULE__{
+          api_reference: boolean(),
           assets: nil | String.t(),
           before_closing_head_tag: (atom() -> String.t()),
           before_closing_body_tag: (atom() -> String.t()),

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -28,10 +28,15 @@ defmodule ExDoc.Formatter.HTML do
       tasks: filter_list(:task, linked)
     }
 
-    extras = [
-      build_api_reference(nodes_map, config)
-      | build_extras(config, autolink)
-    ]
+    extras =
+      if config.api_reference do
+        [
+          build_api_reference(nodes_map, config)
+          | build_extras(config, autolink)
+        ]
+      else
+        build_extras(config, autolink)
+      end
 
     assets_dir = "assets"
     static_files = generate_assets(config, assets_dir, default_assets(config))

--- a/lib/ex_doc/formatter/html/templates/not_found_template.eex
+++ b/lib/ex_doc/formatter/html/templates/not_found_template.eex
@@ -4,8 +4,10 @@
 <h2>Page not found</h2>
 
 <p>Sorry, but the page you were trying to get to, does not exist. You
-may want to try searching this site using the sidebar or using our
-<a href="api-reference.html" title="API Reference">API Reference</a> page to find what
-you were looking for.</p>
+may want to try searching this site using the sidebar
+<%= if config.api_reference do %>
+  or using our <a href="api-reference.html" title="API Reference">API Reference</a> page
+<% end %>
+to find what you were looking for.</p>
 
 <%= footer_template(config) %>

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -47,6 +47,9 @@ defmodule Mix.Tasks.Docs do
   be a keyword list or a function returning a keyword list that will
   be lazily executed.
 
+    * `:api_reference` - Whether to generate `api-reference.html`; default: `true`.
+      If this is set to false, `:main` must also be set.
+
     * `:assets` - Path to a directory that will be copied as is to the "assets"
       directory in the output path. Its entries may be referenced in your docs
       under "assets/ASSET.EXTENSION"; defaults to no assets directory.
@@ -112,7 +115,7 @@ defmodule Mix.Tasks.Docs do
     * `:output` - Output directory for the generated docs; default: "doc".
       May be overridden by command line argument.
 
-    *`:ignore_apps` - Apps to be ignored when generating documentation in an umbrella project.
+    * `:ignore_apps` - Apps to be ignored when generating documentation in an umbrella project.
       Receives a list of atoms. Example: `[:first_app, :second_app]`.
 
   ## Groups

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -341,6 +341,27 @@ defmodule ExDoc.Formatter.HTMLTest do
       content = read_wildcard!("#{output_dir()}/dist/sidebar_items-*.js")
       assert content =~ ~r{"id":"extrapage","title":"Extra Page Title"}
     end
+
+    test "with api-reference" do
+      generate_docs(doc_config())
+      content = File.read!("#{output_dir()}/api-reference.html")
+      assert content =~ ~r{<title>API Reference – Elixir v1.0.1</title>}
+      content = read_wildcard!("#{output_dir()}/dist/sidebar_items-*.js")
+      assert content =~ ~r{"id":"api-reference","title":"API Reference"}
+    end
+
+    test "without api-reference" do
+      generate_docs(
+        doc_config(api_reference: false, extras: ["test/fixtures/README.md"], main: "readme")
+      )
+
+      assert_raise File.Error, fn ->
+        File.read!("#{output_dir()}/api-reference.html")
+      end
+
+      content = read_wildcard!("#{output_dir()}/dist/sidebar_items-*.js")
+      refute content =~ ~r{"id":"api-reference","title":"API Reference"}
+    end
   end
 
   describe ".build" do


### PR DESCRIPTION
Resolves #898 

This PR adds an option, `:api_reference`, allowing the page `api-reference.html` to be disabled. It defaults to `true`, which is consistent with existing behavior.

When set to false, `build_api_reference/2` is not called when generating the list of extras, and the text `or using our <a href="api-reference.html" title="API Reference">API Reference</a> page` is not included in `404.html`.