### PR TITLE
Add support for path dependent markdown autolink

### DIFF
--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -105,10 +105,10 @@ defmodule ExDoc.Autolink do
          uri <- URI.parse(href),
          nil <- uri.host,
          true <- is_binary(uri.path),
-         true <- uri.path == Path.basename(uri.path),
          ".md" <- Path.extname(uri.path) do
-      if uri.path in config.extras do
-        without_ext = String.trim_trailing(uri.path, ".md")
+      md_file = Path.basename(uri.path)
+      if md_file in config.extras do
+        without_ext = String.trim_trailing(md_file, ".md")
         fragment = (uri.fragment && "#" <> uri.fragment) || ""
         HTML.text_to_id(without_ext) <> config.ext <> fragment
       else

--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -107,6 +107,7 @@ defmodule ExDoc.Autolink do
          true <- is_binary(uri.path),
          ".md" <- Path.extname(uri.path) do
       md_file = Path.basename(uri.path)
+
       if md_file in config.extras do
         without_ext = String.trim_trailing(md_file, ".md")
         fragment = (uri.fragment && "#" <> uri.fragment) || ""

--- a/test/ex_doc/autolink_test.exs
+++ b/test/ex_doc/autolink_test.exs
@@ -202,6 +202,8 @@ defmodule ExDoc.AutolinkTest do
 
       assert autolink(~m"[Foo](Foo Bar.md#baz)", opts) == ~m"[Foo](foo-bar.html#baz)"
 
+      assert autolink(~m"[Foo](../guide/Foo Bar.md)", opts) == ~m"[Foo](foo-bar.html)"
+
       assert_unchanged(~m"[Foo](http://example.com/foo.md)", opts)
 
       assert_unchanged(~m"[Foo](#baz)", opts)


### PR DESCRIPTION
add support for local path markdown to be autolinked as html in documentation generated
(as in https://github.com/elixir-lang/ex_doc/issues/1186)

example `../subscriptions.md` autolinked as `subscriptions.html`:
![image](https://user-images.githubusercontent.com/50098236/84440599-7ce04100-ac64-11ea-8359-8fa968476ffd.png)
 