### PR TITLE
Auto link types with a trailing !

### DIFF
--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -287,7 +287,7 @@ defmodule ExDoc.Autolink do
 
   defp do_typespec(string, config) do
     regex =
-      ~r/((?:((?:\:[a-z][_a-zA-Z0-9]*)|(?:[A-Z][_a-zA-Z0-9]*(?:\.[A-Z][_a-zA-Z0-9]*)*))\.)?(\w+))(\(.*\))/
+      ~r/((?:((?:\:[a-z][_a-zA-Z0-9]*)|(?:[A-Z][_a-zA-Z0-9]*(?:\.[A-Z][_a-zA-Z0-9]*)*))\.)?(\w+!?))(\(.*\))/
 
     Regex.replace(regex, string, fn _all, call_string, module_string, name_string, rest ->
       module = string_to_module(module_string)

--- a/test/ex_doc/autolink_test.exs
+++ b/test/ex_doc/autolink_test.exs
@@ -210,7 +210,8 @@ defmodule ExDoc.AutolinkTest do
       ExDoc.Refs.insert([
         {{:module, MyModule}, true},
         {{:type, MyModule, :foo, 1}, true},
-        {{:type, MyModule, :foo, 2}, true}
+        {{:type, MyModule, :foo, 2}, true},
+        {{:type, MyModule, :foo!, 1}, true}
       ])
 
       assert typespec(quote(do: t() :: foo(1))) ==
@@ -227,6 +228,9 @@ defmodule ExDoc.AutolinkTest do
 
       assert typespec(quote(do: t() :: foo(bar(), bar()))) ==
                ~s[t() :: <a href="#t:foo/2">foo</a>(bar(), bar())]
+
+      assert typespec(quote(do: t() :: foo!(bar()))) ==
+               ~s[t() :: <a href="#t:foo!/1">foo!</a>(bar())]
     end
 
     test "remotes" do


### PR DESCRIPTION
This PR fixes a bug causing types with a trailing `!` to not be auto linked any more.

The reason for this is that the regular expression introduced with #1103 does not account for those.
Consequently this is fixed by adding `!?` (an optional `!`) to the `name_string` capturing group.

Relevant screenshots:

<details>
<summary>v0.21.2 - links</summary>

![image](https://user-images.githubusercontent.com/24881032/79038989-32980080-7bde-11ea-8434-ba114817d8bc.png)
</details>

<details>
<summary>3dcab6dc1beb7f4e118a48ef3f6b30331f98347b (commit before #1103) - links</summary>

![image](https://user-images.githubusercontent.com/24881032/79039027-84d92180-7bde-11ea-8c8c-0fbd728bd65d.png)
</details>

<details>
<summary>a14aea847ef750b620f3ae5baccc0225d4488646 (or #1103) - does not link</summary>

![image](https://user-images.githubusercontent.com/24881032/79039394-53158a00-7be1-11ea-83f6-ae3249c97f9a.png)
</details>

<details>
<summary>v0.21.3 - does not link </summary>

![image](https://user-images.githubusercontent.com/24881032/79039021-73901500-7bde-11ea-826f-188e309439e0.png)
</details>

<details>
<summary>4bb9a6f25dd2e522122daa48829a3d455e7f766a (current master) - does not link</summary>

![image](https://user-images.githubusercontent.com/24881032/79039563-4d6c7400-7be2-11ea-907b-ef02dc2aed0e.png)
</details>

<details>
<summary>8935203a8b599b7bac2c16f612b1db94fdf3e93e (this PR) - links</summary>

![image](https://user-images.githubusercontent.com/24881032/79039539-2d3cb500-7be2-11ea-9b55-4d38bdbcaa01.png)
</details>

<details>
<summary>Used code</summary>

```elixir
defmodule Test do
  @type bar :: boolean()
  @type bar! :: boolean()

  @callback foo() :: bar()
  @callback foo!() :: bar!()
end

```
</details>