### PR TITLE
Remove duplicate expression from ast_to_html/1

### DIFF
--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -128,7 +128,6 @@ defmodule ExDoc.Formatter.HTML do
   defp ast_to_html({tag, attrs, ast}) do
     attrs = Enum.map(attrs, fn {key, val} -> " #{key}=\"#{val}\"" end)
     ["<#{tag}", attrs, ">", ast_to_html(ast), "</#{tag}>"]
-    ["<#{tag}#{attrs}>", ast_to_html(ast), "</#{tag}>"]
   end
 
   defp output_setup(build, config) do


### PR DESCRIPTION
`ExDoc.Formatter.HTML.ast_to_html({tag, attrs, ast})` ends with two equivalent expressions that build the HTML iolist (the former is simply evaluated and discarded), so I removed the latter as it performs an extra concatenation.