### PR TITLE
Improve Refs callbacks/types handling and cache hits

### DIFF
--- a/lib/ex_doc/refs.ex
+++ b/lib/ex_doc/refs.ex
@@ -87,9 +87,14 @@ defmodule ExDoc.Refs do
   end
 
   defp fetch({_kind, module, _name, _arity} = ref) do
-    entries = fetch_entries(module, ExDoc.Utils.Code.fetch_docs(module))
-    insert(entries)
-    Map.get(Map.new(entries), ref, :undefined)
+    with mod_visibility <- fetch({:module, module}),
+         true <- mod_visibility in [:public, :hidden],
+         {:ok, visibility} <- lookup(ref) do
+      visibility
+    else
+      _ ->
+        :undefined
+    end
   end
 
   defp fetch_entries(module, result) do

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -85,7 +85,7 @@ defmodule ExDoc.Retriever do
     end
 
     result = ExDoc.Utils.Code.fetch_docs(module)
-    Refs.from_chunk(module, result)
+    Refs.insert_from_chunk(module, result)
 
     case result do
       {:docs_v1, _, _, _, :hidden, _, _} ->

--- a/test/ex_doc/refs_test.exs
+++ b/test/ex_doc/refs_test.exs
@@ -2,69 +2,58 @@ defmodule ExDoc.RefsTest do
   use ExUnit.Case, async: true
   alias ExDoc.Refs
 
+  defmodule InMemory do
+    @type t() :: :ok
+
+    @callback handle_foo() :: :ok
+
+    def foo(), do: :ok
+  end
+
   test "get_visibility/1" do
     assert Refs.get_visibility({:module, String}) == :public
     assert Refs.get_visibility({:module, String.Unicode}) == :hidden
     assert Refs.get_visibility({:module, Unknown}) == :undefined
+    assert Refs.get_visibility({:module, InMemory}) == :public
 
     assert Refs.get_visibility({:function, Enum, :join, 1}) == :public
     assert Refs.get_visibility({:function, Enum, :join, 2}) == :public
     assert Refs.get_visibility({:function, String.Unicode, :version, 0}) == :hidden
     assert Refs.get_visibility({:function, String.Unicode, :version, 9}) == :undefined
     assert Refs.get_visibility({:function, Enum, :join, 9}) == :undefined
-
-    assert Refs.get_visibility({:function, Unknown, :unknown, 0}) == :undefined
+    assert Refs.get_visibility({:function, :lists, :all, 2}) == :public
+    assert Refs.get_visibility({:function, :lists, :all, 9}) == :undefined
+    assert Refs.get_visibility({:function, InMemory, :foo, 0}) == :public
+    assert Refs.get_visibility({:function, InMemory, :foo, 9}) == :undefined
 
     # macros are classified as functions
     assert Refs.get_visibility({:function, Kernel, :def, 2}) == :public
 
+    assert Refs.get_visibility({:function, Unknown, :unknown, 0}) == :undefined
+
     assert Refs.get_visibility({:type, String, :t, 0}) == :public
     assert Refs.get_visibility({:type, String, :t, 1}) == :undefined
+    assert Refs.get_visibility({:type, :sets, :set, 0}) == :public
+    assert Refs.get_visibility({:type, :sets, :set, 9}) == :undefined
+
+    # types are in abstract_code chunk so not available for in-memory modules
+    assert Refs.get_visibility({:type, InMemory, :t, 0}) == :undefined
 
     assert Refs.get_visibility({:callback, GenServer, :handle_call, 3}) == :public
     assert Refs.get_visibility({:callback, GenServer, :handle_call, 9}) == :undefined
-
-    assert Refs.get_visibility({:function, :lists, :all, 2}) == :public
-    assert Refs.get_visibility({:function, :lists, :all, 9}) == :undefined
-
-    assert Refs.get_visibility({:type, :sets, :set, 0}) == :public
-    assert Refs.get_visibility({:type, :sets, :set, 9}) == :public
+    assert Refs.get_visibility({:callback, :gen_server, :handle_call, 3}) == :public
+    assert Refs.get_visibility({:callback, :gen_server, :handle_call, 9}) == :undefined
+    assert Refs.get_visibility({:callback, InMemory, :handle_foo, 0}) == :public
+    assert Refs.get_visibility({:callback, InMemory, :handle_foo, 9}) == :undefined
   end
 
   test "public?/1" do
     assert Refs.public?({:module, String})
     refute Refs.public?({:module, String.Unicode})
-    refute Refs.public?({:module, Unknown})
-
-    assert Refs.public?({:function, Enum, :join, 1})
-    assert Refs.public?({:function, Enum, :join, 2})
-    refute Refs.public?({:function, Enum, :join, 9})
-
-    refute Refs.public?({:function, Unknown, :unknown, 0})
-
-    # macros are classified as functions
-    assert Refs.public?({:function, Kernel, :def, 2})
-
-    assert Refs.public?({:type, String, :t, 0})
-    refute Refs.public?({:type, String, :t, 1})
-
-    assert Refs.public?({:callback, GenServer, :handle_call, 3})
-    refute Refs.public?({:callback, GenServer, :handle_call, 9})
-
-    assert Refs.public?({:function, :lists, :all, 2})
-    refute Refs.public?({:function, :lists, :all, 9})
-
-    if System.otp_release() >= "23" do
-      assert Refs.public?({:callback, :gen_server, :handle_call, 3})
-      assert Refs.public?({:callback, :gen_server, :handle_call, 9}) in [true, false]
-    end
-
-    assert Refs.public?({:type, :sets, :set, 0})
-    assert Refs.public?({:type, :sets, :set, 9}) in [true, false]
   end
 
-  test "from_chunk/2 with module that doesn't exist" do
+  test "insert_from_chunk/2 with module that doesn't exist" do
     result = ExDoc.Utils.Code.fetch_docs(:elixir)
-    assert {:none, _} = ExDoc.Refs.from_chunk(Elixir, result)
+    assert :ok = ExDoc.Refs.insert_from_chunk(Elixir, result)
   end
 end


### PR DESCRIPTION
* a5e8b3b Update Refs to better handle callbacks and types

  If the module does not have a docs chunk, we fall back to `module.behaviour_info(:callbacks)` and `Code.Typespec.fetch_types(module)`

* c6abc63 Don't load module chunk if module is already cached