### PR TITLE
Avoid re-fetching the same page

### DIFF
--- a/assets/js/tooltips/tooltips.js
+++ b/assets/js/tooltips/tooltips.js
@@ -223,7 +223,7 @@ function prepareTooltips () {
 
   if (isSelfLink(href)) { return }
 
-  currentCacheKey = href;
+  currentCacheKey = href
 
   const typeCategory = findTypeCategory(href)
 

--- a/assets/js/tooltips/tooltips.js
+++ b/assets/js/tooltips/tooltips.js
@@ -35,6 +35,7 @@ const moduleContentHash = '#content' // Hash included in links pointing to modul
 let tooltipElement = null // Will store the jQuery selector for the tooltip root
 let currentLinkElement = null // Element that the cursor is hovering over
 let currentRequestId = null // ID of the request we're waiting for
+let currentCacheKey = null // Cache key for the html to be requested
 let showTimeoutAnimation = null // Timeout ID related to the tooltip show animation
 let hideTimeoutVisibility = null // Timeout ID related to the tooltip hide animation
 let hoverDelayTimeout = null // Timeout ID related to the `hoverDelayTime` described above
@@ -88,6 +89,8 @@ function updateToggleLink () {
 function receivePopupMessage (event) {
   if (event.data.requestId !== currentRequestId) { return }
   if (event.data.ready !== true) { return }
+
+  sessionStorage.setItem(currentCacheKey, JSON.stringify(event.data.hint))
 
   showTooltip(event.data.hint)
 }
@@ -220,6 +223,8 @@ function prepareTooltips () {
 
   if (isSelfLink(href)) { return }
 
+  currentCacheKey = href;
+
   const typeCategory = findTypeCategory(href)
 
   if (typeCategory) {
@@ -227,6 +232,8 @@ function prepareTooltips () {
       kind: 'type',
       description: typeCategory.description
     })
+  } else if (currentCacheKey in sessionStorage) {
+    showTooltip(JSON.parse(sessionStorage.getItem(currentCacheKey)))
   } else {
     const hintHref = rewriteHref(href)
     let iframe = $(tooltipIframeSelector).detach()


### PR DESCRIPTION
I was going to eliminating more requests as I stated in
https://twitter.com/PrMaple/status/1151430729026269184

However, the way of fetching whole pages via iframe has its limits.
While not having to build extra infrastructure server side to support
this functionality, I cannot optimize away the extra requests being
sent out in the iframe.

As a compromise, I think it's the least we can do to not re-request
the already fetched data. (~50KB transferred each hover)

Code is only tested in my head, if someone could test it for me or
point me to how to test it properly I'd appreciate it!