### PR TITLE
Travis: Reverse sort Elixir versions in matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,12 @@ env:
     - NODE_VERSION="10.10.0"
 matrix:
   include:
-    - elixir: 1.7.3
-      otp_release: 19.3
-    - elixir: 1.8.1
-      otp_release: 21.2
     - elixir: 1.9.0
       otp_release: 22.0
       env:
         - CHECK_FORMATTED=true
         - CHECK_JS=true
+    - elixir: 1.8.1
+      otp_release: 21.2
+    - elixir: 1.7.3
+      otp_release: 19.3


### PR DESCRIPTION
Since we do more checkings in the latest version, run it first.
We do the same for Elixir core.