### PR TITLE
Modules grouped by prefix

### DIFF
--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -391,10 +391,16 @@ defmodule ExDoc.Formatter.HTML do
 
   def filter_list(:module, nodes) do
     Enum.filter(nodes, &(&1.type != :task))
+    |> sort_module_node_list
   end
 
   def filter_list(type, nodes) do
     Enum.filter(nodes, &(&1.type == type))
+  end
+
+  defp sort_module_node_list(modules) do
+    modules
+    |> Enum.sort_by(fn module -> {module.nested_context, module.nested_title} end)
   end
 
   defp generate_list(nodes, nodes_map, config) do

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -132,8 +132,14 @@ defmodule ExDoc.Formatter.HTML.Templates do
 
         Map.new([group: to_string(module.group)] ++ extra ++ pairs)
       end
+      |> sort_modules()
 
     {id, modules}
+  end
+
+  defp sort_modules(modules) do
+    modules
+    |> Enum.sort_by(fn module -> {module[:nested_context], module[:nested_title]} end)
   end
 
   defp sidebar_entries({group, docs}) do

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -132,14 +132,8 @@ defmodule ExDoc.Formatter.HTML.Templates do
 
         Map.new([group: to_string(module.group)] ++ extra ++ pairs)
       end
-      |> sort_modules()
 
     {id, modules}
-  end
-
-  defp sort_modules(modules) do
-    modules
-    |> Enum.sort_by(fn module -> {module[:nested_context], module[:nested_title]} end)
   end
 
   defp sidebar_entries({group, docs}) do

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -203,16 +203,13 @@ defmodule ExDoc.Formatter.HTMLTest do
 
   test "groups modules by nesting" do
     doc_config()
-    |> Keyword.put(:nest_modules_by_prefix, [Common.Nesting.Prefix])
+    |> Keyword.put(:nest_modules_by_prefix, [Common.Nesting.Prefix.B, Common.Nesting.Prefix.B.B])
     |> generate_docs()
 
     content = read_wildcard!("#{output_dir()}/dist/sidebar_items-*.js")
 
     assert content =~
-             ~r{"id":"Common\.Nesting\.Prefix\.Foo","nested_context":"Common\.Nesting\.Prefix","nested_title":"Foo","title":"Common\.Nesting\.Prefix\.Foo"}ms
-
-    assert content =~
-             ~r{"id":"Common\.Nesting\.Prefix\.Bar","nested_context":"Common\.Nesting\.Prefix","nested_title":"Bar","title":"Common\.Nesting\.Prefix\.Bar"}ms
+             ~r/{"group":"","id":"Common\.Nesting\.Prefix\.B\.C","nested_context":"Common\.Nesting\.Prefix\.B","nested_title":"C","title":"Common\.Nesting\.Prefix\.B\.C"},{"group":"","id":"Common\.Nesting\.Prefix\.B\.B\.A","nested_context":"Common\.Nesting\.Prefix\.B\.B","nested_title":"A","title":"Common.Nesting.Prefix\.B\.B\.A"}/ms
   end
 
   describe "generates logo" do

--- a/test/ex_doc/retriever_test.exs
+++ b/test/ex_doc/retriever_test.exs
@@ -77,19 +77,19 @@ defmodule ExDoc.RetrieverTest do
     end
 
     test "returns nesting information" do
-      prefix = "Common.Nesting.Prefix"
+      prefix = "Common.Nesting.Prefix.B"
 
       module_nodes =
-        docs_from_files([prefix <> ".Foo", prefix <> ".Bar"], nest_modules_by_prefix: [prefix])
+        docs_from_files([prefix <> ".A", prefix <> ".C"], nest_modules_by_prefix: [prefix])
 
       assert length(module_nodes) > 0
 
       for module_node <- module_nodes do
         assert module_node.nested_context == prefix
-        assert module_node.nested_title in ~w(Foo Bar)
+        assert module_node.nested_title in ~w(A C)
       end
 
-      name = "Common.Nesting.Prefix.Foo"
+      name = "Common.Nesting.Prefix.B.B.A"
       [module_node] = docs_from_files([name], nest_modules_by_prefix: [name])
 
       refute module_node.nested_context

--- a/test/fixtures/common_nesting_prefix_b_a.ex
+++ b/test/fixtures/common_nesting_prefix_b_a.ex
@@ -1,0 +1,3 @@
+defmodule Common.Nesting.Prefix.B.A do
+  @moduledoc "moduledoc"
+end

--- a/test/fixtures/common_nesting_prefix_b_b_a.ex
+++ b/test/fixtures/common_nesting_prefix_b_b_a.ex
@@ -1,0 +1,3 @@
+defmodule Common.Nesting.Prefix.B.B.A do
+  @moduledoc "moduledoc"
+end

--- a/test/fixtures/common_nesting_prefix_b_c.ex
+++ b/test/fixtures/common_nesting_prefix_b_c.ex
@@ -1,0 +1,3 @@
+defmodule Common.Nesting.Prefix.B.C do
+  @moduledoc "moduledoc"
+end

--- a/test/fixtures/common_nesting_prefix_bar.ex
+++ b/test/fixtures/common_nesting_prefix_bar.ex
@@ -1,3 +1,0 @@
-defmodule Common.Nesting.Prefix.Bar do
-  @moduledoc "moduledoc"
-end

--- a/test/fixtures/common_nesting_prefix_foo.ex
+++ b/test/fixtures/common_nesting_prefix_foo.ex
@@ -1,3 +1,0 @@
-defmodule Common.Nesting.Prefix.Foo do
-  @moduledoc "moduledoc"
-end


### PR DESCRIPTION
Module nodes are ordered by `nested_context`. Thus, the sidebar does not show the same nested group multiple times.

closes #1123 