### PR TITLE
Make autolinker module parser stricter

### DIFF
--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -30,7 +30,6 @@ defmodule ExDoc.Autolink do
 
   def doc(ast, options \\ []) do
     config = struct!(__MODULE__, options)
-
     walk(ast, config)
   end
 
@@ -200,9 +199,21 @@ defmodule ExDoc.Autolink do
     end
   end
 
-  defp parse_module(string, mode) do
+  defp parse_module(<<first>> <> _ = string, _mode) when first in ?A..?Z do
+    do_parse_module(string)
+  end
+
+  defp parse_module(<<?:>> <> _ = string, :custom_link) do
+    do_parse_module(string)
+  end
+
+  defp parse_module(_, _) do
+    :error
+  end
+
+  defp do_parse_module(string) do
     case Code.string_to_quoted(string, warn_on_unnecessary_quotes: false) do
-      {:ok, module} when mode == :custom_link and is_atom(module) -> {:module, module}
+      {:ok, module} when is_atom(module) -> {:module, module}
       {:ok, {:__aliases__, _, parts}} -> {:module, Module.concat(parts)}
       _ -> :error
     end


### PR DESCRIPTION
This way we will attempt to parse less expressions, notably we wouldn't
parse `()` which warns:

    iex> Code.string_to_quoted("()")
    warning: invalid expression (). If you want to invoke or define a function, make sure there are no spaces between the function name and its arguments. If you wanted to pass an empty block, pass a value instead, such as a nil or an atom
      nofile:1