### PR TITLE
Ignore fourth element in Earmark ast

### DIFF
--- a/lib/ex_doc/markdown/earmark.ex
+++ b/lib/ex_doc/markdown/earmark.ex
@@ -58,6 +58,7 @@ defmodule ExDoc.Markdown.Earmark do
   defp fixup(list) when is_list(list), do: Enum.map(list, &fixup/1)
   defp fixup(binary) when is_binary(binary), do: binary
   defp fixup({tag, attrs, ast}), do: {fixup_tag(tag), Enum.map(attrs, &fixup_attr/1), fixup(ast)}
+  defp fixup({tag, attrs, ast, _meta}), do: fixup({tag, attrs, ast})
 
   defp fixup_tag(tag), do: String.to_atom(tag)
 

--- a/test/ex_doc/markdown/earmark_test.exs
+++ b/test/ex_doc/markdown/earmark_test.exs
@@ -9,6 +9,7 @@ defmodule ExDoc.Markdown.EarmarkTest do
     test "generate AST" do
       assert Markdown.to_ast("# Test\n\nHello", []) == [{:h1, [], ["Test"]}, {:p, [], ["Hello"]}]
       assert Markdown.to_ast("[foo](bar)", []) == [{:p, [], [{:a, [href: "bar"], ["foo"]}]}]
+      assert Markdown.to_ast("<p>\nTest\n</p>", []) == [{:p, '', ["Test"]}]
     end
 
     test "empty input" do


### PR DESCRIPTION
Fixes https://github.com/elixir-lang/ex_doc/issues/1165 by ignoring the fourth element in the tuple