### PR TITLE
Fix documentation of defaults for :fromatters

### DIFF
--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -88,7 +88,7 @@ defmodule Mix.Tasks.Docs do
     * `:filter_prefix` - Include only modules that match the given prefix in
       the generated documentation. Example: "MyApp.Core"
 
-    * `:formatters` - Formatter to use; default: ["html"], options: "html", "epub".
+    * `:formatters` - Formatter to use; default: ["html", "epub"], options: "html", "epub".
 
     * `:groups_for_extras`, `:groups_for_modules`, `:groups_for_functions` - See the "Groups" section
 


### PR DESCRIPTION
I think the new default was only updated on the command line option.