### PR TITLE
Remove extra night-mode padding in .hljs

### DIFF
--- a/assets/less/night/night.less
+++ b/assets/less/night/night.less
@@ -87,7 +87,6 @@ body.night-mode {
     overflow-x: auto;
     background: #1d1f21;
     color: #c5c8c6;
-    padding: 0.5em;
   }
 
   .hljs-emphasis {


### PR DESCRIPTION
This is currently night mode:

<img width="222" alt="image" src="https://user-images.githubusercontent.com/2687/64498164-a398d200-d2f6-11e9-9477-3148498f5e31.png">

And light mode:

<img width="243" alt="image" src="https://user-images.githubusercontent.com/2687/64498174-abf10d00-d2f6-11e9-9f74-1132a46d0a33.png">

And with this PR:

<img width="280" alt="image" src="https://user-images.githubusercontent.com/2687/64498188-b90dfc00-d2f6-11e9-8398-9d0a9441b80a.png">
