### PR TITLE
Deal with headings without contents in sidebar sections

### DIFF
--- a/lib/ex_doc/formatter/html/search_items.ex
+++ b/lib/ex_doc/formatter/html/search_items.ex
@@ -11,8 +11,8 @@ defmodule ExDoc.Formatter.HTML.SearchItems do
     ["searchNodes=" | SimpleJSON.encode(items)]
   end
 
-  @h2_split_regex ~r/<h2.*?>/
-  @header_body_regex ~r/(?<header>.*)<\/h2>(?<body>.*)/s
+  @h2_split_regex ~r/<h2\b.*?>/
+  @header_body_regex ~r/(?<header>.+)<\/h2>(?<body>.*)/s
   defp extra(%{id: id, title: title, content: content}) do
     [intro | sections] = Regex.split(@h2_split_regex, content)
     intro_json_item = encode("#{id}.html", title, :extras, intro)

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -358,7 +358,7 @@ defmodule ExDoc.Formatter.HTMLTest do
                ~s("extras":[{"group":"","headers":[],"id":"api-reference","title":"API Reference"},)
 
       assert content =~
-               ~s({"group":"","headers":[{"anchor":"header-sample","id":"Header sample"},{"anchor":"more-than","id":"more &gt; than"}],"id":"readme","title":"README"})
+               ~s({"group":"","headers":[{"anchor":"heading-without-content","id":"Heading without content"},{"anchor":"header-sample","id":"Header sample"},{"anchor":"more-than","id":"more &gt; than"}],"id":"readme","title":"README"})
     end
 
     test "containing settext headers while discarding links on header" do

--- a/test/fixtures/README.md
+++ b/test/fixtures/README.md
@@ -4,6 +4,8 @@
 `t:atom/0`
 `mix compile.elixir`
 
+## Heading without content
+
 ## `Header` sample
 
 hello
@@ -11,4 +13,3 @@ hello
 ## more > than
 
 world
-


### PR DESCRIPTION
Fixes a bug when a heading has no content (such as in the CHANGELOG)