### PR TITLE
Do not run concurrent tests when Refs is used

### DIFF
--- a/test/ex_doc/autolink_test.exs
+++ b/test/ex_doc/autolink_test.exs
@@ -1,5 +1,5 @@
 defmodule ExDoc.AutolinkTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   doctest ExDoc.Autolink
   import ExUnit.CaptureIO
 

--- a/test/ex_doc/refs_test.exs
+++ b/test/ex_doc/refs_test.exs
@@ -1,5 +1,5 @@
 defmodule ExDoc.RefsTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   alias ExDoc.Refs
 
   defmodule InMemory do

--- a/test/ex_doc/refs_test.exs
+++ b/test/ex_doc/refs_test.exs
@@ -10,6 +10,10 @@ defmodule ExDoc.RefsTest do
     def foo(), do: :ok
   end
 
+  setup do
+    ExDoc.Refs.clear()
+  end
+
   test "get_visibility/1" do
     assert Refs.get_visibility({:module, String}) == :public
     assert Refs.get_visibility({:module, String.Unicode}) == :hidden


### PR DESCRIPTION
To avoid race conditions.