### PR TITLE
Fix anchor links sometimes not working by moving js to HTML head

### DIFF
--- a/lib/ex_doc/formatter/html/templates/footer_template.eex
+++ b/lib/ex_doc/formatter/html/templates/footer_template.eex
@@ -14,7 +14,6 @@
   </div>
 </section>
 </div>
-  <script src="<%= asset_rev config.output, "dist/html*.js" %>"></script>
   <%# Extra content needed by the current markdown processor (e.g. custom Javascript) %>
   <%= ExDoc.Markdown.get_markdown_processor().before_closing_body_tag(:html) %>
   <%# Extra content specified by the user (e.g. custom Javascript) %>

--- a/lib/ex_doc/formatter/html/templates/head_template.eex
+++ b/lib/ex_doc/formatter/html/templates/head_template.eex
@@ -11,6 +11,7 @@
       <link rel="canonical" href="<%= config.canonical %>" />
     <% end %>
     <script src="<%= asset_rev config.output, "dist/sidebar_items*.js" %>"></script>
+    <script async src="<%= asset_rev config.output, "dist/html*.js" %>"></script>
     <%# Extra content needed by the current markdown processor (e.g. custom CSS) %>
     <%= ExDoc.Markdown.get_markdown_processor().before_closing_head_tag(:html) %>
     <%# Extra content specified by the user (e.g. custom CSS) %>


### PR DESCRIPTION
Closes #961

Even an empty script (`<script></script>`) at the end of `<body>` can break anchor links in Chrome for some reason. Fortunately, we can move the script to HTML `<head>` with `async` tag, which should not cause rendering performance to suffer. We can safely do that because our javascript already makes sure to run after the DOM is ready by using jQuery's [ready](https://api.jquery.com/ready/) handler [here](https://github.com/elixir-lang/ex_doc/blob/7ff86d47a7982d72ee16ef26a93cba790a86b355/assets/js/app.js#L34).