### PR TITLE
Remove overlapping functions from defaults

### DIFF
--- a/lib/ex_doc/formatter/html/templates/detail_template.eex
+++ b/lib/ex_doc/formatter/html/templates/detail_template.eex
@@ -1,6 +1,6 @@
 <section class="detail" id="<%=enc HTML.link_id(node.id, node.type) %>">
-  <%= for default <- get_defaults(node) do %>
-    <span id="<%=enc HTML.link_id(default, node.type) %>"></span>
+  <%= for {default_name, default_arity} <- get_defaults(node) do %>
+    <span id="<%=enc HTML.link_id("#{default_name}/#{default_arity}", node.type) %>"></span>
   <% end %>
   <div class="detail-header">
     <a href="#<%=enc HTML.link_id(node) %>" class="detail-link" title="Link to this <%= pretty_type(node) %>">

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -41,6 +41,7 @@ defmodule ExDoc.Retriever do
   def docs_from_modules(modules, config) when is_list(modules) do
     modules
     |> Enum.flat_map(&get_module(&1, config))
+    |> delete_overlapping_defaults()
     |> Enum.sort_by(fn module ->
       {GroupMatcher.group_index(config.groups_for_modules, module.group), module.nested_context,
        module.nested_title, module.id}
@@ -71,6 +72,75 @@ defmodule ExDoc.Retriever do
       nil -> {nil, nil}
       prefix -> {String.trim_leading(title, prefix <> "."), prefix}
     end
+  end
+
+  defp delete_overlapping_defaults(nodes) when is_list(nodes) do
+    for node <- nodes do
+      delete_overlapping_defaults(node)
+    end
+  end
+
+  defp delete_overlapping_defaults(%ExDoc.ModuleNode{} = module_node) do
+    id_to_defaults =
+      for %ExDoc.FunctionNode{} = function_node <- module_node.docs,
+          name_arity <- function_node.defaults ++ [{function_node.name, function_node.arity}] do
+        {function_node.id, name_arity}
+      end
+
+    filtered = filter_overlapping(id_to_defaults)
+
+    if length(filtered) == length(id_to_defaults) do
+      # return node unchanged
+      module_node
+    else
+      defaults_to_remove = build_defaults_map(id_to_defaults -- filtered)
+      affected_ids = Map.keys(defaults_to_remove)
+
+      module_docs =
+        for function_node <- module_node.docs do
+          if function_node.id in affected_ids do
+            delete_overlapping_defaults(function_node, defaults_to_remove)
+          else
+            function_node
+          end
+        end
+
+      %{module_node | docs: module_docs}
+    end
+  end
+
+  defp delete_overlapping_defaults(%ExDoc.FunctionNode{} = function_node, defaults_to_remove)
+       when defaults_to_remove == %{},
+       do: function_node
+
+  defp delete_overlapping_defaults(%ExDoc.FunctionNode{} = function_node, defaults_to_remove)
+       when is_map(defaults_to_remove) do
+    remove_list = Map.get(defaults_to_remove, function_node.id, [])
+    new_defaults = function_node.defaults -- remove_list
+
+    %{function_node | defaults: new_defaults}
+  end
+
+  defp filter_overlapping(id_to_defaults) do
+    {result, _acc} =
+      Enum.reduce(id_to_defaults, {[], MapSet.new()}, fn
+        {_id, name_arity} = entry, {defaults, defaults_acc} ->
+          if MapSet.member?(defaults_acc, name_arity) do
+            {defaults, defaults_acc}
+          else
+            {[entry | defaults], MapSet.put(defaults_acc, name_arity)}
+          end
+      end)
+
+    result
+  end
+
+  defp build_defaults_map(list) do
+    Enum.reduce(list, %{}, fn
+      {key, {name, arity}}, acc ->
+        value = Map.get(acc, key, [])
+        Map.put(acc, key, [{name, arity} | value])
+    end)
   end
 
   # Special case required for Elixir
@@ -313,7 +383,7 @@ defmodule ExDoc.Retriever do
       deprecated: metadata[:deprecated],
       doc: doc_ast,
       doc_line: doc_line,
-      defaults: defaults,
+      defaults: Enum.sort_by(defaults, fn {name, arity} -> sort_key(name, arity) end),
       signature: Enum.join(signature, " "),
       specs: specs,
       source_path: source.path,
@@ -338,7 +408,7 @@ defmodule ExDoc.Retriever do
   defp get_defaults(_name, _arity, 0), do: []
 
   defp get_defaults(name, arity, defaults) do
-    for default <- (arity - defaults)..(arity - 1), do: "#{name}/#{default}"
+    for default <- (arity - defaults)..(arity - 1), do: {name, default}
   end
 
   ## Callback helpers

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -407,6 +407,22 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
                ~r{<h3 id="example_with_h3/0-examples" class="section-heading">.*<a href="#example_with_h3/0-examples" class="hover-link">.*<span class="icon-link" aria-hidden="true"></span>.*</a>.*Examples.*</h3>}ms
     end
 
+    test "do not output overlapping functions, causing duplicate IDs" do
+      content = get_module_page([OverlappingDefaults])
+
+      assert content =~ ~s{<section class="detail" id="overlapping_defaults/2">}
+      assert content =~ ~s{<section class="detail" id="overlapping_defaults/3">}
+      refute content =~ ~s{<span id="overlapping_defaults/2"></span>}
+
+      assert content =~ ~s{<section class="detail" id="special_case/2">}
+
+      assert content =~
+               ~r{<section class="detail" id="special_case/4">\s*<span id="special_case/1"></span>\s*<span id="special_case/3"></span>}
+
+      # This Regex checks for duplicate IDs
+      refute content =~ ~r{id=("[^"]+").*id=\1}s
+    end
+
     ## BEHAVIOURS
 
     test "outputs behavior and callbacks" do

--- a/test/ex_doc/retriever_test.exs
+++ b/test/ex_doc/retriever_test.exs
@@ -117,7 +117,7 @@ defmodule ExDoc.RetrieverTest do
       assert example.id == "example/2"
       assert example.doc == [{:p, [], ["Some example"]}]
       assert example.type == :function
-      assert example.defaults == ["example/1"]
+      assert example.defaults == [example: 1]
       assert example.signature == "example(foo, bar \\\\ Baz)"
       assert example.deprecated == "Use something else instead"
       assert example.group == "Example"
@@ -151,6 +151,30 @@ defmodule ExDoc.RetrieverTest do
       assert is_zero.doc == [{:p, [], ["A simple guard"]}]
       assert is_zero.type == :macro
       assert is_zero.defaults == []
+    end
+
+    test "overlapping defaults" do
+      [module_node] = docs_from_files(["OverlappingDefaults"])
+
+      overlapping_defaults_2 = Enum.find(module_node.docs, &(&1.id == "overlapping_defaults/2"))
+      overlapping_defaults_3 = Enum.find(module_node.docs, &(&1.id == "overlapping_defaults/3"))
+      assert overlapping_defaults_2.defaults == []
+      assert overlapping_defaults_3.defaults == []
+
+      two_defaults_2 = Enum.find(module_node.docs, &(&1.id == "two_defaults/2"))
+      two_defaults_4 = Enum.find(module_node.docs, &(&1.id == "two_defaults/4"))
+      assert two_defaults_2.defaults == []
+      assert two_defaults_4.defaults == [{:two_defaults, 3}]
+
+      special_case_2 = Enum.find(module_node.docs, &(&1.id == "special_case/2"))
+      special_case_4 = Enum.find(module_node.docs, &(&1.id == "special_case/4"))
+      assert special_case_2.defaults == []
+      assert special_case_4.defaults == [special_case: 1, special_case: 3]
+
+      in_the_middle_2 = Enum.find(module_node.docs, &(&1.id == "in_the_middle/2"))
+      in_the_middle_3 = Enum.find(module_node.docs, &(&1.id == "in_the_middle/3"))
+      assert in_the_middle_2.defaults == []
+      assert in_the_middle_3.defaults == []
     end
 
     test "returns the specs for each non-private function" do

--- a/test/fixtures/overlapping_defaults.ex
+++ b/test/fixtures/overlapping_defaults.ex
@@ -1,0 +1,36 @@
+defmodule OverlappingDefaults do
+  @moduledoc """
+  Overlapping default functions
+  """
+
+  @doc "Basic example"
+  def overlapping_defaults(one, two) when is_list(two),
+    do: {one, two}
+
+  @doc "Third default arg overrides previous def clause"
+  def overlapping_defaults(one, two, three \\ []),
+    do: {one, two, three}
+
+  def two_defaults(one, two) when is_atom(one) and is_atom(two),
+    do: {one, two}
+
+  @doc "Two default args"
+  def two_defaults(one, two, three \\ [], four \\ [])
+      when is_list(one) and is_list(two) and is_list(three) and is_list(four),
+      do: {one, two, three, four}
+
+  def special_case(one, two) when is_atom(one) and is_atom(two),
+    do: {one, two}
+
+  @doc "This function defines an arity that is less than the one in the previous clause"
+  def special_case(one, two \\ [], three \\ [], four \\ [])
+      when is_list(one) and is_list(two) and is_list(three) and is_list(four),
+      do: {one, two, three, four}
+
+  defmacro in_the_middle(foo, bar) when is_list(foo) and is_list(bar),
+    do: quote(do: {unquote(foo), unquote(bar)})
+
+  @doc "default arg is in the middle"
+  defmacro in_the_middle(foo, bar \\ Baz, baz),
+    do: quote(do: {unquote(foo), unquote(bar), unquote(baz)})
+end


### PR DESCRIPTION
Removes from the :default field in %ExDoc.FunctionNode,
the default functions that overlap functions defined elsewhere,
and therefore printing two HTML elements with the same ID, making it an invalid HTML page.

It takes into consideration the ordered the functions are showed up in the HTML.

With this commit, the HTML documentation for Elixir is valid HTML
according to https://github.com/svenkreiss/html5validator