### PR TITLE
Fix Night Mode detection

### DIFF
--- a/lib/ex_doc/formatter/html/templates/head_template.eex
+++ b/lib/ex_doc/formatter/html/templates/head_template.eex
@@ -25,4 +25,4 @@
     <%= config.before_closing_head_tag.(:html) %>
   </head>
   <body data-type="<%= sidebar_type(page.type) %>">
-    <script>try { if(localStorage.getItem('night-mode')) document.body.className += ' night-mode'; } catch (e) { }</script>
+    <script>try { if(localStorage.getItem('night-mode') === 'true') document.body.className += ' night-mode'; } catch (e) { }</script>


### PR DESCRIPTION
There is a bug with Night Mode switching.

To reproduce:

1. Go to https://hexdocs.pm/elixir/Kernel.html
2. Switch Night Mode `ON`
3. Switch Night Mode `OFF`
4. Refresh the page

**CURRENT:** Night Mode stays ON.
**EXPECTED:** Night Mode stays switched ON.

Local storage value is a truthy string (ie. "false", "true"), not a boolean. `if(localStorage.getItem('night-mode'))` is always `true` if the key is present.