### PR TITLE
Redirect to correct file when change version

### DIFF
--- a/assets/js/versions.js
+++ b/assets/js/versions.js
@@ -40,7 +40,13 @@ export function initialize () {
     sidebarProjectVersion.append(versionsDropdown)
 
     $('.sidebar-projectVersionsDropdown').width(width).change(function () {
-      window.location.href = $(this).val()
+      let url = $(this).val()
+      const otherVersionWithPath = url + '/' + window.location.href.split('/').pop()
+      $.get(otherVersionWithPath, function () {
+        window.location.href = otherVersionWithPath
+      }).fail(function () {
+        window.location.href = url
+      })
     })
   }
 }


### PR DESCRIPTION
If the same file exists in the selected version, redirect to it. Otherwise, send the user to the root page.

![Untitled_ Jul 6, 2020 10_52 AM](https://user-images.githubusercontent.com/1229625/86601299-844eed80-bf77-11ea-902d-4eadcd6fbf63.gif)
(the video did not record the select box with the other version)

```
// VersionNodes used in the GIF.

var versionNodes = [
  {
    version: "v0.19.3",
    url: "http://workstation/ex_docs/0.19.3"
  },
  {
    version: "v0.22.1",
    url: "http://workstation/ex_docs/"

  }
]
```

This feature was discussed in #1033 