### PR TITLE
Allow files with no extension in extra files

### DIFF
--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -105,11 +105,11 @@ defmodule ExDoc.Autolink do
          uri <- URI.parse(href),
          nil <- uri.host,
          true <- is_binary(uri.path),
-         extension  when extension in [".md", ""] <- Path.extname(uri.path) do
-      md_file = Path.basename(uri.path)
+         extension when extension in [".md", ".txt", ""] <- Path.extname(uri.path) do
+      file = Path.basename(uri.path)
 
-      if md_file in config.extras do
-        without_ext = String.trim_trailing(md_file, ".md")
+      if file in config.extras do
+        without_ext = trim_extension(file, extension)
         fragment = (uri.fragment && "#" <> uri.fragment) || ""
         HTML.text_to_id(without_ext) <> config.ext <> fragment
       else
@@ -121,6 +121,12 @@ defmodule ExDoc.Autolink do
       _ -> nil
     end
   end
+
+  defp trim_extension(file, ""),
+    do: file
+
+  defp trim_extension(file, extension),
+    do: String.trim_trailing(file, extension)
 
   @basic_types [
     any: 0,

--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -105,7 +105,7 @@ defmodule ExDoc.Autolink do
          uri <- URI.parse(href),
          nil <- uri.host,
          true <- is_binary(uri.path),
-         ".md" <- Path.extname(uri.path) do
+         extension  when extension in [".md", ""] <- Path.extname(uri.path) do
       md_file = Path.basename(uri.path)
 
       if md_file in config.extras do

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -128,14 +128,7 @@ defmodule ExDoc.Formatter.HTML do
 
   def ast_to_html({tag, attrs, ast}) do
     attrs = Enum.map(attrs, fn {key, val} -> " #{key}=\"#{val}\"" end)
-
-    case tag do
-      tag when tag in [:pre, :code] ->
-        ["<#{tag}", attrs, ">", Enum.intersperse(ast_to_html(ast), "\n"), "</#{tag}>"]
-
-      _ ->
-        ["<#{tag}", attrs, ">", ast_to_html(ast), "</#{tag}>"]
-    end
+    ["<#{tag}", attrs, ">", ast_to_html(ast), "</#{tag}>"]
   end
 
   defp output_setup(build, config) do
@@ -301,24 +294,22 @@ defmodule ExDoc.Formatter.HTML do
 
     opts = [file: input, line: 1]
 
-    html_content =
+    ast =
       case extension_name(input) do
         extension when extension in ["", ".txt"] ->
-          content = ("\n" <> File.read!(input)) |> String.split(~R{\n|\r\n})
-
-          [{:pre, [], content}]
-          |> autolink_and_render(autolink_opts, opts)
+          [{:pre, [], "\n" <> File.read!(input)}]
 
         ".md" ->
           input
           |> File.read!()
           |> Markdown.to_ast(opts)
-          |> autolink_and_render(autolink_opts, opts)
 
         _ ->
           raise ArgumentError,
                 "file extension not recognized, allowed extension is either .md, .txt or no extension"
       end
+
+    html_content = autolink_and_render(ast, autolink_opts, opts)
 
     group = GroupMatcher.match_extra(groups, input)
     title = title || extract_title(html_content) || filename_to_title(input)

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -303,7 +303,7 @@ defmodule ExDoc.Formatter.HTML do
 
     html_content =
       case extension_name(input) do
-        "" ->
+        extension when extension in ["", ".txt"] ->
           content = ("\n" <> File.read!(input)) |> String.split(~R{\n|\r\n})
 
           [{:pre, [], content}]
@@ -316,7 +316,8 @@ defmodule ExDoc.Formatter.HTML do
           |> autolink_and_render(autolink_opts, opts)
 
         _ ->
-          raise ArgumentError, "file extension not recognized, allowed extension is either .md or no extension"
+          raise ArgumentError,
+                "file extension not recognized, allowed extension is either .md, .txt or no extension"
       end
 
     group = GroupMatcher.match_extra(groups, input)

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -78,12 +78,12 @@ defmodule Mix.Tasks.Docs do
       HexDocs. This can be overridden by your own values. Example: `[plug: "https://myserver/plug/"]`
 
     * `:extra_section` - String that defines the section title of the additional
-      Markdown pages; default: "PAGES". Example: "GUIDES"
+      Markdown and plain text pages; default: "PAGES". Example: "GUIDES"
 
     * `:extras` - List of keywords, each key must indicate the path to additional
-      Markdown pages, the value for each keyword (optional) gives you more control
+      Markdown or plain text pages, the value for each keyword (optional) gives you more control
       about the PATH and the title of the output files; default: `[]`. Example:
-      `["README.md", "CONTRIBUTING.md": [filename: "contributing", title: "Contributing"]]`
+      `["README.md", "LICENSE", "CONTRIBUTING.md": [filename: "contributing", title: "Contributing"]]`
 
     * `:filter_prefix` - Include only modules that match the given prefix in
       the generated documentation. Example: "MyApp.Core"

--- a/mix.exs
+++ b/mix.exs
@@ -78,7 +78,7 @@ defmodule ExDoc.Mixfile do
       extras: [
         "README.md",
         "CHANGELOG.md",
-        "LICENSE",
+        "LICENSE"
       ],
       source_ref: "v#{@version}",
       source_url: "https://github.com/elixir-lang/ex_doc",

--- a/mix.exs
+++ b/mix.exs
@@ -77,7 +77,8 @@ defmodule ExDoc.Mixfile do
       main: "readme",
       extras: [
         "README.md",
-        "CHANGELOG.md"
+        "CHANGELOG.md",
+        "LICENSE",
       ],
       source_ref: "v#{@version}",
       source_url: "https://github.com/elixir-lang/ex_doc",

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -39,7 +39,12 @@ defmodule ExDoc.Formatter.HTMLTest do
       source_root: beam_dir(),
       source_beam: beam_dir(),
       logo: "test/fixtures/elixir.png",
-      extras: ["test/fixtures/README.md"]
+      extras: [
+        "test/fixtures/LICENSE",
+        "test/fixtures/PlainText.txt",
+        "test/fixtures/PlainTextFiles.md",
+        "test/fixtures/README.md"
+      ]
     ]
   end
 
@@ -323,6 +328,24 @@ defmodule ExDoc.Formatter.HTMLTest do
 
       assert content =~
                ~r{<a href="https://hexdocs.pm/mix/Mix.Tasks.Compile.Elixir.html"><code(\sclass="inline")?>mix compile.elixir</code></a>}
+
+      content = File.read!("#{output_dir()}/plaintextfiles.html")
+
+      assert content =~
+               ~R{<p>Read the <a href="license.html">license</a> and the <a href="plaintext.html">plain-text file</a>.}
+
+      plain_text_file = File.read!("#{output_dir()}/plaintext.html")
+
+      assert plain_text_file =~
+               ~R{<pre>\nThis is plain\n  text and nothing\n.+\s+good bye\n</pre>}s
+
+      assert plain_text_file =~ ~R{\n## Neither formatted\n}
+      assert plain_text_file =~ ~R{\n      `t:term/0`\n}
+
+      plain_text_file = File.read!("#{output_dir()}/license.html")
+
+      assert plain_text_file =~
+               ~R{<pre>\nLicensed under the Apache License, Version 2\.0 \(the \&quot;License\&quot;\);\n.+\nlimitations under the License.\n</pre>}s
     end
 
     test "without any other content" do

--- a/test/fixtures/LICENSE
+++ b/test/fixtures/LICENSE
@@ -1,0 +1,11 @@
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/test/fixtures/PlainText.txt
+++ b/test/fixtures/PlainText.txt
@@ -1,0 +1,9 @@
+This is plain
+  text and nothing
+    should be linked `Kernel`
+
+      `t:term/0`
+
+## Neither formatted
+
+        good bye

--- a/test/fixtures/PlainTextFiles.md
+++ b/test/fixtures/PlainTextFiles.md
@@ -1,0 +1,3 @@
+# Plain Text Files
+
+Read the [license](LICENSE) and the [plain-text file](PlainText.txt).

--- a/test/fixtures/README.md
+++ b/test/fixtures/README.md
@@ -11,3 +11,4 @@ hello
 ## more > than
 
 world
+


### PR DESCRIPTION
The files with no extension are considered to be plain text.

Additionally it adds LICENSE as an extra file.