### PR TITLE
Detect if browser prefers night mode

### DIFF
--- a/assets/js/night.js
+++ b/assets/js/night.js
@@ -17,12 +17,14 @@ function activateNightMode () {
 
 function deactivateNightMode () {
   body.removeClass(nightMode)
-  try { localStorage.removeItem(nightMode) } catch (e) { }
+  try { localStorage.setItem(nightMode, false) } catch (e) { }
 }
 
 function checkForNightMode () {
   try {
-    if (localStorage.getItem(nightMode)) {
+    if (localStorage.getItem(nightMode) === true) {
+      activateNightMode()
+    } else if (matchMedia('(prefers-color-scheme: dark)').matches) {
       activateNightMode()
     }
   } catch (e) { }

--- a/assets/js/night.js
+++ b/assets/js/night.js
@@ -23,7 +23,7 @@ function deactivateNightMode () {
 function checkForNightMode () {
   try {
     const userWantsNightMode = localStorage.getItem(nightMode)
-    
+
     if (userWantsNightMode != null) {
       if (userWantsNightMode === true) {
         activateNightMode()

--- a/assets/js/night.js
+++ b/assets/js/night.js
@@ -22,8 +22,12 @@ function deactivateNightMode () {
 
 function checkForNightMode () {
   try {
-    if (localStorage.getItem(nightMode) === true) {
-      activateNightMode()
+    const userWantsNightMode = localStorage.getItem(nightMode)
+    
+    if (userWantsNightMode != null) {
+      if (userWantsNightMode === true) {
+        activateNightMode()
+      }
     } else if (matchMedia('(prefers-color-scheme: dark)').matches) {
       activateNightMode()
     }


### PR DESCRIPTION
Detects if the browser prefers a dark color scheme and switches to dark mode automatically. Needs testing.

Relevant APIs:
https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme
https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia