### PR TITLE
Make earmark version requirement stricter

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule ExDoc.Mixfile do
 
   defp deps do
     [
-      {:earmark, "~> 1.4"},
+      {:earmark, "~> 1.4.0"},
       {:makeup_elixir, "~> 0.14"},
       {:excoveralls, "~> 0.3", only: :test},
       {:jason, "~> 1.2", only: :test}


### PR DESCRIPTION
We depend on experimental AST support that may change in Earmark v1.5.0
so let's keep our requirement stricter for now and possibly loosen it up
again in the future.