### PR TITLE
Speed up slow tests

### DIFF
--- a/test/ex_doc/autolink_test.exs
+++ b/test/ex_doc/autolink_test.exs
@@ -27,7 +27,7 @@ defmodule ExDoc.AutolinkTest do
     end
 
     test "private module" do
-      assert_unchanged("String.Unicode")
+      assert_unchanged("Code.Typespec")
     end
 
     test "erlang module" do

--- a/test/ex_doc/refs_test.exs
+++ b/test/ex_doc/refs_test.exs
@@ -11,15 +11,15 @@ defmodule ExDoc.RefsTest do
   end
 
   test "get_visibility/1" do
-    assert Refs.get_visibility({:module, String}) == :public
-    assert Refs.get_visibility({:module, String.Unicode}) == :hidden
+    assert Refs.get_visibility({:module, Code}) == :public
+    assert Refs.get_visibility({:module, Code.Typespec}) == :hidden
     assert Refs.get_visibility({:module, Unknown}) == :undefined
     assert Refs.get_visibility({:module, InMemory}) == :public
 
     assert Refs.get_visibility({:function, Enum, :join, 1}) == :public
     assert Refs.get_visibility({:function, Enum, :join, 2}) == :public
-    assert Refs.get_visibility({:function, String.Unicode, :version, 0}) == :hidden
-    assert Refs.get_visibility({:function, String.Unicode, :version, 9}) == :undefined
+    assert Refs.get_visibility({:function, Code.Typespec, :spec_to_quoted, 2}) == :hidden
+    assert Refs.get_visibility({:function, Code.Typespec, :spec_to_quoted, 9}) == :undefined
     assert Refs.get_visibility({:function, Enum, :join, 9}) == :undefined
     assert Refs.get_visibility({:function, :lists, :all, 2}) == :public
     assert Refs.get_visibility({:function, :lists, :all, 9}) == :undefined
@@ -51,8 +51,8 @@ defmodule ExDoc.RefsTest do
   end
 
   test "public?/1" do
-    assert Refs.public?({:module, String})
-    refute Refs.public?({:module, String.Unicode})
+    assert Refs.public?({:module, Code})
+    refute Refs.public?({:module, Code.Typespec})
   end
 
   test "insert_from_chunk/2 with module that doesn't exist" do


### PR DESCRIPTION
Do not use String.Unicode module for testing,
which happens to be the heaviest module in the Elixir codebase.