### PR TITLE
Update undefined reference warning and :skip_undefined_reference_warnings_on option

### DIFF
--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -72,7 +72,8 @@ defmodule ExDoc.Formatter.HTML do
         current_module: node.module,
         ext: ext,
         skip_undefined_reference_warnings_on: config.skip_undefined_reference_warnings_on,
-        module_id: node.id
+        module_id: node.id,
+        file: node.source_path
       ]
 
       docs =
@@ -282,7 +283,7 @@ defmodule ExDoc.Formatter.HTML do
   defp build_extra(input, id, title, groups, config, ext) do
     autolink_opts = [
       app: config.app,
-      id: id,
+      file: input,
       ext: ext,
       skip_undefined_reference_warnings_on: config.skip_undefined_reference_warnings_on
     ]

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -153,9 +153,9 @@ defmodule Mix.Tasks.Docs do
       Receives a list of atoms. Example: `[:first_app, :second_app]`.
 
     * `:skip_undefined_reference_warnings_on` - ExDoc warns when it can't create a `Mod.fun/arity`
-      reference in the current project docs e.g. because of a typo. This list controls
-      which docs pages to skip the warnings on, which is useful for e.g. deprecation pages;
-      default: `[]`.
+      reference in the current project docs e.g. because of a typo. This list controls where to
+      skip the warnings, for a given module/function/callback/type (e.g.: `["Foo", "Bar.baz/0"]`)
+      or on a given file (e.g.: `["pages/deprecations.md"]`); default: `[]`.
 
   ## Groups
 

--- a/mix.exs
+++ b/mix.exs
@@ -94,7 +94,8 @@ defmodule ExDoc.Mixfile do
           ExDoc.ModuleNode,
           ExDoc.TypeNode
         ]
-      ]
+      ],
+      skip_undefined_reference_warnings_on: ["CHANGELOG.md"]
     ]
   end
 

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -106,10 +106,21 @@ defmodule ExDoc.Formatter.HTMLTest do
         generate_docs(doc_config(skip_undefined_reference_warnings_on: []))
       end)
 
-    assert output =~ ~r"Warnings.bar/0 .* \(parsing Warnings docs\)"
-    assert output =~ ~r"Warnings.bar/0 .* \(parsing Warnings.foo/0 docs\)"
-    assert output =~ ~r"Warnings.bar/0 .* \(parsing c:Warnings.handle_foo/0 docs\)"
-    assert output =~ ~r"Warnings.bar/0 .* \(parsing t:Warnings.t/0 docs\)"
+    assert output =~ ~r"Warnings.bar/0.*\n  test/fixtures/warnings.ex: Warnings"
+    assert output =~ ~r"Warnings.bar/0.*\n  test/fixtures/warnings.ex: Warnings.foo/0"
+    assert output =~ ~r"Warnings.bar/0.*\n  test/fixtures/warnings.ex: c:Warnings.handle_foo/0"
+    assert output =~ ~r"Warnings.bar/0.*\n  test/fixtures/warnings.ex: t:Warnings.t/0"
+  end
+
+  test "warns on undefined functions in file" do
+    output =
+      capture_io(:stderr, fn ->
+        generate_docs(
+          doc_config(skip_undefined_reference_warnings_on: ["test/fixtures/warnings.ex"])
+        )
+      end)
+
+    assert output == ""
   end
 
   test "generates headers for index.html and module pages" do


### PR DESCRIPTION
Previously we were warning like this:

    warning: documentation references function ExUnit.Case.__using__/1 but it doesn't exist or isn't public (parsing Kernel.use/2 docs)

Now, to be consistent with other Elixir warnings, we output:

    warning: documentation references function ExUnit.Case.__using__/1 but it is undefined or private
      lib/elixir/lib/kernel.ex: Kernel.use/2

We're also making a breaking change to
`:skip_undefined_reference_warnings_on`, previously we could give it the
generated id of an extra e.g.: `["compatibility-and-deprecations"]`, now
we'd give it the path instead:
`["lib/elixir/pages/compatibility-and-deprecations.md"]`.