### PR TITLE
Fix custom links in Elixir modules

### DIFF
--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -396,22 +396,40 @@ defmodule ExDoc.Formatter.HTML.Autolink do
     end
   end
 
-  defp replace_fun(:module, :elixir, _link_type, options) do
+  defp replace_fun(:module, :elixir, link_type, options) do
     extension = options[:extension] || ".html"
     lib_dirs = options[:lib_dirs] || default_lib_dirs(:elixir)
     module_id = options[:module_id] || nil
     modules_refs = options[:modules_refs] || []
 
-    fn all, _text, match ->
+    fn all, text, match ->
       cond do
         match == module_id ->
-          "[`#{match}`](#content)"
+          case link_type do
+            :normal ->
+              "[`#{match}`](#content)"
+
+            :custom ->
+              "[#{text}](#content)"
+          end
 
         match in modules_refs ->
-          "[`#{match}`](#{match}#{extension})"
+          case link_type do
+            :normal ->
+              "[`#{match}`](#{match}#{extension})"
+
+            :custom ->
+              "[#{text}](#{match}#{extension})"
+          end
 
         doc = module_docs(:elixir, match, lib_dirs) ->
-          "[`#{match}`](#{doc}#{match}.html)"
+          case link_type do
+            :normal ->
+              "[`#{match}`](#{doc}#{match}.html)"
+
+            :custom ->
+              "[#{text}](#{doc}#{match}.html)"
+          end
 
         true ->
           all

--- a/test/ex_doc/formatter/html/autolink_test.exs
+++ b/test/ex_doc/formatter/html/autolink_test.exs
@@ -350,6 +350,23 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
       assert project_doc("[in the `Kernel` module](Kernel.html#guards)", %{docs_refs: []}) ==
                "[in the `Kernel` module](Kernel.html#guards)"
     end
+
+    test "supports custom links" do
+      assert project_doc("[`example`](`Example`)", %{modules_refs: ["Example"]}) ==
+               "[`example`](Example.html)"
+
+      assert project_doc("[the `example` module](`Example`)", %{modules_refs: ["Example"]}) ==
+               "[the `example` module](Example.html)"
+
+      assert project_doc("[the `Example` module](`Example`)", %{modules_refs: ["Example"]}) ==
+               "[the `Example` module](Example.html)"
+
+      assert project_doc("[the `string` module](`String`)", %{modules_refs: []}) ==
+               "[the `string` module](#{@elixir_docs}elixir/String.html)"
+
+      assert project_doc("[the `String` module](`String`)", %{modules_refs: []}) ==
+               "[the `String` module](#{@elixir_docs}elixir/String.html)"
+    end
   end
 
   describe "Mix tasks" do


### PR DESCRIPTION
The text set in a custom link was lost.
[this is `my` module](MyModule)

would have just been converted to
[`MyModule`](MyModule.html)