### PR TITLE
Do not link to modules with `@moduledoc false`

### DIFF
--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -544,4 +544,21 @@ defmodule ExDoc.Formatter.HTMLTest do
       end
     end
   end
+
+  describe "does not link to local modules with @moduledoc false" do
+    test "links" do
+      generate_docs(doc_config())
+
+      content = File.read!("#{output_dir()}/LinkToModuledocFalse.html")
+      assert content =~ ~r[<li><code class="inline">ModuledocFalse</code>]
+      assert content =~ ~r[<li><code class="inline">ModuledocFalse.foo/0</code>]
+      assert content =~ ~r[<li><code class="inline">t:ModuledocFalse.t/0</code>]
+
+      assert content =~
+               ~r[<li><a href=\"https://hexdocs.pm/elixir/Kernel.ParallelCompiler.html#require/2\"><code class=\"inline\">Kernel.ParallelCompiler.require/2</code></a>]
+
+      content = File.read("#{output_dir()}/ModuledocFalse.html")
+      assert content == {:error, :enoent}
+    end
+  end
 end

--- a/test/ex_doc/retriever_test.exs
+++ b/test/ex_doc/retriever_test.exs
@@ -51,6 +51,13 @@ defmodule ExDoc.RetrieverTest do
              """
     end
 
+    test "returns modules with @doc false" do
+      assert [CompiledWithDocs, CompiledWithDocs] ==
+               ["CompiledWithDocs", "ModuledocFalse", "CompiledWithDocs"]
+               |> docs_from_files()
+               |> Enum.map(& &1.module)
+    end
+
     test "returns module group" do
       [module_node] =
         docs_from_files(["CompiledWithDocs"], groups_for_modules: [Group: [CompiledWithDocs]])

--- a/test/fixtures/link_to_moduledoc_false.ex
+++ b/test/fixtures/link_to_moduledoc_false.ex
@@ -1,0 +1,32 @@
+defmodule LinkToModuledocFalse do
+  @moduledoc """
+  Links to the following modules/functions:
+
+    - `ModuledocFalse`
+    - `ModuledocFalse.foo/0`
+    - `t:ModuledocFalse.t/0`
+    - `Kernel.ParallelCompiler.require/2`
+    - `Kernel.Doesnotexist`
+    - `String`
+    - `String.foo/0`
+    - `t:String.t/0`
+    - `String.Foo`
+    - `Makeup`
+    - `Doc.False.hello/0`
+    - `Doc.Exist.hello/0`
+
+  """
+
+  @doc """
+  Hello world.
+
+  ## Examples
+
+      iex> LinkToModuledocFalse.hello()
+      :world
+
+  """
+  def hello do
+    :world
+  end
+end

--- a/test/fixtures/moduledoc_false.ex
+++ b/test/fixtures/moduledoc_false.ex
@@ -1,0 +1,12 @@
+defmodule ModuledocFalse do
+  @moduledoc false
+
+  @type t :: term
+
+  @doc """
+  Foo is the new bar
+  """
+  def foo do
+    :foo
+  end
+end


### PR DESCRIPTION
I'm opening a new PR, so this one replaces #1009, and closes #951

While a big amount of code has to be changed (mostly tests), I think it is the way to go.

So before generating the docs, the `ExDoc.Retriever` cache needs to be started by running `ExDoc.Retriever.start_cache/1`, and a tuple with `{response, cache_id}` is returned where `response` is the `Agent.start_link/1` response when the ETS is created, and `cache_id` is an atom that identifies the ETS table.

```elixir
{_response, cache_id} = ExDoc.Retriever.start_cache([])
ExDoc.Autolink.project_doc("`example/2`", nil, %{cache_id: cache_id, locals: ["example/2"]})
```

Then this cache_id needs to be passed to any function in the API.
I decided to take the approach to not work if `cache_id` is not passed, to speed things up.
I made a simpler version that didn't require much refactoring of the tests, and when no cache_id was provided, a new ETS would be created, and this caused a HUGE slow-down in the execution of the tests, from 18s before the PR to 28s after the PR. Now, making sure the Cache is started and passing the cached_id, it's around 21seconds.

Please care only on what's under lib/ and the tests that deals with `@moduledoc false`, the rest is just refactoring to adjust to the changes.

But `ExDoc.generate_docs/3` doesn't need any change and created the cache_id by itself.