### PR TITLE
Warn on unavailable local functions

### DIFF
--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -458,18 +458,13 @@ defmodule ExDoc.Formatter.HTML.Autolink do
             "#{extension}##{prefix}#{enc(function)}/#{arity})"
 
         module in modules_refs ->
-          if module_id not in skip_warnings_on and id not in skip_warnings_on do
-            IO.warn(
-              "documentation references #{match} but it doesn't exist " <>
-                "or it's listed as @doc false (parsing #{id} docs)",
-              []
-            )
-          end
-
-          text
+          maybe_warn(text, match, module_id, id, skip_warnings_on)
 
         doc = module_docs(:elixir, module, lib_dirs) ->
           "[#{text}](#{doc}#{module}.html##{prefix}#{enc(function)}/#{arity})"
+
+        link_type == :custom ->
+          maybe_warn(text, match, module_id, id, skip_warnings_on)
 
         true ->
           all
@@ -500,6 +495,18 @@ defmodule ExDoc.Formatter.HTML.Autolink do
           all
       end
     end
+  end
+
+  defp maybe_warn(text, match, module_id, id, skip_warnings_on) do
+    if module_id not in skip_warnings_on and id not in skip_warnings_on do
+      IO.warn(
+        "documentation references #{match} but it doesn't exist " <>
+          "or it's listed as @doc false (parsing #{id} docs)",
+        []
+      )
+    end
+
+    text
   end
 
   defp task_module("help " <> task_name) do

--- a/test/ex_doc/formatter/html/autolink_test.exs
+++ b/test/ex_doc/formatter/html/autolink_test.exs
@@ -142,6 +142,11 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
                         "`Mod.example/2`"
              end) =~ ~r"references Mod.example/2 .* \(parsing extras docs\)"
 
+      assert capture_io(:stderr, fn ->
+               assert Autolink.project_doc("[title](`example/2`)", "Mod.foo/0", compiled) ==
+                        "title"
+             end) =~ ~r"references example/2 .* \(parsing Mod.foo/0 docs\)"
+
       # skip warning when module page is blacklisted
       overwritten = Map.put(compiled, :module_id, "Bar")
       assert assert project_doc("`Mod.example/2`", "Mod.bar/0", overwritten) == "`Mod.example/2`"


### PR DESCRIPTION
We introduce another clause (`link_type == :custom ->`) because we only
want to warn for _custom_ links if we didn't find a match, for regular
links if given local function does not exist it's ok, perhaps the docs
refer to function the user is supposed to implement themselves.

Closes #1059.