### PR TITLE
Optimize Ref caching system

### DIFF
--- a/lib/ex_doc/refs.ex
+++ b/lib/ex_doc/refs.ex
@@ -54,18 +54,15 @@ defmodule ExDoc.Refs do
           :undefined
         else
           _ ->
+            kind = elem(ref, 0)
             case load(ref) do
               # when we only have exports, consider all types and callbacks refs as matching
               {:exports, entries} when elem(ref, 0) in [:type, :callback] ->
                 :ok = insert([{ref, :public} | entries])
                 :public
 
-              {:none, [{^ref = {:module, _module}, :undefined}] = entries} ->
-                :ok = insert(entries)
-                :undefined
-
               # if module is :undefined, then the ref is :undefined
-              {:none, entries = [{{:module, _module}, :undefined}]}->
+              {:none, entries = [{{:module, _module}, :undefined}]} when kind != :module ->
                 :ok = insert([{ref, :undefined} | entries])
                 :undefined
 

--- a/test/ex_doc/refs_test.exs
+++ b/test/ex_doc/refs_test.exs
@@ -28,7 +28,7 @@ defmodule ExDoc.RefsTest do
     assert Refs.get_visibility({:function, :lists, :all, 9}) == :undefined
 
     assert Refs.get_visibility({:type, :sets, :set, 0}) == :public
-    assert Refs.get_visibility({:type, :sets, :set, 9}) == :public
+    assert Refs.get_visibility({:type, :sets, :set, 9}) == :undefined
   end
 
   test "public?/1" do

--- a/test/ex_doc/refs_test.exs
+++ b/test/ex_doc/refs_test.exs
@@ -14,6 +14,7 @@ defmodule ExDoc.RefsTest do
     assert Refs.get_visibility({:function, Enum, :join, 9}) == :undefined
 
     assert Refs.get_visibility({:function, Unknown, :unknown, 0}) == :undefined
+    assert Refs.get_visibility({:function, Unknown2, :unknown, 0}) == :undefined
 
     # macros are classified as functions
     assert Refs.get_visibility({:function, Kernel, :def, 2}) == :public


### PR DESCRIPTION
Only load and fetch_docs from modules when needed.
When the module is already chached, and we cannot find the ref in the ETS table,
we just define it as :undefined and store it.