### PR TITLE
Escape escape signature.

### DIFF
--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -316,9 +316,11 @@ defmodule ExDoc.Autolink do
       |> Macro.to_string()
       |> Code.format_string!(line_length: 80)
       |> IO.iodata_to_binary()
+      |> T.h()
 
     name = typespec_name(ast)
     {name, rest} = split_name(string, name)
+
     name <> do_typespec(rest, config)
   end
 

--- a/test/ex_doc/autolink_test.exs
+++ b/test/ex_doc/autolink_test.exs
@@ -322,6 +322,11 @@ defmodule ExDoc.AutolinkTest do
       assert typespec(quote(do: t() :: :sets.set())) ==
                ~s[t() :: <a href=\"http://www.erlang.org/doc/man/sets.html#type-set\">:sets.set</a>()]
     end
+
+    test "escape special HTML characters" do
+      assert typespec(quote(do: term() < term() :: boolean())) ==
+               ~s[<a href="https://hexdocs.pm/elixir/typespecs.html#built-in-types">term</a>() &lt; <a href="https://hexdocs.pm/elixir/typespecs.html#built-in-types">term</a>() :: <a href="https://hexdocs.pm/elixir/typespecs.html#built-in-types">boolean</a>()]
+    end
   end
 
   test "warnings" do


### PR DESCRIPTION
It was breaking HTML validation when function name had special HTML chars that
needs to be escaped. such as `<`