### PR TITLE
Escape HTML special characters in HTML sidebar entries

### DIFF
--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -149,7 +149,7 @@ defmodule ExDoc.Formatter.HTML.Templates do
   end
 
   defp sidebar_entries({group, docs}) do
-    nodes = Enum.map(docs, fn doc -> %{id: doc.id, anchor: URI.encode(HTML.link_id(doc))} end)
+    nodes = Enum.map(docs, fn doc -> %{id: h(doc.id), anchor: URI.encode(HTML.link_id(doc))} end)
     %{key: HTML.text_to_id(group), name: group, nodes: nodes}
   end
 


### PR DESCRIPTION
Similar to https://github.com/elixir-lang/ex_doc/pull/1226

This bug was preventing funcions with special chars in their names to be displayed in the sidebar,
such as Kernel.</2