### PR TITLE
Fix typespec arg number

### DIFF
--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -451,11 +451,11 @@ defmodule ExDoc.Retriever do
   defp strip_types(args, arity) do
     args
     |> Enum.take(-arity)
-    |> Enum.with_index()
+    |> Enum.with_index(1)
     |> Enum.map(fn
-      {{:::, _, [left, _]}, i} -> to_var(left, i)
-      {{:|, _, _}, i} -> to_var({}, i)
-      {left, i} -> to_var(left, i)
+      {{:::, _, [left, _]}, position} -> to_var(left, position)
+      {{:|, _, _}, position} -> to_var({}, position)
+      {left, position} -> to_var(left, position)
     end)
   end
 
@@ -469,7 +469,7 @@ defmodule ExDoc.Retriever do
   defp to_var(float, _) when is_integer(float), do: {:float, [], nil}
   defp to_var(list, _) when is_list(list), do: {:list, [], nil}
   defp to_var(atom, _) when is_atom(atom), do: {:atom, [], nil}
-  defp to_var(_, i), do: {:"arg#{i}", [], nil}
+  defp to_var(_, position), do: {:"arg#{position}", [], nil}
 
   ## General helpers
 

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -378,7 +378,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       assert content =~ ~r{Callbacks}
       assert content =~ ~r{<section class="detail" id="c:hello/1">}
       assert content =~ ~s[hello(integer)]
-      assert content =~ ~s[greet(arg0)]
+      assert content =~ ~s[greet(arg1)]
 
       content = get_module_page([CustomBehaviourTwo])
 

--- a/test/ex_doc/retriever_test.exs
+++ b/test/ex_doc/retriever_test.exs
@@ -245,7 +245,7 @@ defmodule ExDoc.RetrieverTest do
       assert hello.type == :callback
       assert hello.signature == "hello(integer)"
       assert greet.type == :callback
-      assert greet.signature == "greet(arg0)"
+      assert greet.signature == "greet(arg1)"
     end
 
     test "returns macro callbacks" do


### PR DESCRIPTION
Previously signature where typespecs didn't have an argument name,
were named starting with 0

time_zone_period_from_utc_iso_days(arg0, arg1)
time_zone_period_from_utc_iso_days(Calendar.iso_days(), Calendar.time_zone()) :: ...

this commit fixes the number starting from 1