### PR TITLE
Rely on `prefers-color-scheme` w/o night mode set

### DIFF
--- a/assets/js/night.js
+++ b/assets/js/night.js
@@ -17,7 +17,7 @@ function activateNightMode () {
 
 function deactivateNightMode () {
   body.removeClass(nightMode)
-  try { localStorage.setItem(nightMode, false) } catch (e) { }
+  try { localStorage.removeItem(nightMode) } catch (e) { }
 }
 
 function checkForNightMode () {
@@ -29,7 +29,7 @@ function checkForNightMode () {
         activateNightMode()
       }
     } else if (matchMedia('(prefers-color-scheme: dark)').matches) {
-      activateNightMode()
+      body.addClass(nightMode)
     }
   } catch (e) { }
 }


### PR DESCRIPTION
Currently when a user visits the page during the night (or rather when
`prefers-color-scheme` is `dark`), the page uses night mode.

This is great, but what's not so great is that it remembers this as a
user choice, and won't automactically change if the user visits the page
at a later time during the day (when `prefers-color-scheme` is `light`
or `no-preference`).

This makes it so that night mode is an explicit choice, which is still
remembered. But if the user turns off night mode it goes back to the
light colors, and if the user later visits the site during night time,
that will be picked up.

The reasoning here is that it's called night mode, which previously was
a opt-in, but the current code makes it set the preference on first
load, and never let's the user change that.