### PR TITLE
Make index redirect warning case-sensitive

### DIFF
--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -386,8 +386,7 @@ defmodule ExDoc.Formatter.HTML do
   defp case_sensitive_file_regular?(path) do
     if File.regular?(path) do
       files = path |> Path.dirname() |> File.ls!()
-      file = path |> Path.basename()
-      Enum.member?(files, file)
+      Path.basename(path) in files
     else
       false
     end

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -375,12 +375,22 @@ defmodule ExDoc.Formatter.HTML do
   end
 
   defp generate_redirect(filename, config, redirect_to) do
-    unless File.regular?("#{config.output}/#{redirect_to}") do
+    unless case_sensitive_file_regular?("#{config.output}/#{redirect_to}") do
       IO.puts(:stderr, "warning: #{filename} redirects to #{redirect_to}, which does not exist")
     end
 
     content = Templates.redirect_template(config, redirect_to)
     File.write!("#{config.output}/#{filename}", content)
+  end
+
+  defp case_sensitive_file_regular?(path) do
+    if File.regular?(path) do
+      files = path |> Path.dirname() |> File.ls!()
+      file = path |> Path.basename()
+      Enum.member?(files, file)
+    else
+      false
+    end
   end
 
   def filter_list(:module, nodes) do

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -100,12 +100,12 @@ defmodule ExDoc.Formatter.HTMLTest do
   test "warns when generating an index.html file with an invalid redirect" do
     output =
       capture_io(:stderr, fn ->
-        generate_docs(doc_config(main: "Unknown"))
+        generate_docs(doc_config(main: "Randomerror"))
       end)
 
-    assert output == "warning: index.html redirects to Unknown.html, which does not exist\n"
+    assert output == "warning: index.html redirects to Randomerror.html, which does not exist\n"
     assert File.regular?("#{output_dir()}/index.html")
-    refute File.regular?("#{output_dir()}/Unknown.html")
+    assert File.regular?("#{output_dir()}/RandomError.html")
   end
 
   test "warns on undefined functions" do


### PR DESCRIPTION
This intends to fix #1076

Tests are passing on both, case-sensitive system (Arch Linux with ext4) and case-insensitive system (OSX with ... uhm, their FS). Also, a warning is now correctly displayed on OSX.

I adjusted the test to cover this case as well, however, it doesn't really prove much. Not sure if this suffices or if we have to think of some way to actually make this behaviour testable on any system. - I couldn't think of an easy way of simulating the case-insensitive behaviour on my work machine / the CI)