### PR TITLE
Sort function names alphabetically in the sidebar

### DIFF
--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -129,7 +129,7 @@ defmodule ExDoc.Retriever do
       type: module_data.type,
       deprecated: metadata[:deprecated],
       function_groups: function_groups,
-      docs: Enum.sort_by(docs, & &1.id),
+      docs: Enum.sort_by(docs, &{&1.name, &1.id}),
       doc: moduledoc,
       doc_line: doc_line,
       typespecs: Enum.sort_by(types, & &1.id),


### PR DESCRIPTION
`ExDoc.FunctionNode`'s `:id` is composed of the function name, a slash, and the function arity. For example: `name/0`.

`ExDoc.ModuleNode` is sorting the functions alphabetically based on that `:id`, but it doesn't take into account that `"/" >= "!" == true`. That means that `fetch!/2` is displayed before `fetch/2`.

This is a regression from previous docs (check order of `fetch` and `fetch!`): [Elixir v1.6 `Map`](https://hexdocs.pm/elixir/1.6/Map.html#fetch/2), [Elixir v1.7.3 `Map`](https://hexdocs.pm/elixir/Map.html#fetch!/2)