### PR TITLE
Fix documentation of formatters defaults in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,7 @@ You can ExDoc via the command line as follows:
     ```bash
     $ ex_doc "PROJECT_NAME" "PROJECT_VERSION" path/to/project/ebin -m "PROJECT_MODULE" -u "https://github.com/GITHUB_USER/GITHUB_REPO" -l path/to/logo.png
     ```
-
-4. By default, ex_doc produces HTML files, but, you can also create a EPUB document passing the option `--formatter epub`:
-
-    ```bash
-    $ PATH_TO_YOUR_EXDOC/bin/ex_doc "PROJECT_NAME" "PROJECT_VERSION" path/to/project/ebin -m "PROJECT_MODULE" -u "https://github.com/GITHUB_USER/GITHUB_REPO" -l path/to/logo.png -f epub
-    ```
+    By default, ex_doc produces HTML files and a EPUB document.  
 
 For example, here are some acceptable values:
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ You can ExDoc via the command line as follows:
     ```bash
     $ ex_doc "PROJECT_NAME" "PROJECT_VERSION" path/to/project/ebin -m "PROJECT_MODULE" -u "https://github.com/GITHUB_USER/GITHUB_REPO" -l path/to/logo.png
     ```
-    By default, ex_doc produces HTML files and a EPUB document.  
 
 For example, here are some acceptable values:
 


### PR DESCRIPTION
I think as HTML + EPUB is default now, we should remove the mention of the formatters options completely in the README.