### PR TITLE
Revamp Refs

### DIFF
--- a/test/ex_doc/autolink_test.exs
+++ b/test/ex_doc/autolink_test.exs
@@ -41,7 +41,7 @@ defmodule ExDoc.AutolinkTest do
 
     test "project-local module" do
       ExDoc.Refs.insert([
-        {{:module, Foo}, true}
+        {{:module, Foo}, :public}
       ])
 
       assert autolink("Foo") == ~m"[`Foo`](Foo.html)"
@@ -51,10 +51,10 @@ defmodule ExDoc.AutolinkTest do
 
     test "remote function" do
       ExDoc.Refs.insert([
-        {{:module, Foo}, true},
-        {{:function, Foo, :foo, 1}, true},
-        {{:function, Foo, :., 2}, true},
-        {{:function, Foo, :.., 2}, true}
+        {{:module, Foo}, :public},
+        {{:function, Foo, :foo, 1}, :public},
+        {{:function, Foo, :., 2}, :public},
+        {{:function, Foo, :.., 2}, :public}
       ])
 
       assert autolink("Foo.foo/1") == ~m"[`Foo.foo/1`](Foo.html#foo/1)"
@@ -80,10 +80,10 @@ defmodule ExDoc.AutolinkTest do
 
     test "local function" do
       ExDoc.Refs.insert([
-        {{:module, Foo}, true},
-        {{:function, Foo, :foo, 1}, true},
-        {{:function, Foo, :., 2}, true},
-        {{:function, Foo, :.., 2}, true}
+        {{:module, Foo}, :public},
+        {{:function, Foo, :foo, 1}, :public},
+        {{:function, Foo, :., 2}, :public},
+        {{:function, Foo, :.., 2}, :public}
       ])
 
       assert autolink("foo/1", current_module: Foo) == ~m"[`foo/1`](#foo/1)"
@@ -242,10 +242,10 @@ defmodule ExDoc.AutolinkTest do
 
     test "locals" do
       ExDoc.Refs.insert([
-        {{:module, MyModule}, true},
-        {{:type, MyModule, :foo, 1}, true},
-        {{:type, MyModule, :foo, 2}, true},
-        {{:type, MyModule, :foo!, 1}, true}
+        {{:module, MyModule}, :public},
+        {{:type, MyModule, :foo, 1}, :public},
+        {{:type, MyModule, :foo, 2}, :public},
+        {{:type, MyModule, :foo!, 1}, :public}
       ])
 
       assert typespec(quote(do: t() :: foo(1))) ==
@@ -269,8 +269,8 @@ defmodule ExDoc.AutolinkTest do
 
     test "remotes" do
       ExDoc.Refs.insert([
-        {{:module, Foo}, true},
-        {{:type, Foo, :t, 0}, true}
+        {{:module, Foo}, :public},
+        {{:type, Foo, :t, 0}, :public}
       ])
 
       assert typespec(quote(do: t() :: Foo.t())) ==
@@ -279,9 +279,9 @@ defmodule ExDoc.AutolinkTest do
 
     test "autolinks same type and function name" do
       ExDoc.Refs.insert([
-        {{:module, MyModule}, true},
-        {{:type, MyModule, :foo, 0}, true},
-        {{:type, MyModule, :foo, 1}, true}
+        {{:module, MyModule}, :public},
+        {{:type, MyModule, :foo, 0}, :public},
+        {{:type, MyModule, :foo, 1}, :public}
       ])
 
       assert typespec(quote(do: foo() :: foo()))
@@ -326,9 +326,9 @@ defmodule ExDoc.AutolinkTest do
 
   test "warnings" do
     ExDoc.Refs.insert([
-      {{:module, Foo}, true},
-      {{:function, Foo, :bar, 1}, false},
-      {{:type, Foo, :bad, 0}, false}
+      {{:module, Foo}, :public},
+      {{:function, Foo, :bar, 1}, :hidden},
+      {{:type, Foo, :bad, 0}, :hidden}
     ])
 
     captured =

--- a/test/ex_doc/refs_test.exs
+++ b/test/ex_doc/refs_test.exs
@@ -2,6 +2,35 @@ defmodule ExDoc.RefsTest do
   use ExUnit.Case, async: true
   alias ExDoc.Refs
 
+  test "get_visibility/1" do
+    assert Refs.get_visibility({:module, String}) == :public
+    assert Refs.get_visibility({:module, String.Unicode}) == :hidden
+    assert Refs.get_visibility({:module, Unknown}) == :undefined
+
+    assert Refs.get_visibility({:function, Enum, :join, 1}) == :public
+    assert Refs.get_visibility({:function, Enum, :join, 2}) == :public
+    assert Refs.get_visibility({:function, String.Unicode, :version, 0}) == :hidden
+    assert Refs.get_visibility({:function, String.Unicode, :version, 9}) == :undefined
+    assert Refs.get_visibility({:function, Enum, :join, 9}) == :undefined
+
+    assert Refs.get_visibility({:function, Unknown, :unknown, 0}) == :undefined
+
+    # macros are classified as functions
+    assert Refs.get_visibility({:function, Kernel, :def, 2}) == :public
+
+    assert Refs.get_visibility({:type, String, :t, 0}) == :public
+    assert Refs.get_visibility({:type, String, :t, 1}) == :undefined
+
+    assert Refs.get_visibility({:callback, GenServer, :handle_call, 3}) == :public
+    assert Refs.get_visibility({:callback, GenServer, :handle_call, 9}) == :undefined
+
+    assert Refs.get_visibility({:function, :lists, :all, 2}) == :public
+    assert Refs.get_visibility({:function, :lists, :all, 9}) == :undefined
+
+    assert Refs.get_visibility({:type, :sets, :set, 0}) == :public
+    assert Refs.get_visibility({:type, :sets, :set, 9}) == :public
+  end
+
   test "public?/1" do
     assert Refs.public?({:module, String})
     refute Refs.public?({:module, String.Unicode})
@@ -25,9 +54,10 @@ defmodule ExDoc.RefsTest do
     assert Refs.public?({:function, :lists, :all, 2})
     refute Refs.public?({:function, :lists, :all, 9})
 
-    # TODO: enable when OTP 23.0-rc2 is out (it should have callbacks support)
-    # assert Refs.public?({:callback, :gen_server, :handle_call, 3})
-    # assert Refs.public?({:callback, :gen_server, :handle_call, 9}) in [true, false]
+    if opt_release() >= 23 do
+      assert Refs.public?({:callback, :gen_server, :handle_call, 3})
+      assert Refs.public?({:callback, :gen_server, :handle_call, 9}) in [true, false]
+    end
 
     assert Refs.public?({:type, :sets, :set, 0})
     assert Refs.public?({:type, :sets, :set, 9}) in [true, false]
@@ -36,5 +66,10 @@ defmodule ExDoc.RefsTest do
   test "from_chunk/2 with module that doesn't exist" do
     result = ExDoc.Utils.Code.fetch_docs(:elixir)
     assert {:none, _} = ExDoc.Refs.from_chunk(Elixir, result)
+  end
+
+  defp opt_release() do
+    System.otp_release()
+    |> String.to_integer()
   end
 end


### PR DESCRIPTION
Refs no longer store wether the ref is public or not,
but adds the concept of visibility, such as :public, :hidden, :undefined