### PR TITLE
Readme: Add link to main configuration listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ ExDoc is a tool to generate documentation for your Elixir projects. To see an ex
 
 To learn about how to document your projects, see [Elixir's writing documentation page](https://hexdocs.pm/elixir/writing-documentation.html).
 
+To see all supported options, see the documetation for [mix docs](https://hexdocs.pm/ex_doc/Mix.Tasks.Docs.html)
+
 ## Features
 
 ExDoc ships with many features:


### PR DESCRIPTION
I think it's important to have a link to the page with the full configuration, otherwise it is difficult to find because it isn't explicitly linked anywhere.

A relative link might be better, but since this is a plain markdown file I'm not aware of a method that would work.
