### PR TITLE
Added parens in ex_doc script

### DIFF
--- a/bin/ex_doc
+++ b/bin/ex_doc
@@ -1,5 +1,5 @@
 #!/usr/bin/env elixir
-mix_env = System.get_env["MIX_ENV"] || "dev"
+mix_env = System.get_env()["MIX_ENV"] || "dev"
 Code.prepend_path Path.expand("../_build/#{mix_env}/lib/nimble_parsec/ebin", __DIR__)
 Code.prepend_path Path.expand("../_build/#{mix_env}/lib/makeup/ebin", __DIR__)
 Code.prepend_path Path.expand("../_build/#{mix_env}/lib/makeup_elixir/ebin", __DIR__)
@@ -7,7 +7,7 @@ Code.prepend_path Path.expand("../_build/#{mix_env}/lib/earmark/ebin", __DIR__)
 Code.prepend_path Path.expand("../_build/#{mix_env}/lib/ex_doc/ebin", __DIR__)
 
 if Code.ensure_loaded?(ExDoc.CLI) do
-  ExDoc.CLI.main(System.argv)
+  ExDoc.CLI.main(System.argv())
 else
   IO.puts :stderr, "Error: cannot generate docs because ExDoc.CLI module is not available. " <>
                    "Please run `mix compile` before or ensure ExDoc is available."


### PR DESCRIPTION
Addressing these warnings:
```
% make docs                                                                                     
==> ex_doc (elixir)
bin/elixir ../ex_doc/bin/ex_doc "Elixir" "1.11.0-dev" "lib/elixir/ebin" --main "Kernel" --source-url "https://github.com/elixir-lang/elixir" --source-ref "cc8093aad9b58f32a2300e31838434275ec3664a"  --output doc/elixir --canonical "https://hexdocs.pm/elixir/master/ " --homepage-url "https://elixir-lang.org/docs.html" --formatter "html" --config "lib/elixir/docs.exs"
warning: missing parentheses on call to System.get_env/0. Parentheses are always required on function calls without arguments
  /Users/.../Projects/ex_doc/bin/ex_doc:2

warning: missing parentheses on call to System.argv/0. Parentheses are always required on function calls without arguments
  /Users/.../Projects/ex_doc/bin/ex_doc:10
```