### PR TITLE
Fix text overflow in sidebar

### DIFF
--- a/assets/less/sidebar.less
+++ b/assets/less/sidebar.less
@@ -227,6 +227,8 @@
       padding: 0;
       line-height: 27px;
       white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
 
       &.open > ul {
         display: block;


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/59962222/84139762-0a643b00-aa83-11ea-8348-23587875b2e9.png)

After:
![2020-06-09_17-29](https://user-images.githubusercontent.com/59962222/84139779-13550c80-aa83-11ea-8b1a-527300b935a1.png)
