### PR TITLE
Use em-dash for separation in page title

### DIFF
--- a/lib/ex_doc/formatter/html/templates/head_template.eex
+++ b/lib/ex_doc/formatter/html/templates/head_template.eex
@@ -5,7 +5,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="generator" content="ExDoc v<%= ExDoc.version %>">
-    <title><%= page.title %> – <%= config.project %> v<%= config.version %></title>
+    <title><%= page.title %> — <%= config.project %> v<%= config.version %></title>
     <link rel="stylesheet" href="<%= asset_rev config.output, "dist/html*.css" %>" />
     <%= if config.canonical do %>
       <link rel="canonical" href="<%= config.canonical %>" />

--- a/lib/ex_doc/formatter/html/templates/redirect_template.eex
+++ b/lib/ex_doc/formatter/html/templates/redirect_template.eex
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title><%= config.project %> v<%= config.version %> – Documentation</title>
+    <title><%= config.project %> v<%= config.version %> — Documentation</title>
     <meta http-equiv="refresh" content="0; url=<%= h(redirect_to) %>">
     <meta name="robots" content="noindex">
     <meta name="generator" content="ExDoc v<%= ExDoc.version %>">

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -132,12 +132,12 @@ defmodule ExDoc.Formatter.HTMLTest do
         generator: ~r{<meta name="generator" content="ExDoc v#{ExDoc.version()}">}
       },
       index: %{
-        title: ~r{<title>Elixir v1.0.1 – Documentation</title>},
+        title: ~r{<title>Elixir v1.0.1 — Documentation</title>},
         index: ~r{<meta name="robots" content="noindex"},
         refresh: ~r{<meta http-equiv="refresh" content="0; url=RandomError.html">}
       },
       module: %{
-        title: ~r{<title>RandomError – Elixir v1.0.1</title>},
+        title: ~r{<title>RandomError — Elixir v1.0.1</title>},
         viewport: ~r{<meta name="viewport" content="width=device-width, initial-scale=1.0">},
         x_ua: ~r{<meta http-equiv="x-ua-compatible" content="ie=edge">}
       }
@@ -348,7 +348,7 @@ defmodule ExDoc.Formatter.HTMLTest do
     test "with custom title" do
       generate_docs(doc_config(extras: ["test/fixtures/README.md": [title: "Getting Started"]]))
       content = File.read!("#{output_dir()}/readme.html")
-      assert content =~ ~r{<title>Getting Started – Elixir v1.0.1</title>}
+      assert content =~ ~r{<title>Getting Started — Elixir v1.0.1</title>}
       content = read_wildcard!("#{output_dir()}/dist/sidebar_items-*.js")
       assert content =~ ~r{"id":"readme","title":"Getting Started","group":""}
     end
@@ -367,7 +367,7 @@ defmodule ExDoc.Formatter.HTMLTest do
     test "with auto-extracted titles" do
       generate_docs(doc_config(extras: ["test/fixtures/ExtraPage.md"]))
       content = File.read!("#{output_dir()}/extrapage.html")
-      assert content =~ ~r{<title>Extra Page Title – Elixir v1.0.1</title>}
+      assert content =~ ~r{<title>Extra Page Title — Elixir v1.0.1</title>}
       content = read_wildcard!("#{output_dir()}/dist/sidebar_items-*.js")
       assert content =~ ~r{"id":"extrapage","title":"Extra Page Title"}
     end


### PR DESCRIPTION
...instead of en-dash.