### PR TITLE
sort modules by group, nested_context, nested_title, id

### DIFF
--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -442,16 +442,10 @@ defmodule ExDoc.Formatter.HTML do
 
   def filter_list(:module, nodes) do
     Enum.filter(nodes, &(&1.type != :task))
-    |> sort_module_node_list
   end
 
   def filter_list(type, nodes) do
     Enum.filter(nodes, &(&1.type == type))
-  end
-
-  defp sort_module_node_list(modules) do
-    modules
-    |> Enum.sort_by(fn module -> {module.nested_context, module.nested_title} end)
   end
 
   defp generate_list(nodes, nodes_map, config) do

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -42,7 +42,8 @@ defmodule ExDoc.Retriever do
     modules
     |> Enum.flat_map(&get_module(&1, config))
     |> Enum.sort_by(fn module ->
-      {GroupMatcher.group_index(config.groups_for_modules, module.group), module.id}
+      {GroupMatcher.group_index(config.groups_for_modules, module.group), module.nested_context,
+       module.nested_title, module.id}
     end)
   end
 

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -213,6 +213,29 @@ defmodule ExDoc.Formatter.HTMLTest do
              ~r/{"group":"","id":"Common\.Nesting\.Prefix\.B\.C","nested_context":"Common\.Nesting\.Prefix\.B","nested_title":"C","title":"Common\.Nesting\.Prefix\.B\.C"},{"group":"","id":"Common\.Nesting\.Prefix\.B\.B\.A","nested_context":"Common\.Nesting\.Prefix\.B\.B","nested_title":"A","title":"Common.Nesting.Prefix\.B\.B\.A"}/ms
   end
 
+  test "groups modules by nesting respecting groups" do
+    groups = [
+      Group1: [
+        Common.Nesting.Prefix.B.A,
+        Common.Nesting.Prefix.B.C
+      ],
+      Group2: [
+        Common.Nesting.Prefix.B.B.A,
+        Common.Nesting.Prefix.C
+      ]
+    ]
+
+    doc_config()
+    |> Keyword.put(:nest_modules_by_prefix, [Common.Nesting.Prefix.B, Common.Nesting.Prefix.B.B])
+    |> Keyword.put(:groups_for_modules, groups)
+    |> generate_docs()
+
+    content = read_wildcard!("#{output_dir()}/dist/sidebar_items-*.js")
+
+    assert content =~
+             ~r/{"group":"Group1","id":"Common\.Nesting\.Prefix\.B\.A","nested_context":"Common\.Nesting\.Prefix\.B","nested_title":"A","title":"Common\.Nesting\.Prefix\.B\.A"},{"group":"Group1","id":"Common\.Nesting\.Prefix\.B\.C","nested_context":"Common\.Nesting\.Prefix\.B","nested_title":"C","title":"Common\.Nesting\.Prefix\.B\.C"},{"group":"Group2","id":"Common\.Nesting\.Prefix\.C","title":"Common\.Nesting\.Prefix\.C"},{"group":"Group2","id":"Common\.Nesting\.Prefix\.B\.B\.A","nested_context":"Common\.Nesting\.Prefix\.B\.B","nested_title":"A","title":"Common\.Nesting\.Prefix\.B\.B\.A"}/ms
+  end
+
   describe "generates logo" do
     test "overriding previous entries" do
       File.mkdir_p!("#{output_dir()}/assets")

--- a/test/fixtures/common_nesting_prefix_c.ex
+++ b/test/fixtures/common_nesting_prefix_c.ex
@@ -1,0 +1,3 @@
+defmodule Common.Nesting.Prefix.C do
+  @moduledoc "moduledoc"
+end


### PR DESCRIPTION
When using both `:nest_modules_by_prefix` and `:groups_for_modules` together, groups might be rendered more than once:
![duplicated groups example](https://user-images.githubusercontent.com/24881032/79559539-3926ec00-80a6-11ea-8566-f2033eda2d81.png)

This is due to the modules getting sorted first by groups and then later in the html formatter again by nested_context and nested_title. (introduced in #1141)

Including these sort criteria where modules are initially sorted seems to fix this while not breaking #1123 again.

![no longer duplicated groups example](https://user-images.githubusercontent.com/24881032/79559722-8d31d080-80a6-11ea-998b-db89c2839615.png)

