### PR TITLE
Rewrite html formatter tests so it avoid future problems with Travis

### DIFF
--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -175,8 +175,8 @@ defmodule ExDoc.Formatter.HTMLTest do
     assert File.regular?("#{output_dir()}/CompiledWithDocs.html")
     assert File.regular?("#{output_dir()}/CompiledWithDocs.Nested.html")
 
-    assert [_] = Path.wildcard("#{output_dir()}/dist/html-*.css")
-    assert [_] = Path.wildcard("#{output_dir()}/dist/html-*.js")
+    refute [] == Path.wildcard("#{output_dir()}/dist/html-*.css")
+    refute [] == Path.wildcard("#{output_dir()}/dist/html-*.js")
     assert [] = Path.wildcard("#{output_dir()}/another_dir/dist/html-*.js.map")
 
     content = File.read!("#{output_dir()}/index.html")


### PR DESCRIPTION
Tests will fail in Travis when a PR is on the works, and master is ahead
of the PR and new JS and CSS assets have been introduced to master.
You can see the errors here: https://travis-ci.org/elixir-lang/ex_doc/jobs/555347013#L422-L422
Travis fetches the PR and applies it to master.

So one way to solve this is to not to check for only one JS or one CSS file,
but to check for at least having one.