### PR TITLE
Do not strip "Elixir." from text, in fully namespaced calls

### DIFF
--- a/test/ex_doc/formatter/html/autolink_test.exs
+++ b/test/ex_doc/formatter/html/autolink_test.exs
@@ -636,14 +636,31 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
                "[`<<>>/1`](#{@elixir_docs}elixir/Kernel.SpecialForms.html#%3C%3C%3E%3E/1)"
     end
 
-    test "removes optional Elixir namespace" do
-      assert project_doc("`Elixir.Enum`", %{}) == "[`Enum`](#{@elixir_docs}elixir/Enum.html)"
+    test "deals with optional Elixir namespace" do
+      assert project_doc("`Elixir.Enum`", %{}) ==
+               "[`Elixir.Enum`](#{@elixir_docs}elixir/Enum.html)"
 
       assert project_doc("`Elixir.Enum.concat/1`", %{}) ==
-               "[`Enum.concat/1`](#{@elixir_docs}elixir/Enum.html#concat/1)"
+               "[`Elixir.Enum.concat/1`](#{@elixir_docs}elixir/Enum.html#concat/1)"
 
       assert project_doc("`t:Elixir.Enum.t/0`", %{}) ==
-               "[`Enum.t/0`](#{@elixir_docs}elixir/Enum.html#t:t/0)"
+               "[`Elixir.Enum.t/0`](#{@elixir_docs}elixir/Enum.html#t:t/0)"
+
+      assert project_doc(
+               "The fully namespaced module `Elixir.Enum` and the alias `Enum` resolve to the same module.",
+               %{}
+             ) ==
+               "The fully namespaced module [`Elixir.Enum`](#{@elixir_docs}elixir/Enum.html) and the alias [`Enum`](#{
+                 @elixir_docs
+               }elixir/Enum.html) resolve to the same module."
+
+      assert project_doc(
+               "`Elixir.Enum.reduce/3` and `Enum.reduce/3` resolve to the same function.",
+               %{}
+             ) ==
+               "[`Elixir.Enum.reduce/3`](#{@elixir_docs}elixir/Enum.html#reduce/3) and [`Enum.reduce/3`](#{
+                 @elixir_docs
+               }elixir/Enum.html#reduce/3) resolve to the same function."
     end
   end
 

--- a/test/ex_doc/formatter/html/autolink_test.exs
+++ b/test/ex_doc/formatter/html/autolink_test.exs
@@ -645,22 +645,6 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
 
       assert project_doc("`t:Elixir.Enum.t/0`", %{}) ==
                "[`Elixir.Enum.t/0`](#{@elixir_docs}elixir/Enum.html#t:t/0)"
-
-      assert project_doc(
-               "The fully namespaced module `Elixir.Enum` and the alias `Enum` resolve to the same module.",
-               %{}
-             ) ==
-               "The fully namespaced module [`Elixir.Enum`](#{@elixir_docs}elixir/Enum.html) and the alias [`Enum`](#{
-                 @elixir_docs
-               }elixir/Enum.html) resolve to the same module."
-
-      assert project_doc(
-               "`Elixir.Enum.reduce/3` and `Enum.reduce/3` resolve to the same function.",
-               %{}
-             ) ==
-               "[`Elixir.Enum.reduce/3`](#{@elixir_docs}elixir/Enum.html#reduce/3) and [`Enum.reduce/3`](#{
-                 @elixir_docs
-               }elixir/Enum.html#reduce/3) resolve to the same function."
     end
   end
 


### PR DESCRIPTION
This is a continuation of 098b99fcec956a55d3feeae47957ff76e5269d56

Related issue: #1036