### PR TITLE
Fix tag mismatch error

### DIFF
--- a/lib/ex_doc/formatter/html/templates/detail_template.eex
+++ b/lib/ex_doc/formatter/html/templates/detail_template.eex
@@ -10,7 +10,7 @@
       <span class="icon-link" aria-hidden="true"></span>
       <span class="sr-only">Link to this <%= pretty_type(node) %></span>
     </a>
-    <h1 class="signature"><%=h node.signature %></span>
+    <h1 class="signature"><%=h node.signature %></h1>
     <%= if node.source_url do %>
       <a href="<%= node.source_url %>" class="view-source" rel="help" title="View Source">
        <span class="icon-code" aria-hidden="true"></span>


### PR DESCRIPTION
When generating epub:

![image](https://user-images.githubusercontent.com/457237/59515211-fcda9c00-8e94-11e9-846b-2cc82c97717c.png)
