### PR TITLE
Ignore escript in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ ex_doc-*.tar
 # Ignore artifacts from non-production builds
 formatters/epub/dist/epub.js
 formatters/html/dist/html.js
+
+# Ignore escript when built
+/ex_doc


### PR DESCRIPTION
As you are aware I need to build the escript in order to generate the docs for Earmark, while doing so I get a _dirty_ repo, maybe you want to merge this humble PR in order to avoid this?

Thx in advance