### PR TITLE
Fix autolinking of functions with / in name

### DIFF
--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -185,8 +185,8 @@ defmodule ExDoc.Autolink do
   defp url("mix " <> name, _mode, config), do: mix_task(name, config)
 
   defp url(code, mode, config) do
-    case String.split(code, "/") do
-      [left, right] ->
+    case Regex.run(~r{^(.+)/(\d+)$}, code) do
+      [_, left, right] ->
         with {:ok, arity} <- parse_arity(right) do
           {kind, rest} = kind(left)
 
@@ -205,8 +205,8 @@ defmodule ExDoc.Autolink do
             nil
         end
 
-      [string] ->
-        case parse_module(string, mode) do
+      nil ->
+        case parse_module(code, mode) do
           {:module, module} ->
             module_url(module, config)
 

--- a/test/ex_doc/autolink_test.exs
+++ b/test/ex_doc/autolink_test.exs
@@ -216,6 +216,20 @@ defmodule ExDoc.AutolinkTest do
       assert_unchanged(~m"[Foo](#baz)", opts)
     end
 
+    test "special case links" do
+      assert autolink(~m"`//2`") ==
+                {:a, [href: "https://hexdocs.pm/elixir/Kernel.html#//2"], [ast("//2")]}
+
+      assert autolink(~m"[division](`//2`)") ==
+                {:a, [href: "https://hexdocs.pm/elixir/Kernel.html#//2"], ["division"]}
+
+      assert autolink(~m"`Kernel.//2`") ==
+                {:a, [href: "https://hexdocs.pm/elixir/Kernel.html#//2"], [ast("Kernel.//2")]}
+
+      assert autolink(~m"[division](`Kernel.//2`)") ==
+                {:a, [href: "https://hexdocs.pm/elixir/Kernel.html#//2"], ["division"]}
+    end
+
     test "other link" do
       assert_unchanged(~m"[`String`](foo.html)")
       assert_unchanged(~m"[custom text](foo.html)")


### PR DESCRIPTION
Such as the case of Kernel.//2