### PR TITLE
Fix chunk extraction for Elixir module on case-insensitive fs

### DIFF
--- a/lib/ex_doc/refs.ex
+++ b/lib/ex_doc/refs.ex
@@ -1,5 +1,6 @@
 defmodule ExDoc.Refs do
   @moduledoc false
+
   # A read-through cache of documentation references.
   #
   # The cache consists of entries:

--- a/lib/ex_doc/refs.ex
+++ b/lib/ex_doc/refs.ex
@@ -89,13 +89,18 @@ defmodule ExDoc.Refs do
         {:chunk, entries}
 
       {:error, :chunk_not_found} ->
-        entries =
-          for {name, arity} <- exports(module) do
-            {{:function, module, name, arity}, true}
-          end
+        if Code.ensure_loaded?(module) do
+          entries =
+            for {name, arity} <- exports(module) do
+              {{:function, module, name, arity}, true}
+            end
 
-        entries = [{{:module, module}, true} | entries]
-        {:exports, entries}
+          entries = [{{:module, module}, true} | entries]
+          {:exports, entries}
+        else
+          entries = [{{:module, module}, false}]
+          {:none, entries}
+        end
 
       _ ->
         entries = [{{:module, module}, false}]

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -75,6 +75,7 @@ defmodule ExDoc.Retriever do
 
   # Special case required for Elixir
   defp docs_chunk(:elixir_bootstrap), do: false
+  defp docs_chunk(Elixir), do: false
 
   defp docs_chunk(module) do
     unless function_exported?(Code, :fetch_docs, 1) do

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -75,7 +75,6 @@ defmodule ExDoc.Retriever do
 
   # Special case required for Elixir
   defp docs_chunk(:elixir_bootstrap), do: false
-  defp docs_chunk(Elixir), do: false
 
   defp docs_chunk(module) do
     unless function_exported?(Code, :fetch_docs, 1) do

--- a/lib/ex_doc/utils/code.ex
+++ b/lib/ex_doc/utils/code.ex
@@ -4,11 +4,6 @@ defmodule ExDoc.Utils.Code do
   # TODO: this is vendored from Elixir v1.11.0.
   #       Remove and use Code.fetch_docs/1 in the future.
 
-  # special case required for Elixir
-  def fetch_docs(Elixir) do
-    false
-  end
-
   def fetch_docs(module) when is_atom(module) do
     case :code.get_object_code(module) do
       {_module, bin, beam_path} ->

--- a/lib/ex_doc/utils/code.ex
+++ b/lib/ex_doc/utils/code.ex
@@ -3,6 +3,12 @@ defmodule ExDoc.Utils.Code do
 
   # TODO: this is vendored from Elixir v1.11.0.
   #       Remove and use Code.fetch_docs/1 in the future.
+
+  # special case required for Elixir
+  def fetch_docs(Elixir) do
+    false
+  end
+
   def fetch_docs(module) when is_atom(module) do
     case :code.get_object_code(module) do
       {_module, bin, beam_path} ->

--- a/test/ex_doc/refs_test.exs
+++ b/test/ex_doc/refs_test.exs
@@ -32,4 +32,9 @@ defmodule ExDoc.RefsTest do
     assert Refs.public?({:type, :sets, :set, 0})
     assert Refs.public?({:type, :sets, :set, 9}) in [true, false]
   end
+
+  test "from_chunk/2 with module that doesn't exist" do
+    result = ExDoc.Utils.Code.fetch_docs(:elixir)
+    assert {:none, _} = ExDoc.Refs.from_chunk(Elixir, result)
+  end
 end


### PR DESCRIPTION
Closes #1149

On such filesystems we'd get:

    iex> :code.get_object_code(Elixir)
    {Elixir, <<70, 79, 82, , ...>>, '(...)/../lib/elixir/ebin/Elixir.beam'}

And so we're getting the beam file for the private `:elixir` module.