### PR TITLE
Warn on undefined remote functions from project's docs

### DIFF
--- a/lib/ex_doc/config.ex
+++ b/lib/ex_doc/config.ex
@@ -42,7 +42,8 @@ defmodule ExDoc.Config do
             source_url: nil,
             source_url_pattern: nil,
             title: nil,
-            version: nil
+            version: nil,
+            warn_on_undefined_functions: false
 
   @type t :: %__MODULE__{
           api_reference: boolean(),
@@ -72,6 +73,7 @@ defmodule ExDoc.Config do
           source_url: nil | String.t(),
           source_url_pattern: nil | String.t(),
           title: nil | String.t(),
-          version: nil | String.t()
+          version: nil | String.t(),
+          warn_on_undefined_functions: boolean()
         }
 end

--- a/lib/ex_doc/config.ex
+++ b/lib/ex_doc/config.ex
@@ -43,7 +43,7 @@ defmodule ExDoc.Config do
             source_url_pattern: nil,
             title: nil,
             version: nil,
-            warn_on_undefined_functions: true
+            warn_on_undefined_references: true
 
   @type t :: %__MODULE__{
           api_reference: boolean(),
@@ -74,6 +74,6 @@ defmodule ExDoc.Config do
           source_url_pattern: nil | String.t(),
           title: nil | String.t(),
           version: nil | String.t(),
-          warn_on_undefined_functions: boolean()
+          warn_on_undefined_references: boolean()
         }
 end

--- a/lib/ex_doc/config.ex
+++ b/lib/ex_doc/config.ex
@@ -43,7 +43,7 @@ defmodule ExDoc.Config do
             source_url_pattern: nil,
             title: nil,
             version: nil,
-            warn_on_undefined_references: true
+            skip_undefined_reference_warnings_on: []
 
   @type t :: %__MODULE__{
           api_reference: boolean(),
@@ -74,6 +74,6 @@ defmodule ExDoc.Config do
           source_url_pattern: nil | String.t(),
           title: nil | String.t(),
           version: nil | String.t(),
-          warn_on_undefined_references: boolean()
+          skip_undefined_reference_warnings_on: [String.t()]
         }
 end

--- a/lib/ex_doc/config.ex
+++ b/lib/ex_doc/config.ex
@@ -43,7 +43,7 @@ defmodule ExDoc.Config do
             source_url_pattern: nil,
             title: nil,
             version: nil,
-            warn_on_undefined_functions: false
+            warn_on_undefined_functions: true
 
   @type t :: %__MODULE__{
           api_reference: boolean(),

--- a/lib/ex_doc/formatter/epub.ex
+++ b/lib/ex_doc/formatter/epub.ex
@@ -16,7 +16,7 @@ defmodule ExDoc.Formatter.EPUB do
     File.rm_rf!(config.output)
     File.mkdir_p!(Path.join(config.output, "OEBPS"))
 
-    autolink = HTML.Autolink.compile(project_nodes, ".xhtml", config.deps)
+    autolink = HTML.Autolink.compile(project_nodes, ".xhtml", config)
     linked = HTML.Autolink.all(project_nodes, autolink)
 
     nodes_map = %{

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -19,7 +19,7 @@ defmodule ExDoc.Formatter.HTML do
     build = Path.join(config.output, ".build")
     output_setup(build, config)
 
-    autolink = Autolink.compile(project_nodes, ".html", config.deps)
+    autolink = Autolink.compile(project_nodes, ".html", config)
     linked = Autolink.all(project_nodes, autolink)
 
     nodes_map = %{

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -213,7 +213,7 @@ defmodule ExDoc.Formatter.HTML do
       content =
         input
         |> File.read!()
-        |> Autolink.project_doc(nil, autolink)
+        |> Autolink.project_doc(id, autolink)
 
       group = GroupMatcher.match_extra(groups, input)
       html_content = Markdown.to_html(content, file: input, line: 1)

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -213,7 +213,7 @@ defmodule ExDoc.Formatter.HTML do
       content =
         input
         |> File.read!()
-        |> Autolink.project_doc(autolink)
+        |> Autolink.project_doc(nil, autolink)
 
       group = GroupMatcher.match_extra(groups, input)
       html_content = Markdown.to_html(content, file: input, line: 1)

--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -101,7 +101,7 @@ defmodule ExDoc.Formatter.HTML.Autolink do
       extension: extension,
       lib_dirs: lib_dirs,
       modules_refs: modules_refs,
-      warn_on_undefined_references: config.warn_on_undefined_references
+      skip_undefined_reference_warnings_on: config.skip_undefined_reference_warnings_on
     }
   end
 
@@ -429,6 +429,8 @@ defmodule ExDoc.Formatter.HTML.Autolink do
     locals = options[:locals] || []
     elixir_docs = get_elixir_docs(aliases, lib_dirs)
     id = options[:id]
+    module_id = options[:module_id]
+    skip_warnings_on = options[:skip_undefined_reference_warnings_on] || []
 
     fn all, text, match ->
       pmfa = {prefix, module, function, arity} = split_function(match)
@@ -454,8 +456,8 @@ defmodule ExDoc.Formatter.HTML.Autolink do
           "[#{text}](#{elixir_docs}Kernel.SpecialForms" <>
             "#{extension}##{prefix}#{enc_h(function)}/#{arity})"
 
-        module in modules_refs && id ->
-          if options[:warn_on_undefined_references] do
+        module in modules_refs ->
+          if module_id not in skip_warnings_on and id not in skip_warnings_on do
             IO.warn("#{match} is not found (parsing #{id} docs)", [])
           end
 

--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -120,11 +120,12 @@ defmodule ExDoc.Formatter.HTML.Autolink do
 
   This is the main API to autolink any project documentation.
   """
-  def project_doc(nil, _compiled), do: nil
+  def project_doc(nil, _id, _compiled), do: nil
 
-  def project_doc(string, compiled) when is_binary(string) and is_map(compiled) do
+  def project_doc(string, id, compiled) when is_binary(string) and is_map(compiled) do
     config =
       compiled
+      |> Map.put(:id, id)
       |> Map.put_new(:module_id, nil)
       |> Map.put_new(:locals, [])
 
@@ -166,17 +167,17 @@ defmodule ExDoc.Formatter.HTML.Autolink do
       |> Map.put(:module_id, module.id)
       |> Map.put(:locals, funs ++ types)
 
-    moduledoc = project_doc(module.doc, %{compiled | id: id(module, nil)})
+    moduledoc = project_doc(module.doc, id(module, nil), compiled)
 
     docs =
       for node <- module.docs do
-        doc = project_doc(node.doc, %{compiled | id: id(module, node)})
+        doc = project_doc(node.doc, id(module, node), compiled)
         %{node | doc: doc}
       end
 
     typedocs =
       for node <- module.typespecs do
-        doc = project_doc(node.doc, %{compiled | id: id(module, node)})
+        doc = project_doc(node.doc, id(module, node), compiled)
         %{node | doc: doc}
       end
 

--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -101,7 +101,7 @@ defmodule ExDoc.Formatter.HTML.Autolink do
       extension: extension,
       lib_dirs: lib_dirs,
       modules_refs: modules_refs,
-      warn_on_undefined_functions: config.warn_on_undefined_functions
+      warn_on_undefined_references: config.warn_on_undefined_references
     }
   end
 
@@ -454,7 +454,7 @@ defmodule ExDoc.Formatter.HTML.Autolink do
             "#{extension}##{prefix}#{enc_h(function)}/#{arity})"
 
         module in modules_refs && id ->
-          if options[:warn_on_undefined_functions] do
+          if options[:warn_on_undefined_references] do
             IO.warn("#{match} is not found (parsing #{id} docs)", [])
           end
 

--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -415,10 +415,12 @@ defmodule ExDoc.Formatter.HTML.Autolink do
   defp replace_fun(:function, :elixir, link_type, options) do
     aliases = options[:aliases] || []
     docs_refs = options[:docs_refs] || []
+    modules_refs = options[:modules_refs] || []
     extension = options[:extension] || ".html"
     lib_dirs = options[:lib_dirs] || default_lib_dirs(:elixir)
     locals = options[:locals] || []
     elixir_docs = get_elixir_docs(aliases, lib_dirs)
+    module_id = options[:module_id]
 
     fn all, text, match ->
       pmfa = {prefix, module, function, arity} = split_function(match)
@@ -443,6 +445,10 @@ defmodule ExDoc.Formatter.HTML.Autolink do
         match in @special_form_strings ->
           "[#{text}](#{elixir_docs}Kernel.SpecialForms" <>
             "#{extension}##{prefix}#{enc_h(function)}/#{arity})"
+
+        module in modules_refs && module_id ->
+          IO.warn("#{match} is not found (parsing #{module_id} docs)", [])
+          all
 
         doc = module_docs(:elixir, module, lib_dirs) ->
           "[#{text}](#{doc}#{module}.html##{prefix}#{enc_h(function)}/#{arity})"

--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -163,7 +163,6 @@ defmodule ExDoc.Formatter.HTML.Autolink do
 
     compiled =
       compiled
-      |> Map.put(:id, nil)
       |> Map.put(:module_id, module.id)
       |> Map.put(:locals, funs ++ types)
 

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -120,6 +120,11 @@ defmodule Mix.Tasks.Docs do
     * `:ignore_apps` - Apps to be ignored when generating documentation in an umbrella project.
       Receives a list of atoms. Example: `[:first_app, :second_app]`.
 
+    * `:skip_undefined_reference_warnings_on` - ExDoc warns when it can't create a `Mod.fun/arity`
+      reference in the current project docs e.g. because of a typo. This list controls
+      which docs pages to skip the warnings on, which is useful for e.g. deprecation pages;
+      default: `[]`.
+
   ## Groups
 
   ExDoc content can be organized in groups. This is done via the `:groups_for_extras`

--- a/test/ex_doc/formatter/epub/templates_test.exs
+++ b/test/ex_doc/formatter/epub/templates_test.exs
@@ -29,7 +29,7 @@ defmodule ExDoc.Formatter.EPUB.TemplatesTest do
   defp get_module_page(names, config \\ []) do
     config = doc_config(config)
     mods = ExDoc.Retriever.docs_from_modules(names, config)
-    mods = HTML.Autolink.all(mods, HTML.Autolink.compile(mods, ".xhtml", []))
+    mods = HTML.Autolink.all(mods, HTML.Autolink.compile(mods, ".xhtml", config))
     Templates.module_page(config, hd(mods))
   end
 

--- a/test/ex_doc/formatter/epub_test.exs
+++ b/test/ex_doc/formatter/epub_test.exs
@@ -38,7 +38,7 @@ defmodule ExDoc.Formatter.EPUBTest do
       source_root: beam_dir(),
       source_beam: beam_dir(),
       extras: ["test/fixtures/README.md"],
-      warn_on_undefined_functions: false
+      warn_on_undefined_references: false
     ]
   end
 

--- a/test/ex_doc/formatter/epub_test.exs
+++ b/test/ex_doc/formatter/epub_test.exs
@@ -38,7 +38,7 @@ defmodule ExDoc.Formatter.EPUBTest do
       source_root: beam_dir(),
       source_beam: beam_dir(),
       extras: ["test/fixtures/README.md"],
-      warn_on_undefined_references: false
+      skip_undefined_reference_warnings_on: ["Warnings"]
     ]
   end
 

--- a/test/ex_doc/formatter/epub_test.exs
+++ b/test/ex_doc/formatter/epub_test.exs
@@ -37,7 +37,8 @@ defmodule ExDoc.Formatter.EPUBTest do
       output: output_dir(),
       source_root: beam_dir(),
       source_beam: beam_dir(),
-      extras: ["test/fixtures/README.md"]
+      extras: ["test/fixtures/README.md"],
+      warn_on_undefined_functions: false
     ]
   end
 

--- a/test/ex_doc/formatter/html/autolink_test.exs
+++ b/test/ex_doc/formatter/html/autolink_test.exs
@@ -2,7 +2,6 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
   use ExUnit.Case, async: true
   import ExUnit.CaptureIO
   alias ExDoc.Formatter.HTML.Autolink
-  import Autolink, only: [project_doc: 2]
 
   @elixir_docs "https://hexdocs.pm/"
   @erlang_docs "http://www.erlang.org/doc/man/"
@@ -124,17 +123,17 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
     test "warns when module exists but the function does not" do
       compiled = %{
         docs_refs: ["Mod.example/1"],
-        id: "Mod.foo/0",
         modules_refs: ["Mod"],
         warn_on_undefined_references: true
       }
 
       assert capture_io(:stderr, fn ->
-               assert project_doc("`Mod.example/2`", compiled) == "`Mod.example/2`"
+               assert Autolink.project_doc("`Mod.example/2`", "Mod.foo/0", compiled) ==
+                        "`Mod.example/2`"
              end) =~ "Mod.example/2 is not found (parsing Mod.foo/0 docs)"
 
       # don't warn when parsing extras
-      assert assert project_doc("`Mod.example/2`", %{compiled | id: nil}) == "`Mod.example/2`"
+      assert assert project_doc("`Mod.example/2`", nil, compiled) == "`Mod.example/2`"
     end
 
     test "autolinks functions Module.fun/arity in elixir" do
@@ -610,5 +609,9 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
     ast = Code.string_to_quoted!(original)
     {actual, _} = Autolink.format_and_extract_typespec_placeholders(ast, typespecs, aliases, [])
     assert actual == expected, "Original: #{original}\nExpected: #{expected}\nActual:   #{actual}"
+  end
+
+  defp project_doc(string, id \\ nil, compiled) do
+    Autolink.project_doc(string, id, compiled)
   end
 end

--- a/test/ex_doc/formatter/html/autolink_test.exs
+++ b/test/ex_doc/formatter/html/autolink_test.exs
@@ -134,8 +134,7 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
              end) =~ "Mod.example/2 is not found (parsing Mod.foo/0 docs)"
 
       # don't warn when parsing extras
-      assert assert project_doc("`Mod.example/2`", %{compiled | id: nil}) ==
-                      "`Mod.example/2`"
+      assert assert project_doc("`Mod.example/2`", %{compiled | id: nil}) == "`Mod.example/2`"
     end
 
     test "autolinks functions Module.fun/arity in elixir" do

--- a/test/ex_doc/formatter/html/autolink_test.exs
+++ b/test/ex_doc/formatter/html/autolink_test.exs
@@ -122,14 +122,19 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
     end
 
     test "warns when module exists but the function does not" do
-      compiled = %{docs_refs: ["Mod.example/1"], module_id: "Mod", modules_refs: ["Mod"]}
+      compiled = %{
+        docs_refs: ["Mod.example/1"],
+        id: "Mod.foo/0",
+        modules_refs: ["Mod"],
+        warn_on_undefined_functions: true
+      }
 
       assert capture_io(:stderr, fn ->
                assert project_doc("`Mod.example/2`", compiled) == "`Mod.example/2`"
-             end) =~ "Mod.example/2 is not found (parsing Mod docs)"
+             end) =~ "Mod.example/2 is not found (parsing Mod.foo/0 docs)"
 
       # don't warn when parsing extras
-      assert assert project_doc("`Mod.example/2`", %{compiled | module_id: nil}) ==
+      assert assert project_doc("`Mod.example/2`", %{compiled | id: nil}) ==
                       "`Mod.example/2`"
     end
 

--- a/test/ex_doc/formatter/html/autolink_test.exs
+++ b/test/ex_doc/formatter/html/autolink_test.exs
@@ -126,7 +126,7 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
         docs_refs: ["Mod.example/1"],
         id: "Mod.foo/0",
         modules_refs: ["Mod"],
-        warn_on_undefined_functions: true
+        warn_on_undefined_references: true
       }
 
       assert capture_io(:stderr, fn ->

--- a/test/ex_doc/formatter/html/autolink_test.exs
+++ b/test/ex_doc/formatter/html/autolink_test.exs
@@ -1,5 +1,6 @@
 defmodule ExDoc.Formatter.HTML.AutolinkTest do
   use ExUnit.Case, async: true
+  import ExUnit.CaptureIO
   alias ExDoc.Formatter.HTML.Autolink
   import Autolink, only: [project_doc: 2]
 
@@ -118,6 +119,18 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
                %{docs_refs: ["Mod.funny_name\?/1", "Mod.funny_name!/2"]}
              ) ==
                "[`Mod.funny_name\?/1`](Mod.html#funny_name\?/1) and [`Mod.funny_name!/2`](Mod.html#funny_name!/2)"
+    end
+
+    test "warns when module exists but the function does not" do
+      compiled = %{docs_refs: ["Mod.example/1"], module_id: "Mod", modules_refs: ["Mod"]}
+
+      assert capture_io(:stderr, fn ->
+               assert project_doc("`Mod.example/2`", compiled) == "`Mod.example/2`"
+             end) =~ "Mod.example/2 is not found (parsing Mod docs)"
+
+      # don't warn when parsing extras
+      assert assert project_doc("`Mod.example/2`", %{compiled | module_id: nil}) ==
+                      "`Mod.example/2`"
     end
 
     test "autolinks functions Module.fun/arity in elixir" do

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -31,7 +31,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
   defp get_module_page(names, config \\ []) do
     config = doc_config(config)
     mods = ExDoc.Retriever.docs_from_modules(names, config)
-    mods = HTML.Autolink.all(mods, HTML.Autolink.compile(mods, ".html", []))
+    mods = HTML.Autolink.all(mods, HTML.Autolink.compile(mods, ".html", config))
     Templates.module_page(hd(mods), @empty_nodes_map, config)
   end
 

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -56,7 +56,7 @@ defmodule ExDoc.Formatter.HTMLTest do
   end
 
   defp generate_docs(config) do
-    config = Keyword.put_new(config, :warn_on_undefined_references, false)
+    config = Keyword.put_new(config, :skip_undefined_reference_warnings_on, ["Warnings"])
     ExDoc.generate_docs(config[:project], config[:version], config)
   end
 
@@ -111,7 +111,7 @@ defmodule ExDoc.Formatter.HTMLTest do
   test "warns on undefined functions" do
     output =
       capture_io(:stderr, fn ->
-        generate_docs(doc_config(warn_on_undefined_references: true))
+        generate_docs(doc_config(skip_undefined_reference_warnings_on: []))
       end)
 
     assert output =~ "Warnings.bar/0 is not found (parsing Warnings docs)"

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -56,6 +56,7 @@ defmodule ExDoc.Formatter.HTMLTest do
   end
 
   defp generate_docs(config) do
+    config = Keyword.put_new(config, :warn_on_undefined_functions, false)
     ExDoc.generate_docs(config[:project], config[:version], config)
   end
 
@@ -105,6 +106,18 @@ defmodule ExDoc.Formatter.HTMLTest do
     assert output == "warning: index.html redirects to Unknown.html, which does not exist\n"
     assert File.regular?("#{output_dir()}/index.html")
     refute File.regular?("#{output_dir()}/Unknown.html")
+  end
+
+  test "warns on undefined functions" do
+    output =
+      capture_io(:stderr, fn ->
+        generate_docs(doc_config(warn_on_undefined_functions: true))
+      end)
+
+    assert output =~ "Warnings.bar/0 is not found (parsing Warnings docs)"
+    assert output =~ "Warnings.bar/0 is not found (parsing Warnings.foo/0 docs)"
+    assert output =~ "Warnings.bar/0 is not found (parsing c:Warnings.handle_foo/0 docs)"
+    assert output =~ "Warnings.bar/0 is not found (parsing t:Warnings.t/0 docs)"
   end
 
   test "generates headers for index.html and module pages" do

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -56,7 +56,7 @@ defmodule ExDoc.Formatter.HTMLTest do
   end
 
   defp generate_docs(config) do
-    config = Keyword.put_new(config, :warn_on_undefined_functions, false)
+    config = Keyword.put_new(config, :warn_on_undefined_references, false)
     ExDoc.generate_docs(config[:project], config[:version], config)
   end
 
@@ -111,7 +111,7 @@ defmodule ExDoc.Formatter.HTMLTest do
   test "warns on undefined functions" do
     output =
       capture_io(:stderr, fn ->
-        generate_docs(doc_config(warn_on_undefined_functions: true))
+        generate_docs(doc_config(warn_on_undefined_references: true))
       end)
 
     assert output =~ "Warnings.bar/0 is not found (parsing Warnings docs)"

--- a/test/fixtures/protocol.ex
+++ b/test/fixtures/protocol.ex
@@ -1,4 +1,8 @@
 defprotocol CustomProtocol do
+  @moduledoc """
+  See `plus_one/1`.
+  """
+
   def plus_one(foo)
   def plus_two(bar)
 end

--- a/test/fixtures/warnings.ex
+++ b/test/fixtures/warnings.ex
@@ -1,0 +1,20 @@
+defmodule Warnings do
+  @moduledoc """
+  `Warnings.bar/0`
+  """
+
+  @typedoc """
+  `Warnings.bar/0`
+  """
+  @type t() :: :ok
+
+  @doc """
+  `Warnings.bar/0`
+  """
+  @callback handle_foo() :: :ok
+
+  @doc """
+  `Warnings.bar/0`
+  """
+  def foo(), do: :ok
+end


### PR DESCRIPTION
This only works for project's docs so when e.g. `Foo.bar/0` from `foo` dependency doesn't exist we won't warn yet.

We also don't warn when parsing extras pages, this is useful for Elixir deprecations page when we reference functions that are deprecated.