### PR TITLE
Display line numbers for undefined reference warnings

### DIFF
--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -73,13 +73,14 @@ defmodule ExDoc.Formatter.HTML do
         ext: ext,
         skip_undefined_reference_warnings_on: config.skip_undefined_reference_warnings_on,
         module_id: node.id,
-        file: node.source_path
+        file: node.source_path,
+        line: node.doc_line
       ]
 
       docs =
         for child_node <- node.docs do
           id = id(node, child_node)
-          autolink_opts = [{:id, id} | autolink_opts]
+          autolink_opts = autolink_opts ++ [id: id, line: child_node.doc_line]
           specs = Enum.map(child_node.specs, &Autolink.typespec(&1, autolink_opts))
           child_node = %{child_node | specs: specs}
           render_doc(child_node, autolink_opts, opts)
@@ -88,7 +89,7 @@ defmodule ExDoc.Formatter.HTML do
       typespecs =
         for child_node <- node.typespecs do
           id = id(node, child_node)
-          autolink_opts = [{:id, id} | autolink_opts]
+          autolink_opts = autolink_opts ++ [id: id, line: child_node.doc_line]
           child_node = %{child_node | spec: Autolink.typespec(child_node.spec, autolink_opts)}
           render_doc(child_node, autolink_opts, opts)
         end

--- a/test/ex_doc/autolink_test.exs
+++ b/test/ex_doc/autolink_test.exs
@@ -300,11 +300,11 @@ defmodule ExDoc.AutolinkTest do
 
     captured =
       assert_warn(fn ->
-        assert_unchanged(~t"Foo.bar/1", file: "lib/foo.ex", id: nil)
+        assert_unchanged(~t"Foo.bar/1", file: "lib/foo.ex", line: 1, id: nil)
       end)
 
     assert captured =~ "documentation references function Foo.bar/1"
-    assert captured =~ ~r{lib/foo.ex\n$}
+    assert captured =~ ~r{lib/foo.ex:1\n$}
 
     captured =
       assert_warn(fn ->

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -106,10 +106,10 @@ defmodule ExDoc.Formatter.HTMLTest do
         generate_docs(doc_config(skip_undefined_reference_warnings_on: []))
       end)
 
-    assert output =~ ~r"Warnings.bar/0.*\n  test/fixtures/warnings.ex: Warnings"
-    assert output =~ ~r"Warnings.bar/0.*\n  test/fixtures/warnings.ex: Warnings.foo/0"
-    assert output =~ ~r"Warnings.bar/0.*\n  test/fixtures/warnings.ex: c:Warnings.handle_foo/0"
-    assert output =~ ~r"Warnings.bar/0.*\n  test/fixtures/warnings.ex: t:Warnings.t/0"
+    assert output =~ ~r"Warnings.bar/0.*\n  test/fixtures/warnings.ex:2: Warnings"
+    assert output =~ ~r"Warnings.bar/0.*\n  test/fixtures/warnings.ex:18: Warnings.foo/0"
+    assert output =~ ~r"Warnings.bar/0.*\n  test/fixtures/warnings.ex:13: c:Warnings.handle_foo/0"
+    assert output =~ ~r"Warnings.bar/0.*\n  test/fixtures/warnings.ex:8: t:Warnings.t/0"
   end
 
   test "warns on undefined functions in file" do


### PR DESCRIPTION
Currently we simply display the line number of the beginning of the docs
if present (i.e.: line of `@moduledoc`, `@doc`, etc. We don't do it for
extras)

In the future, when Markdown engine will return line number in AST,
we'll make the warning even more accurate.