### PR TITLE
(0) Δ Refactor docs.ex

### DIFF
--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -246,7 +246,8 @@ defmodule Mix.Tasks.Docs do
 
     project = to_string(config[:name] || config[:app])
     version = config[:version] || "dev"
-    options = get_docs_opts(config, cli_opts) # def'd after `get_formatters/1`
+    options = get_docs_opts(config, cli_opts)
+    # def'd after `get_formatters/1`
 
     for formatter <- get_formatters(options) do
       index = generator.(project, version, Keyword.put(options, :formatter, formatter))
@@ -260,7 +261,7 @@ defmodule Mix.Tasks.Docs do
 
   defp get_formatters(options) do
     case Keyword.get_values(options, :formatter) do
-      []     -> options[:formatters] || [ExDoc.Config.default_formatter()]
+      [] -> options[:formatters] || [ExDoc.Config.default_formatter()]
       values -> values
     end
   end
@@ -280,17 +281,18 @@ defmodule Mix.Tasks.Docs do
 
     cond do
       is_function(docs, 0) -> docs.()
-      is_nil(docs)         -> []
-      true                 -> docs
+      is_nil(docs) -> []
+      true -> docs
     end
     |> Keyword.merge(cli_opts)
-    |> normalize_urls(config, [:source_url, :homepage_url]) # accepted at root level config
+    # accepted at root level config
+    |> normalize_urls(config, [:source_url, :homepage_url])
   end
 
   defp normalize_urls(options, config, keys) do
     Enum.reduce(keys, options, fn key, options_ ->
       case Keyword.get(config, key) do
-        nil   -> options_
+        nil -> options_
         value -> Keyword.put(options_, key, value)
       end
     end)
@@ -300,13 +302,16 @@ defmodule Mix.Tasks.Docs do
   def normalize_source_beam(options, config) do
     source_beam =
       case Mix.Project.umbrella?(config) do
-        false -> Mix.Project.compile_path()
+        false ->
+          Mix.Project.compile_path()
 
-        true  -> ignored_apps = Keyword.get(options, :ignore_apps, [])
-                 build        = Mix.Project.build_path()
+        true ->
+          ignored_apps = Keyword.get(options, :ignore_apps, [])
+          build = Mix.Project.build_path()
 
-                 for {app, _} <- Mix.Project.apps_paths(), app not in ignored_apps,
-                   do: Path.join([build, "lib", Atom.to_string(app), "ebin"])
+          for {app, _} <- Mix.Project.apps_paths(),
+              app not in ignored_apps,
+              do: Path.join([build, "lib", Atom.to_string(app), "ebin"])
       end
 
     Keyword.put_new(options, :source_beam, source_beam)
@@ -317,26 +322,30 @@ defmodule Mix.Tasks.Docs do
     main = options[:main]
 
     cond do
-      is_nil(main)    -> Keyword.delete(options, :main)
-      is_atom(main)   -> Keyword.put(options, :main, inspect(main))
+      is_nil(main) -> Keyword.delete(options, :main)
+      is_atom(main) -> Keyword.put(options, :main, inspect(main))
       is_binary(main) -> options
     end
     |> normalize_deps()
   end
 
   defp normalize_deps(options) do
-    deps = for {app, doc} <- Keyword.merge( get_deps(), Keyword.get(options, :deps, []) ),
-               lib_dir = :code.lib_dir(app),
-               is_list(lib_dir),
-                 do: {List.to_string(lib_dir), doc}
+    deps =
+      for {app, doc} <- Keyword.merge(get_deps(), Keyword.get(options, :deps, [])),
+          lib_dir = :code.lib_dir(app),
+          is_list(lib_dir),
+          do: {List.to_string(lib_dir), doc}
 
     Keyword.put(options, :deps, deps)
     # call stack returns to `run/1`
   end
 
-  defp get_deps, do:
-    for {key, _} <- Mix.Project.deps_paths(),
-        _   = Application.load(key),
+  defp get_deps,
+    do:
+      for(
+        {key, _} <- Mix.Project.deps_paths(),
+        _ = Application.load(key),
         vsn = Application.spec(key, :vsn),
-          do: {key, "https://hexdocs.pm/#{key}/#{vsn}/"}
+        do: {key, "https://hexdocs.pm/#{key}/#{vsn}/"}
+      )
 end

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -317,9 +317,9 @@ defmodule Mix.Tasks.Docs do
     main = options[:main]
 
     cond do
-      is_binary(main) -> options
-      is_atom(main)   -> Keyword.put(options, :main, inspect(main))
       is_nil(main)    -> Keyword.delete(options, :main)
+      is_atom(main)   -> Keyword.put(options, :main, inspect(main))
+      is_binary(main) -> options
     end
     |> normalize_deps()
   end

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -265,7 +265,16 @@ defmodule Mix.Tasks.Docs do
     end
   end
 
-
+  # Table of Contents:
+  #
+  # config
+  # |> get_docs_opts()
+  # |> Keyword.merge(cli_opts)
+  # |> normalize_urls(config, [:source_url, :homepage_url]) # accepted at root level config
+  # |> normalize_source_beam(config)
+  # |> normalize_main()
+  # |> normalize_deps()
+  #
   defp get_docs_opts(config, cli_opts) do
     docs = config[:docs]
 
@@ -275,10 +284,10 @@ defmodule Mix.Tasks.Docs do
       true                 -> docs
     end
     |> Keyword.merge(cli_opts)
-    |> normalize(config, [:source_url, :homepage_url]) # accepted at root level config
+    |> normalize_urls(config, [:source_url, :homepage_url]) # accepted at root level config
   end
 
-  defp normalize(options, config, keys) do
+  defp normalize_urls(options, config, keys) do
     Enum.reduce(keys, options, fn key, options_ ->
       case Keyword.get(config, key) do
           nil -> options_

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -260,7 +260,7 @@ defmodule Mix.Tasks.Docs do
 
   defp get_formatters(options) do
     case Keyword.get_values(options, :formatter) do
-          [] -> options[:formatters] || [ExDoc.Config.default_formatter()]
+      []     -> options[:formatters] || [ExDoc.Config.default_formatter()]
       values -> values
     end
   end
@@ -290,7 +290,7 @@ defmodule Mix.Tasks.Docs do
   defp normalize_urls(options, config, keys) do
     Enum.reduce(keys, options, fn key, options_ ->
       case Keyword.get(config, key) do
-          nil -> options_
+        nil   -> options_
         value -> Keyword.put(options_, key, value)
       end
     end)
@@ -325,12 +325,10 @@ defmodule Mix.Tasks.Docs do
   end
 
   defp normalize_deps(options) do
-    user_deps = Keyword.get(options, :deps, [])
-
-    deps      = for {app, doc} <- Keyword.merge(get_deps(), user_deps),
-                    lib_dir = :code.lib_dir(app),
-                    is_list(lib_dir),
-                      do: {List.to_string(lib_dir), doc}
+    deps = for {app, doc} <- Keyword.merge( get_deps(), Keyword.get(options, :deps, []) ),
+               lib_dir = :code.lib_dir(app),
+               is_list(lib_dir),
+                 do: {List.to_string(lib_dir), doc}
 
     Keyword.put(options, :deps, deps)
     # call stack returns to `run/1`


### PR DESCRIPTION
### Motivation

A few months ago, I wanted to add a new feature to `:ex_doc`, so I made a clone. However, the call stacks in the files I needed to change ran so deep that for someone unfamiliar with the codebase, they were unreadable. Unfortunately, the team did not have the bandwidth to guide me along.

As a result, with a bit more free time now, I figure the natural next step is to solve that problem: readability.

### Description

> This is the first of many PR's to come. If the team disagrees with my initial effort, no worries! I have created my own [fork](https://github.com/English3000/ex_doc), so if you'd prefer, I can just offer a PR with the final product.

In this PR, I refactored the root file, `docs.ex`, for the feature I want to add.

I took 2 approaches. In the first commit, I simply refactored for concision. Then I thought to a conversation from work about code style. The result was the second commit.

_The comparison is best explained with the metaphor of a book:_ When you open a book, you could go to the **Table of Contents** to see its overall structure and what it is about. Or, you could skip to the first **Chapter** and just start reading.

Your code (and my first commit) followed the **Table of Contents** approach. While this makes for _slightly easier-to-refactor_ code, it makes it _**very hard to follow**_ what the code is actually doing because someone new to the code has to _**jump all over the file**_, losing track in one's mind of the bigger picture. So, the **Table of Contents** approach is _creator-friendly_.

By contrast, in this PR (which follows the **Chapter** approach), you can almost _read the file as you would a book_, starting from the top and finishing at the bottom, _with notes_ to the reader in the few places one does need to jump.

The pros of this approach are a _leaner_ `run/1`, which is less intimidating and easier to understand at a high-level (without the distraction of the Table of Contents), and an _easy-to-follow call stack_ using tail-calls to maximize readability.

Given the main pro of the **Table of Contents** approach _(slightly easier to refactor)_, I did leave a comment with it above `get_docs_opts/2` in case a maintainer needs to reason with it in making a significant change. However, given that `:ex_doc` is a relatively mature project and that this file has a specific purpose which is unlikely to change significantly, at this point I think it makes more sense to make the code more accessible for open source contributions.

Let me know what you think!