### PR TITLE
Introduce :private visibility in Refs

### DIFF
--- a/lib/ex_doc/refs.ex
+++ b/lib/ex_doc/refs.ex
@@ -1,17 +1,22 @@
 defmodule ExDoc.Refs do
+  alias ExDoc.Utils
+  import Utils.Code, only: [ref_visibility: 1, ref_visibility: 2]
+
   @moduledoc false
 
   # A read-through cache of documentation references.
   #
   # The cache consists of entries:
   #
-  #     entry() :: {ref(), visibility :: :hidden | :private | :public | :undefined}
+  #     entry() :: {ref(), visibility()}
   #
   #     ref() ::
   #       {:module, module()}
   #       | {kind(), module(), name :: atom(), arity()}
   #
   #     kind() :: :function | :callback | :type
+  #
+  #     visibility() :: :hidden | :private | :public | :undefined
   #
   # A given ref is always associated with a module. If we don't have a ref in the cache we fetch
   # the module's chunk and fill in the cache. This means that if we keep asking for references
@@ -22,6 +27,13 @@ defmodule ExDoc.Refs do
   # If the module does not have a chunk, we fill in the cache with it's exports. Anytime we ask
   # such module whether it has given types or callbacks we need to say "yes" (and cache that)
   # as we can't know.
+
+  @typep entry() :: {ref(), visibility()}
+  @typep ref() ::
+           {:module, module()}
+           | {kind(), module(), name :: atom(), arity()}
+  @typep kind() :: :function | :callback | :type
+  @typep visibility() :: :hidden | :private | :public | :undefined
 
   @name __MODULE__
 
@@ -41,21 +53,20 @@ defmodule ExDoc.Refs do
     :ok
   end
 
-  def get_visibility(ref) do
+  @spec get_visibility(ref()) :: visibility()
+  def get_visibility(ref) when is_tuple(ref) do
+    kind = elem(ref, 0)
+
     case lookup(ref) do
       [{^ref, visibility}] ->
         visibility
 
       [] ->
         case load(ref) do
-          # when we only have exports, consider all types and callbacks refs as matching
-          {:exports_and_privates, entries} when elem(ref, 0) in [:type, :callback] ->
+          # when module has been compiled with no docs, consider all types and callbacks refs as matching
+          {:definitions, entries} when kind in [:type, :callback] ->
             :ok = insert([{ref, :public} | entries])
             :public
-
-          {:exports_and_privates, entries} when elem(ref, 0) == :typep ->
-            :ok = insert([{ref, :private} | entries])
-            :private
 
           {_, entries} ->
             :ok = insert(entries)
@@ -71,16 +82,22 @@ defmodule ExDoc.Refs do
     end
   end
 
+  @spec public?(ref()) :: boolean
   def public?(ref) do
     get_visibility(ref) == :public
   end
 
+  @spec lookup(ref()) :: [entry()]
   def lookup(ref) do
     :ets.lookup(@name, ref)
   rescue
     _ ->
       [{ref, :undefined}]
   end
+
+  @spec insert([entry()]) :: :ok
+  def insert([] = _entries),
+    do: :ok
 
   def insert(entries) do
     true = :ets.insert(@name, entries)
@@ -89,24 +106,15 @@ defmodule ExDoc.Refs do
 
   # Returns refs for `module` from the result of calling `Code.fetch_docs/1`.
   @doc false
-  def from_chunk(module, result) do
-    case result do
-      {:docs_v1, _, _, _, module_visibility, _, docs} ->
-        module_visibility =
-          if module_visibility == :hidden do
-            :hidden
-          else
-            :public
-          end
+  @spec from_chunk(module, tuple()) :: {:chunk | :definitions | :none, [entry()]}
+  def from_chunk(module, fetch_docs_result) do
+    case fetch_docs_result do
+      {:docs_v1, _, _, _, module_doc, _, docs} ->
+        module_visibility = ref_visibility(module_doc)
 
         entries =
           for {{kind, name, arity}, _, _, doc, metadata} <- docs do
-            ref_visibility =
-              if doc == :hidden or module_visibility == :hidden do
-                :hidden
-              else
-                :public
-              end
+            ref_visibility = ref_visibility(doc, module_visibility)
 
             for arity <- (arity - (metadata[:defaults] || 0))..arity do
               {{kind(kind), module, name, arity}, ref_visibility}
@@ -114,20 +122,31 @@ defmodule ExDoc.Refs do
           end
 
         entries = [
-          {{:module, module}, module_visibility} | List.flatten(entries ++ private_types(module))
+          {{:module, module}, module_visibility}
+          | List.flatten([
+              entries,
+              private_types(module, module_visibility),
+              callbacks(module, module_visibility),
+              private_functions_macros(module, module_visibility)
+            ])
         ]
 
         {:chunk, entries}
 
       {:error, :chunk_not_found} ->
         if Code.ensure_loaded?(module) do
-          public_functions =
-            for {name, arity} <- exports(module) do
-              {{:function, module, name, arity}, :public}
-            end
+          module_visibility = :public
 
-          entries = [{{:module, module}, :public} | public_functions ++ private_types(module)]
-          {:exports_and_privates, entries}
+          entries =
+            Enum.concat([
+              [{{:module, module}, module_visibility}],
+              exports(module, module_visibility),
+              private_types(module, module_visibility),
+              callbacks(module, module_visibility),
+              private_functions_macros(module, module_visibility)
+            ])
+
+          {:definitions, entries}
         else
           entries = [{{:module, module}, :undefined}]
           {:none, entries}
@@ -139,15 +158,23 @@ defmodule ExDoc.Refs do
     end
   end
 
-  defp exports(module) do
-    if function_exported?(module, :__info__, 1) do
-      module.__info__(:functions) ++ module.__info__(:macros)
-    else
-      module.module_info(:exports)
+  defp exports(module, module_visibility) when is_atom(module) and is_atom(module_visibility) do
+    exports =
+      if function_exported?(module, :__info__, 1) do
+        module.__info__(:functions) ++ module.__info__(:macros)
+      else
+        module.module_info(:exports)
+      end
+
+    ref_visibility = ref_visibility(:public, module_visibility)
+
+    for {name, arity} <- exports do
+      {{:function, module, name, arity}, ref_visibility}
     end
   end
 
-  def private_types(module) when is_atom(module) do
+  defp private_types(module, module_visibility)
+       when is_atom(module) and is_atom(module_visibility) do
     refs =
       case Code.Typespec.fetch_types(module) do
         {:ok, types} ->
@@ -163,13 +190,42 @@ defmodule ExDoc.Refs do
           []
       end
 
+    ref_visibility = ref_visibility(:private, module_visibility)
+
     for {name, arity} <- refs do
-      {{:type, module, name, arity}, :private}
+      {{:type, module, name, arity}, ref_visibility}
+    end
+  end
+
+  defp callbacks(module, module_visibility) when is_atom(module) and is_atom(module_visibility) do
+    case Code.Typespec.fetch_callbacks(module) do
+      {:ok, callbacks} ->
+        ref_visibility = ref_visibility(:public, module_visibility)
+
+        for {function, arity} <- callbacks do
+          {{:callback, module, function, arity}, ref_visibility}
+        end
+
+      :error ->
+        []
+    end
+  end
+
+  def private_functions_macros(module, module_visibility)
+      when is_atom(module) and is_atom(module_visibility) do
+    case Utils.Code.fetch_definitions(module, module_visibility) do
+      {:ok, definitions} ->
+        for {{function, arity}, ref_visibility} <- definitions do
+          {{:function, module, function, arity}, ref_visibility}
+        end
+
+      :error ->
+        []
     end
   end
 
   defp load({:module, module}) do
-    from_chunk(module, ExDoc.Utils.Code.fetch_docs(module))
+    from_chunk(module, Utils.Code.fetch_docs(module))
   end
 
   defp load({_kind, module, _name, _arity}) do

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -179,7 +179,7 @@ defmodule ExDoc.Retriever do
       type: get_type(module),
       specs: get_specs(module),
       impls: get_impls(module),
-      abst_code: get_abstract_code(module),
+      abst_code: ExDoc.Utils.Code.get_abstract_code(module),
       docs: docs_chunk
     }
   end
@@ -212,15 +212,6 @@ defmodule ExDoc.Retriever do
     doc_line = anno_line(anno)
     options = [file: source_path, line: doc_line + 1]
     {doc_line, doc_ast(content_type, moduledoc, options), metadata}
-  end
-
-  defp get_abstract_code(module) do
-    {^module, binary, _file} = :code.get_object_code(module)
-
-    case :beam_lib.chunks(binary, [:abstract_code]) do
-      {:ok, {_, [{:abstract_code, {_vsn, abstract_code}}]}} -> abstract_code
-      _otherwise -> []
-    end
   end
 
   ## Function helpers

--- a/lib/ex_doc/utils/code.ex
+++ b/lib/ex_doc/utils/code.ex
@@ -64,4 +64,101 @@ defmodule ExDoc.Utils.Code do
     _ ->
       {:error, {:invalid_chunk, bin}}
   end
+
+  def get_abstract_code(module) when is_atom(module) do
+    {^module, beam} = get_module_and_beam(module)
+
+    case :beam_lib.chunks(beam, [:abstract_code]) do
+      {:ok, {_, [{:abstract_code, {_vsn, abstract_code}}]}} -> abstract_code
+      _otherwise -> []
+    end
+  end
+
+  # Borrowed from Elixir's Code.Typespec module
+  def fetch_definitions(module, module_visibility \\ :public) when is_atom(module) do
+    with {module, binary} <- get_module_and_beam(module),
+         {:ok, {_, [debug_info: {:debug_info_v1, backend, data}]}} <-
+           :beam_lib.chunks(binary, [:debug_info]) do
+      case data do
+        {:elixir_v1, info, _attributes} when is_map(info) ->
+          definitions =
+            for {{function, arity}, def_kind, _, _} <- info.definitions do
+              kind_visibility = kind_visibility(def_kind)
+              ref_visibility = ref_visibility(kind_visibility, module_visibility)
+              {{function, arity}, ref_visibility}
+            end
+
+          {:ok, definitions}
+
+        _ ->
+          case backend.debug_info(:erlang_v1, module, data, []) do
+            {:ok, abstract_code} ->
+              exports =
+                for {:attribute, _, :export, exports} <- abstract_code do
+                  exports
+                end
+                |> List.flatten()
+
+              definitions =
+                for {:function, _, function, arity, _} <- abstract_code do
+                  kind_visibility = if {function, arity} in exports, do: :public, else: :private
+                  ref_visibility = ref_visibility(kind_visibility, module_visibility)
+
+                  {{function, arity}, ref_visibility}
+                end
+
+              {:ok, definitions}
+
+            _ ->
+              :error
+          end
+      end
+    else
+      _ -> :error
+    end
+  end
+
+  defp get_module_and_beam(module) when is_atom(module) do
+    case :code.get_object_code(module) do
+      {^module, beam, _filename} -> {module, beam}
+      :error -> :error
+    end
+  end
+
+  def ref_visibility(doc_or_visibility)
+  def ref_visibility(:hidden), do: :hidden
+  def ref_visibility(_), do: :public
+
+  def ref_visibility(kind_visibility, module_visibility)
+
+  def ref_visibility(_, :private),
+    do: raise(ArgumentError, "module_visibility cannot be :private. Choose :hidden instead")
+
+  def ref_visibility(:private, _), do: :private
+  def ref_visibility(:hidden, _), do: :hidden
+  def ref_visibility(_, :hidden), do: :hidden
+  def ref_visibility(_, _), do: :public
+
+  defp kind_visibility(kind_or_def_kind)
+       when kind_or_def_kind in [
+              :def,
+              :function,
+              :defmacro,
+              :macro,
+              :type,
+              :opaque,
+              :defcallback,
+              :callback,
+              :defmacrocallback,
+              :macrocallback
+            ],
+       do: :public
+
+  defp kind_visibility(kind_or_def_kind)
+       when kind_or_def_kind in [
+              :defp,
+              :defmacrop,
+              :typep
+            ],
+       do: :private
 end

--- a/test/ex_doc/refs_test.exs
+++ b/test/ex_doc/refs_test.exs
@@ -20,6 +20,7 @@ defmodule ExDoc.RefsTest do
 
     assert Refs.get_visibility({:type, String, :t, 0}) == :public
     assert Refs.get_visibility({:type, String, :t, 1}) == :undefined
+    assert Refs.get_visibility({:type, Module, :definition, 0}) == :private
 
     assert Refs.get_visibility({:callback, GenServer, :handle_call, 3}) == :public
     assert Refs.get_visibility({:callback, GenServer, :handle_call, 9}) == :undefined
@@ -47,6 +48,7 @@ defmodule ExDoc.RefsTest do
 
     assert Refs.public?({:type, String, :t, 0})
     refute Refs.public?({:type, String, :t, 1})
+    refute Refs.public?({:type, Module, :definition, 0})
 
     assert Refs.public?({:callback, GenServer, :handle_call, 3})
     refute Refs.public?({:callback, GenServer, :handle_call, 9})

--- a/test/ex_doc/refs_test.exs
+++ b/test/ex_doc/refs_test.exs
@@ -7,11 +7,19 @@ defmodule ExDoc.RefsTest do
     assert Refs.get_visibility({:module, String.Unicode}) == :hidden
     assert Refs.get_visibility({:module, Unknown}) == :undefined
 
-    assert Refs.get_visibility({:function, Enum, :join, 1}) == :public
-    assert Refs.get_visibility({:function, Enum, :join, 2}) == :public
-    assert Refs.get_visibility({:function, String.Unicode, :version, 0}) == :hidden
-    assert Refs.get_visibility({:function, String.Unicode, :version, 9}) == :undefined
-    assert Refs.get_visibility({:function, Enum, :join, 9}) == :undefined
+    assert Refs.get_visibility({:function, RefsTest.Public, :function_public, 1}) == :public
+    assert Refs.get_visibility({:function, RefsTest.Public, :function_private, 1}) == :private
+    assert Refs.get_visibility({:function, RefsTest.Public, :macro_public, 1}) == :public
+    assert Refs.get_visibility({:function, RefsTest.Public, :macro_private, 1}) == :private
+    assert Refs.get_visibility({:function, RefsTest.Public, :function_public, 2}) == :undefined
+    assert Refs.get_visibility({:function, RefsTest.Public, :does_not_exist, 1}) == :undefined
+
+    assert Refs.get_visibility({:function, RefsTest.Hidden, :function_public, 1}) == :hidden
+    assert Refs.get_visibility({:function, RefsTest.Hidden, :function_private, 1}) == :private
+    assert Refs.get_visibility({:function, RefsTest.Hidden, :macro_public, 1}) == :hidden
+    assert Refs.get_visibility({:function, RefsTest.Hidden, :macro_private, 1}) == :private
+    assert Refs.get_visibility({:function, RefsTest.Hidden, :function_public, 2}) == :undefined
+    assert Refs.get_visibility({:function, RefsTest.Hidden, :does_not_exist, 1}) == :undefined
 
     assert Refs.get_visibility({:function, Unknown, :unknown, 0}) == :undefined
 
@@ -19,14 +27,27 @@ defmodule ExDoc.RefsTest do
     assert Refs.get_visibility({:function, Kernel, :def, 2}) == :public
 
     assert Refs.get_visibility({:type, String, :t, 0}) == :public
-    assert Refs.get_visibility({:type, String, :t, 1}) == :undefined
-    assert Refs.get_visibility({:type, Module, :definition, 0}) == :private
+    assert Refs.get_visibility({:type, String, :t, 10}) == :undefined
+
+    assert Refs.get_visibility({:type, RefsTest.Public, :a_type, 0}) == :public
+    assert Refs.get_visibility({:type, RefsTest.Public, :a_typep, 0}) == :private
+    assert Refs.get_visibility({:type, RefsTest.Public, :an_opaque, 0}) == :public
+
+    assert Refs.get_visibility({:type, RefsTest.Hidden, :a_type, 0}) == :hidden
+    assert Refs.get_visibility({:type, RefsTest.Hidden, :a_typep, 0}) == :private
+    assert Refs.get_visibility({:type, RefsTest.Hidden, :an_opaque, 0}) == :hidden
 
     assert Refs.get_visibility({:callback, GenServer, :handle_call, 3}) == :public
     assert Refs.get_visibility({:callback, GenServer, :handle_call, 9}) == :undefined
+    assert Refs.get_visibility({:callback, Mix.RemoteConverger, :converge, 2}) == :hidden
+    assert Refs.get_visibility({:callback, RefsTest.Public, :a_callback, 1}) == :public
+    assert Refs.get_visibility({:callback, RefsTest.Public, :a_macrocallback, 1}) == :public
+    assert Refs.get_visibility({:callback, RefsTest.Hidden, :a_callback, 1}) == :hidden
+    assert Refs.get_visibility({:callback, RefsTest.Hidden, :a_macrocallback, 1}) == :hidden
 
     assert Refs.get_visibility({:function, :lists, :all, 2}) == :public
     assert Refs.get_visibility({:function, :lists, :all, 9}) == :undefined
+    assert Refs.get_visibility({:function, :lists, :mergel, 2}) == :private
 
     assert Refs.get_visibility({:type, :sets, :set, 0}) == :public
     assert Refs.get_visibility({:type, :sets, :set, 9}) == :public
@@ -37,32 +58,10 @@ defmodule ExDoc.RefsTest do
     refute Refs.public?({:module, String.Unicode})
     refute Refs.public?({:module, Unknown})
 
-    assert Refs.public?({:function, Enum, :join, 1})
-    assert Refs.public?({:function, Enum, :join, 2})
-    refute Refs.public?({:function, Enum, :join, 9})
-
-    refute Refs.public?({:function, Unknown, :unknown, 0})
-
-    # macros are classified as functions
-    assert Refs.public?({:function, Kernel, :def, 2})
-
-    assert Refs.public?({:type, String, :t, 0})
-    refute Refs.public?({:type, String, :t, 1})
-    refute Refs.public?({:type, Module, :definition, 0})
-
-    assert Refs.public?({:callback, GenServer, :handle_call, 3})
-    refute Refs.public?({:callback, GenServer, :handle_call, 9})
-
-    assert Refs.public?({:function, :lists, :all, 2})
-    refute Refs.public?({:function, :lists, :all, 9})
-
     if opt_release() >= 23 do
       assert Refs.public?({:callback, :gen_server, :handle_call, 3})
       assert Refs.public?({:callback, :gen_server, :handle_call, 9}) in [true, false]
     end
-
-    assert Refs.public?({:type, :sets, :set, 0})
-    assert Refs.public?({:type, :sets, :set, 9}) in [true, false]
   end
 
   test "from_chunk/2 with module that doesn't exist" do

--- a/test/fixtures/refs/refs_test_sample.ex
+++ b/test/fixtures/refs/refs_test_sample.ex
@@ -1,0 +1,33 @@
+modules = [
+  {RefsTest.Public, "This is a public module."},
+  {RefsTest.Hidden, false}
+]
+
+for {module, moduledoc} <- modules do
+  contents =
+    quote do
+      @moduledoc unquote(moduledoc)
+
+      @type a_type() :: any()
+      @typep a_typep() :: any()
+      @opaque an_opaque() :: {any()}
+
+      @callback a_callback(any()) :: boolean
+      @macrocallback a_macrocallback(any()) :: boolean
+
+      defmacro macro_public(x),
+        do: quote(do: unquote(x))
+
+      defmacrop macro_private(x),
+        do: quote(do: unquote(x))
+
+      @spec function_public(a_type()) :: a_typep()
+      def function_public(x),
+        do: function_private(x)
+
+      defp function_private(x),
+        do: macro_private(x)
+    end
+
+  Module.create(module, contents, Macro.Env.location(__ENV__))
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -7,9 +7,16 @@ ExUnit.start(exclude: Enum.filter(exclude, &elem(&1, 1)))
 # Prepare module fixtures
 File.rm_rf!("test/tmp")
 File.mkdir_p!("test/tmp/beam")
+File.mkdir_p!("test/tmp/beam/refs")
 Code.prepend_path("test/tmp/beam")
+Code.prepend_path("test/tmp/beam/refs")
 
 # Compile module fixtures
 "test/fixtures/*.ex"
 |> Path.wildcard()
 |> Kernel.ParallelCompiler.compile_to_path("test/tmp/beam")
+
+# Compile Refs fixtures
+"test/fixtures/refs/*.ex"
+|> Path.wildcard()
+|> Kernel.ParallelCompiler.compile_to_path("test/tmp/beam/refs")


### PR DESCRIPTION
Addresses the issue of warning about private types, which is not tackled in this PR per se.