### PR TITLE
Fix epub toc without groups

### DIFF
--- a/lib/ex_doc/formatter/epub/templates/nav_template.eex
+++ b/lib/ex_doc/formatter/epub/templates/nav_template.eex
@@ -3,13 +3,17 @@
     <nav epub:type="toc">
       <ol>
         <%= for {title, extras} <- config.extras do %>
-        <li><span><%= title %></span>
-          <ol>
+          <%= if title do %>
+          <li><span><%= title %></span>
+            <ol>
+          <% end %>
           <%= for extra <- extras do %>
             <li><a href="<%= extra.id %>.xhtml"><%= extra.title %></a></li>
           <% end %>
-          </ol>
-        </li>
+          <%= if title do %>
+            </ol>
+          </li>
+          <% end %>
         <% end %>
 
         <%= nav_item_template "Modules", nodes.modules %>


### PR DESCRIPTION
Remove the parent level when there's no group defined.

Before:

![image](https://user-images.githubusercontent.com/457237/59527300-8f893400-8eb1-11e9-8907-572a8407fde1.png)

After:

![image](https://user-images.githubusercontent.com/457237/59527379-d0814880-8eb1-11e9-999d-11a692de0a36.png)
