### PR TITLE
Ensure that link_headings/3 generates unique anchor id's

### DIFF
--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -109,6 +109,20 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
              </h3>
              """
     end
+
+    test "generates headers with unique id's" do
+      assert Templates.link_headings("<h3>Foo</h3>\n<h3>Foo</h3>") == """
+             <h3 id="foo" class="section-heading">
+               <a href="#foo" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+               Foo
+             </h3>
+
+             <h3 id="foo-1" class="section-heading">
+               <a href="#foo-1" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+               Foo
+             </h3>
+             """
+    end
   end
 
   describe "synopsis" do


### PR DESCRIPTION
This PR ensures that the anchor id's generated by `link_headings/3` are always unique.

This is achieved by replacing the simple use of `Regex.replace/3` with `Regex.scan/2` and an `Enum.reduce/3`, which keeps track of id's that already occurred and adds a `-n` suffix to them.

#998 will be fixed when this is merged.