### PR TITLE
Recognize : in function/operator names (for ::/2)

### DIFF
--- a/lib/ex_doc/formatter/html/autolink.ex
+++ b/lib/ex_doc/formatter/html/autolink.ex
@@ -686,7 +686,7 @@ defmodule ExDoc.Formatter.HTML.Autolink do
       (
         (?:[a-z_][_a-zA-Z0-9]*[\?\!]?)     # regular function_name
         |                                  # OR
-        [\{\}=&\\|\\.<>~*^@\\+\\%\\!-\/]+  # special_form
+        [\{\}=&\\|\\.:<>~*^@\\+\\%\\!-\/]+ # special_form
       )
     }x
   end

--- a/test/ex_doc/formatter/html/autolink_test.exs
+++ b/test/ex_doc/formatter/html/autolink_test.exs
@@ -91,6 +91,9 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
 
       assert project_doc("`<<>>/1`", %{aliases: [Kernel]}) ==
                "[`<<>>/1`](Kernel.SpecialForms.html#%3C%3C%3E%3E/1)"
+
+      assert project_doc("`::/2`", %{aliases: [Kernel]}) ==
+               "[`::/2`](Kernel.SpecialForms.html#::/2)"
     end
 
     test "autolinks Kernel functions" do
@@ -227,6 +230,9 @@ defmodule ExDoc.Formatter.HTML.AutolinkTest do
 
       assert project_doc("`Mod.<<>>/1`", %{docs_refs: ["Mod.<<>>/1"]}) ==
                "[`Mod.<<>>/1`](Mod.html#%3C%3C%3E%3E/1)"
+
+      assert project_doc("`Mod.::/2`", %{docs_refs: ["Mod.::/2"]}) ==
+               "[`Mod.::/2`](Mod.html#::/2)"
     end
 
     test "autolinks callbacks" do


### PR DESCRIPTION
This will remove the need for [this workaround](https://github.com/elixir-lang/elixir/pull/9903#discussion_r395922872).