### PR TITLE
Link to callback docs instead of copying them

### DIFF
--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -253,7 +253,8 @@ defmodule ExDoc.Retriever do
     annotations = annotations_from_metadata(metadata)
 
     line = find_function_line(module_data, actual_def) || doc_line
-    doc = docstring(doc, name, arity, type, Map.fetch(module_data.impls, {name, arity}))
+    impl = Map.fetch(module_data.impls, actual_def)
+    doc = docstring(doc, name, arity, impl)
     defaults = get_defaults(name, arity, Map.get(metadata, :defaults, 0))
 
     specs =
@@ -301,23 +302,11 @@ defmodule ExDoc.Retriever do
   defp delegate_doc(nil), do: nil
   defp delegate_doc({m, f, a}), do: "See `#{Exception.format_mfa(m, f, a)}`."
 
-  defp docstring(:none, name, arity, type, {:ok, behaviour}) do
-    info = "Callback implementation for `c:#{inspect(behaviour)}.#{name}/#{arity}`."
-
-    with {:docs_v1, _, _, _, _, _, docs} <- Code.fetch_docs(behaviour),
-         key = {definition_to_callback(type), name, arity},
-         {_, _, _, doc, _} <- List.keyfind(docs, key, 0),
-         docstring when is_binary(docstring) <- docstring(doc) do
-      "#{docstring}\n\n#{info}"
-    else
-      _ -> info
-    end
+  defp docstring(:none, name, arity, {:ok, behaviour}) do
+    "Callback implementation for `c:#{inspect(behaviour)}.#{name}/#{arity}`."
   end
 
-  defp docstring(doc, _, _, _, _), do: docstring(doc)
-
-  defp definition_to_callback(:function), do: :callback
-  defp definition_to_callback(:macro), do: :macrocallback
+  defp docstring(doc, _, _, _), do: docstring(doc)
 
   defp get_defaults(_name, _arity, 0), do: []
 

--- a/test/ex_doc/retriever_test.exs
+++ b/test/ex_doc/retriever_test.exs
@@ -272,14 +272,11 @@ defmodule ExDoc.RetrieverTest do
       docs = module_node.docs
       assert Enum.map(docs, & &1.id) == ["bye/1", "greet/1", "hello/1"]
 
-      assert Enum.at(docs, 0).doc ==
-               "A doc for this so it doesn't use 'Callback implementation for'"
+      assert Enum.at(docs, 0).doc == "Callback implementation for `c:CustomBehaviourTwo.bye/1`."
 
-      assert Enum.at(docs, 1).doc == "Callback implementation for `c:CustomBehaviourOne.greet/1`."
+      assert Enum.at(docs, 1).doc == "A doc so it doesn't use 'Callback implementation for'"
 
-      assert Enum.at(docs, 2).doc ==
-               "This is a sample callback.\n\n\n" <>
-                 "Callback implementation for `c:CustomBehaviourOne.hello/1`."
+      assert Enum.at(docs, 2).doc == "Callback implementation for `c:CustomBehaviourOne.hello/1`."
     end
   end
 

--- a/test/fixtures/behaviour.ex
+++ b/test/fixtures/behaviour.ex
@@ -21,8 +21,9 @@ defmodule CustomBehaviourImpl do
   @behaviour CustomBehaviourTwo
 
   def hello(i), do: i
+
+  @doc "A doc so it doesn't use 'Callback implementation for'"
   def greet(i), do: i
 
-  @doc "A doc for this so it doesn't use 'Callback implementation for'"
   defmacro bye(i), do: i
 end


### PR DESCRIPTION
Closes #1093

Additionally we fix a bug where we haven't been handling macrocallback.