### PR TITLE
Improve Accessibility

### DIFF
--- a/assets/less/content/general.less
+++ b/assets/less/content/general.less
@@ -18,16 +18,8 @@ h1 {
     margin: 0;
   }
 
-  &.section-heading {
-    margin: 1.5em 0 .5em;
-  }
-
   & small {
     font-weight: 300;
-  }
-
-  a.view-source {
-    font-size: 1.2rem;
   }
 }
 
@@ -52,8 +44,9 @@ a.no-underline {
 }
 
 a.view-source {
+  display: inline-block;
   float: right;
-  color: @mediumGray;
+  color: #727272;
   text-decoration: none;
   border: none;
   transition: color 0.3s ease-in-out;
@@ -65,9 +58,9 @@ a.view-source {
 }
 
 .note {
-  color: #959595;
+  color: #727272;
   margin-right: 5px;
-  font-size: 14px;
+  font-size: 0.875em;
   font-weight: normal;
 }
 
@@ -113,10 +106,30 @@ td, th {
   vertical-align: top;
 }
 
+.main-header {
+  margin-top: 2em;
+
+  h1 {
+    display: inline;
+
+    & ~ a.view-source {
+      font-size: 1.2rem;
+      line-height: 3rem;
+    }
+  }
+}
+
 .section-heading {
+  margin: 3em 0 1em;
+
   &:hover a.hover-link {
     opacity: 1;
     text-decoration: none;
+  }
+
+  h1 {
+    display: inline-block;
+    margin: 0;
   }
 
   a.hover-link {

--- a/assets/less/html.less
+++ b/assets/less/html.less
@@ -18,10 +18,13 @@
 
 @import './night/night';
 @import './night/content';
+@import './night/search';
 @import './night/sidebar';
+@import './night/quick-switch';
 @import './night/keyboard-shortcuts';
 @import './night/tooltips';
 
 @import './screen-reader';
 @import './print';
 @import './makeup';
+@import './night/makeup';

--- a/assets/less/makeup.less
+++ b/assets/less/makeup.less
@@ -10,18 +10,18 @@ code.makeup {
 }
 
 @default-text-color: #4d4d4c;
-/* https://tmbb.github.io/makeup_demo/elixir.html#tango */
+/* Originally taken from https://tmbb.github.io/makeup_demo/elixir.html#tango */
 .makeup {
   .hll {background-color: #ffffcc}
   .bp {color: #3465a4; } /* :name_builtin_pseudo */
-  .c {color: #999999; } /* :comment */
-  .c1 {color: #999999; } /* :comment_single */
-  .ch {color: #999999; } /* :comment_hashbang */
-  .cm {color: #999999; } /* :comment_multiline */
-  .cp {color: #999999; } /* :comment_preproc */
-  .cpf {color: #999999; } /* :comment_preproc_file */
-  .cs {color: #999999; } /* :comment_special */
-  .dl {color: #4e9a06; } /* :string_delimiter */
+  .c {color: #737373; } /* :comment */
+  .c1 {color: #737373; } /* :comment_single */
+  .ch {color: #737373; } /* :comment_hashbang */
+  .cm {color: #737373; } /* :comment_multiline */
+  .cp {color: #737373; } /* :comment_preproc */
+  .cpf {color: #737373; } /* :comment_preproc_file */
+  .cs {color: #737373; } /* :comment_special */
+  .dl {color: #408200; } /* :string_delimiter */
   .err {color: #a40000; border: #ef2929; } /* :error */
   .fm {color: @default-text-color; } /* :name_function_magic */
   .g {color: @default-text-color; } /* :generic */
@@ -30,7 +30,7 @@ code.makeup {
   .gh {color: #000080; font-weight: bold; } /* :generic_heading */
   .gi {color: #00A000; } /* :generic_inserted */
   .go {color: @default-text-color; font-style: italic; } /* :generic_output */
-  .gp {color: #999999; } /* :generic_prompt */
+  .gp {color: #737373; } /* :generic_prompt */
   .gr {color: #ef2929; } /* :generic_error */
   .gs {color: @default-text-color; font-weight: bold; } /* :generic_strong */
   .gt {color: #a40000; font-weight: bold; } /* :generic_traceback */
@@ -52,37 +52,37 @@ code.makeup {
   .mi {color: #2937ab; } /* :number_integer */
   .mo {color: #2937ab; } /* :number_oct */
   .n {color: @default-text-color; } /* :name */
-  .na {color: #c4a000; } /* :name_attribute */
+  .na {color: #8a7000; } /* :name_attribute */
   .nb {color: #204a87; } /* :name_builtin */
   .nc {color: #0000cf; } /* :name_class */
   .nd {color: #5c35cc; font-weight: bold; } /* :name_decorator */
   .ne {color: #cc0000; font-weight: bold; } /* :name_exception */
-  .nf {color: #f57900; } /* :name_function */
-  .ni {color: #ce5c00; } /* :name_entity */
-  .nl {color: #f57900; } /* :name_label */
+  .nf {color: #b65800; } /* :name_function */
+  .ni {color: #bc5400; } /* :name_entity */
+  .nl {color: #b65800; } /* :name_label */
   .nn {color: @default-text-color; } /* :name_namespace */
-  .no {color: #c17d11; } /* :name_constant */
+  .no {color: #a06600; } /* :name_constant */
   .nt {color: #204a87; font-weight: bold; } /* :name_tag */
   .nv {color: @default-text-color; } /* :name_variable */
   .nx {color: @default-text-color; } /* :name_other */
-  .o {color: #ce5c00; } /* :operator */
+  .o {color: #bc5400; } /* :operator */
   .ow {color: #204a87; } /* :operator_word */
   .p {color: @default-text-color; } /* :punctuation */
   .py {color: @default-text-color; } /* :name_property */
-  .s {color: #4e9a06; } /* :string */
-  .s1 {color: #4e9a06; } /* :string_single */
-  .s2 {color: #4e9a06; } /* :string_double */
-  .sa {color: #4e9a06; } /* :string_affix */
-  .sb {color: #4e9a06; } /* :string_backtick */
-  .sc {color: #4e9a06; } /* :string_char */
+  .s {color: #408200; } /* :string */
+  .s1 {color: #408200; } /* :string_single */
+  .s2 {color: #408200; } /* :string_double */
+  .sa {color: #408200; } /* :string_affix */
+  .sb {color: #408200; } /* :string_backtick */
+  .sc {color: #408200; } /* :string_char */
   .sd {color: #8f5902; font-style: italic; } /* :string_doc */
   .se {color: #204a87; } /* :string_escape */
-  .sh {color: #4e9a06; } /* :string_heredoc */
+  .sh {color: #408200; } /* :string_heredoc */
   .si {color: #204a87; } /* :string_interpol */
   .sr {color: #cc0000; } /* :string_regex */
-  .ss {color: #c17d11; } /* :string_symbol */
-  .sx {color: #4e9a06; } /* :string_other */
-  .sx {color: #4e9a06; } /* :string_sigil */
+  .ss {color: #a06600; } /* :string_symbol */
+  .sx {color: #408200; } /* :string_other */
+  .sx {color: #408200; } /* :string_sigil */
   .vc {color: @default-text-color; } /* :name_variable_class */
   .vg {color: @default-text-color; } /* :name_variable_global */
   .vi {color: @default-text-color; } /* :name_variable_instance */
@@ -96,27 +96,27 @@ code.makeup {
 
   .hll {background-color: #49483e}
   .bp {color: #f8f8f2; } /* :name_builtin_pseudo */
-  .c {color: #75715e; } /* :comment */
-  .c1 {color: #75715e; } /* :comment_single */
-  .ch {color: #75715e; } /* :comment_hashbang */
-  .cm {color: #75715e; } /* :comment_multiline */
-  .cp {color: #75715e; } /* :comment_preproc */
-  .cpf {color: #75715e; } /* :comment_preproc_file */
-  .cs {color: #75715e; } /* :comment_special */
+  .c {color: #969386; } /* :comment */
+  .c1 {color: #969386; } /* :comment_single */
+  .ch {color: #969386; } /* :comment_hashbang */
+  .cm {color: #969386; } /* :comment_multiline */
+  .cp {color: #969386; } /* :comment_preproc */
+  .cpf {color: #969386; } /* :comment_preproc_file */
+  .cs {color: #969386; } /* :comment_special */
   .dl {color: #e6db74; } /* :string_delimiter */
   .err {color: #960050; background-color: #1e0010; } /* :error */
   .fm {color: #a6e22e; } /* :name_function_magic */
-  .gd {color: #f92672; } /* :generic_deleted */
+  .gd {color: #ff5385; } /* :generic_deleted */
   .ge {font-style: italic; } /* :generic_emph */
   .gi {color: #a6e22e; } /* :generic_inserted */
   .gs {font-weight: bold; } /* :generic_strong */
-  .gu {color: #75715e; } /* :generic_subheading */
-  .gt {color: #f92672; font-weight: bold; } /* :generic_traceback */
+  .gu {color: #969386; } /* :generic_subheading */
+  .gt {color: #ff5385; font-weight: bold; } /* :generic_traceback */
   .il {color: #ae81ff; } /* :number_integer_long */
   .k {color: #66d9ef; } /* :keyword */
   .kc {color: #66d9ef; } /* :keyword_constant */
   .kd {color: #66d9ef; } /* :keyword_declaration */
-  .kn {color: #f92672; } /* :keyword_namespace */
+  .kn {color: #ff5385; } /* :keyword_namespace */
   .kp {color: #66d9ef; } /* :keyword_pseudo */
   .kr {color: #66d9ef; } /* :keyword_reserved */
   .kt {color: #66d9ef; } /* :keyword_type */
@@ -139,11 +139,11 @@ code.makeup {
   .nl {color: #f8f8f2; } /* :name_label */
   .nn {color: #f8f8f2; } /* :name_namespace */
   .no {color: #66d9ef; } /* :name_constant */
-  .nt {color: #f92672; } /* :name_tag */
+  .nt {color: #ff5385; } /* :name_tag */
   .nv {color: #f8f8f2; } /* :name_variable */
   .nx {color: #a6e22e; } /* :name_other */
-  .o {color: #f92672; } /* :operator */
-  .ow {color: #f92672; } /* :operator_word */
+  .o {color: #ff5385; } /* :operator */
+  .ow {color: #ff5385; } /* :operator_word */
   .p {color: #f8f8f2; } /* :punctuation */
   .py {color: #f8f8f2; } /* :name_property */
   .s {color: #e6db74; } /* :string */

--- a/assets/less/night/content/footer.less
+++ b/assets/less/night/content/footer.less
@@ -1,11 +1,13 @@
 .footer {
-  color: @mediumGray;
+  color: @nightMediumGray;
 
-  .line {
-    display: inline-block;
+  .footer-button {
+    color: @nightMediumGray;
+    .linkUnderlines(@nightMediumGray)
   }
 
   a {
-    color: @mediumGray;
+    color: @nightMediumGray;
+    .linkUnderlines(@nightMediumGray)
   }
 }

--- a/assets/less/night/content/general.less
+++ b/assets/less/night/content/general.less
@@ -18,11 +18,16 @@ a.no-underline {
 }
 
 a.view-source {
+  color: #939393;
   text-decoration: none;
 
   &:hover {
     color: @white;
   }
+}
+
+.note {
+  color: #939393;
 }
 
 .summary h2 a {

--- a/assets/less/night/makeup.less
+++ b/assets/less/night/makeup.less
@@ -1,0 +1,16 @@
+// Colors
+@comment: #939393;
+
+/* https://tmbb.github.io/makeup_demo/elixir.html#tango */
+body.night-mode {
+  .makeup {
+    .c {color: @comment; } /* :comment */
+    .c1 {color: @comment; } /* :comment_single */
+    .ch {color: @comment; } /* :comment_hashbang */
+    .cm {color: @comment; } /* :comment_multiline */
+    .cp {color: @comment; } /* :comment_preproc */
+    .cpf {color: @comment; } /* :comment_preproc_file */
+    .cs {color: @comment; } /* :comment_special */
+    .gp {color: @comment; } /* :generic_prompt */
+  }
+}

--- a/assets/less/night/quick-switch.less
+++ b/assets/less/night/quick-switch.less
@@ -1,0 +1,20 @@
+#quick-switch-modal {
+  .quick-switch-wrapper {
+
+    .icon-search {
+      color: @nightMediumGray;
+    }
+
+    #quick-switch-input {
+      border-bottom-color: @nightMediumGray;
+    }
+
+    #quick-switch-results {
+      margin: 0;
+
+      .quick-switch-result {
+        border-bottom-color: @nightMediumGray;
+      }
+    }
+  }
+}

--- a/assets/less/night/search.less
+++ b/assets/less/night/search.less
@@ -1,0 +1,5 @@
+#search {
+  .loading div {
+    border-top-color: @mediumGray;
+  }
+}

--- a/assets/less/sidebar.less
+++ b/assets/less/sidebar.less
@@ -66,6 +66,7 @@
   }
 
   .sidebar-projectVersion {
+    display: block;
     position: relative;
     margin: 0;
     padding: 0;

--- a/assets/less/variables/common.less
+++ b/assets/less/variables/common.less
@@ -1,5 +1,5 @@
 // Colors
-@mediumGray: #959595;
+@mediumGray: #767676;
 @gray: #e1e1e1;
 @lightestGray: #d5dae6;
 @white: #ffffff;
@@ -13,6 +13,7 @@
 
 // Night mode
 @nightYellow: #666600;
+@nightMediumGray: #888888;
 @nightBackground: #212127;
 @nightCodeBackground: #2C2C31;
 @nightCodeBorder: #38383D;

--- a/assets/less/variables/elixir.less
+++ b/assets/less/variables/elixir.less
@@ -1,4 +1,4 @@
 @import './common';
 
-@main: #9768d1;
+@main: #8e58cb;
 @darkGray: #373f52;

--- a/assets/test/tooltips/hints-extraction.spec.js
+++ b/assets/test/tooltips/hints-extraction.spec.js
@@ -4,21 +4,28 @@ import $ from 'jquery'
 describe('hints extraction', () => {
   describe('extractModuleHint', () => {
     var modulePageObject = $($.parseHTML(`
-      <div>
-        <h1>
-          <small class="app-vsn">ex_doc v0.0.1</small>
-          Some module
+      <div id="content" class="content-inner">
+        <div class="main-header">
+          <h1>
+            Some module
+            <small class="app-vsn">(ExDoc v0.0.1)</small>
+          </h1>
+
           <a href="https://github.com/" title="View Source" class="view-source" rel="help">
             <span class="icon-code" aria-hidden="true"></span>
             <span class="sr-only">View Source</span>
           </a>
-        </h1>
+        </div>
+
         <section id="moduledoc">
           <p>
             Module <strong>description</strong> here
           </p>
         </section>
-        <section id="summary">List of functions with summaries</section>
+
+        <section id="summary" class="details-list">
+          List of functions with summaries
+        </section>
       </div>
     `))
 

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -248,7 +248,7 @@ defmodule ExDoc.Formatter.HTML.Templates do
   defp link_heading(_match, tag, title, id, prefix) do
     """
     <#{tag} id="#{prefix}#{id}" class="section-heading">
-      <a href="##{prefix}#{id}" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+      <a href="##{prefix}#{id}" class="hover-link" aria-label="Link to this section"><span class="icon-link" aria-hidden="true"></span></a>
       #{title}
     </#{tag}>
     """

--- a/lib/ex_doc/formatter/html/templates/api_reference_template.eex
+++ b/lib/ex_doc/formatter/html/templates/api_reference_template.eex
@@ -1,7 +1,8 @@
-<h1>
-  <small class="app-vsn"><%= config.project %> v<%= config.version %></small>
-  API Reference
-</h1>
+<div>
+  <h1 style="display: inline">
+    API Reference <small class="app-vsn"><%= config.project %> v<%= config.version %></small>
+  </h1>
+</div>
 
 <%= if nodes_map.modules != [] do %>
   <section class="details-list">

--- a/lib/ex_doc/formatter/html/templates/module_template.eex
+++ b/lib/ex_doc/formatter/html/templates/module_template.eex
@@ -1,16 +1,18 @@
     <%= head_template(config, %{title: module.title, type: module.type}) %>
     <%= sidebar_template(config, nodes_map) %>
 
-      <h1>
-        <small class="app-vsn"><%= config.project %> v<%= config.version %></small>
-        <%= module_title(module) %>
+      <div class="main-header">
+        <h1>
+          <%= module_title(module) %>
+          <small class="app-vsn">(<%= config.project %> v<%= config.version %>)</small>
+        </h1>
         <%= if module.source_url do %>
           <a href="<%= module.source_url %>" title="View Source" class="view-source" rel="help">
             <span class="icon-code" aria-hidden="true"></span>
             <span class="sr-only">View Source</span>
           </a>
         <% end %>
-      </h1>
+      </div>
 
       <%= if deprecated = module.deprecated do %>
         <div class="deprecated">
@@ -26,26 +28,30 @@
 
       <%= if Enum.any?(summary, fn {_, v} -> v != [] end) do %>
         <section id="summary" class="details-list">
-          <h1 class="section-heading">
-            <a class="hover-link" href="#summary">
+          <div class="section-heading">
+            <a class="hover-link" href="#summary" aria-label="Link to this section">
               <span class="icon-link" aria-hidden="true"></span>
-              <span class="sr-only">Link to this section</span>
             </a>
-            Summary
-          </h1>
-          <%= for {name, nodes} <- summary, do: summary_template(name, nodes) %>
+            <h1>
+              Summary
+            </h1>
+            <%= for {name, nodes} <- summary, do: summary_template(name, nodes) %>
+          </div>
         </section>
       <% end %>
 
       <%= for {name, nodes} <- summary, nodes != [], key = HTML.text_to_id(name) do %>
         <section id="<%= key %>" class="details-list">
-          <h1 class="section-heading">
-            <a class="hover-link" href="#<%= key %>">
+          <div class="section-heading">
+            <a class="hover-link" href="#<%= key %>" aria-label="Link to this section">
               <span class="icon-link" aria-hidden="true"></span>
-              <span class="sr-only">Link to this section</span>
             </a>
-            <%= name %>
-          </h1>
+
+            <h1>
+              <%= name %>
+            </h1>
+          </div>
+
           <div class="<%= key %>-list">
             <%= for node <- nodes, do: detail_template(node, module) %>
           </div>

--- a/lib/ex_doc/formatter/html/templates/sidebar_template.eex
+++ b/lib/ex_doc/formatter/html/templates/sidebar_template.eex
@@ -6,14 +6,14 @@
 
 <section class="sidebar">
   <form class="sidebar-search" action="search.html">
-    <button type="submit" class="search-button">
-      <span class="icon-search" aria-hidden="true"></span>
+    <button type="submit" class="search-button" aria-label="Submit Search">
+      <span class="icon-search" aria-hidden="true" title="Submit search"></span>
     </button>
-    <button type="button" tabindex="-1" class="search-close-button">
-      <span class="icon-cross" title="Cancel search"></span>
+    <button type="button" tabindex="-1" class="search-close-button" aria-label="Cancel Search">
+      <span class="icon-cross" aria-hidden="true" title="Cancel search"></span>
     </button>
     <label class="search-label">
-      <input name="q" type="text" id="search-list" class="search-input" placeholder="Search..." aria-label="Search" autocomplete="off" />
+      <input name="q" type="text" id="search-list" class="search-input" placeholder="Search..." aria-label="Input your search terms" autocomplete="off" />
     </label>
   </form>
 
@@ -28,9 +28,9 @@
       <a href="<%= url %>" class="sidebar-projectName">
         <%= config.project %>
       </a>
-      <h2 class="sidebar-projectVersion">
+      <strong class="sidebar-projectVersion">
         v<%= config.version %>
-      </h2>
+      </strong>
     </div>
     <%= if config.logo do %>
       <a href="<%= url %>">

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -47,30 +47,30 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
     test "generates headers with hovers" do
       assert Templates.link_headings("<h2>Foo</h2><h2>Bar</h2>") == """
              <h2 id="foo" class="section-heading">
-               <a href="#foo" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+               <a href="#foo" class="hover-link" aria-label="Link to this section"><span class="icon-link" aria-hidden="true"></span></a>
                Foo
              </h2>
              <h2 id="bar" class="section-heading">
-               <a href="#bar" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+               <a href="#bar" class="hover-link" aria-label="Link to this section"><span class="icon-link" aria-hidden="true"></span></a>
                Bar
              </h2>
              """
 
       assert Templates.link_headings("<h2>Foo</h2>\n<h2>Bar</h2>") == """
              <h2 id="foo" class="section-heading">
-               <a href="#foo" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+               <a href="#foo" class="hover-link" aria-label="Link to this section"><span class="icon-link" aria-hidden="true"></span></a>
                Foo
              </h2>
 
              <h2 id="bar" class="section-heading">
-               <a href="#bar" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+               <a href="#bar" class="hover-link" aria-label="Link to this section"><span class="icon-link" aria-hidden="true"></span></a>
                Bar
              </h2>
              """
 
       assert Templates.link_headings("<h2></h2><h2>Bar</h2>") == """
              <h2></h2><h2 id="bar" class="section-heading">
-               <a href="#bar" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+               <a href="#bar" class="hover-link" aria-label="Link to this section"><span class="icon-link" aria-hidden="true"></span></a>
                Bar
              </h2>
              """
@@ -78,7 +78,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       assert Templates.link_headings("<h2></h2>\n<h2>Bar</h2>") == """
              <h2></h2>
              <h2 id="bar" class="section-heading">
-               <a href="#bar" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+               <a href="#bar" class="hover-link" aria-label="Link to this section"><span class="icon-link" aria-hidden="true"></span></a>
                Bar
              </h2>
              """
@@ -86,7 +86,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       assert Templates.link_headings("<h2>Foo</h2><h2></h2>") ==
                String.trim_trailing("""
                <h2 id="foo" class="section-heading">
-                 <a href="#foo" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+                 <a href="#foo" class="hover-link" aria-label="Link to this section"><span class="icon-link" aria-hidden="true"></span></a>
                  Foo
                </h2>
                <h2></h2>
@@ -95,7 +95,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       assert Templates.link_headings("<h2>Foo</h2>\n<h2></h2>") ==
                String.trim_trailing("""
                <h2 id="foo" class="section-heading">
-                 <a href="#foo" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+                 <a href="#foo" class="hover-link" aria-label="Link to this section"><span class="icon-link" aria-hidden="true"></span></a>
                  Foo
                </h2>
 
@@ -104,7 +104,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
 
       assert Templates.link_headings("<h3>Foo</h3>") == """
              <h3 id="foo" class="section-heading">
-               <a href="#foo" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+               <a href="#foo" class="hover-link" aria-label="Link to this section"><span class="icon-link" aria-hidden="true"></span></a>
                Foo
              </h3>
              """
@@ -113,12 +113,12 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
     test "generates headers with unique id's" do
       assert Templates.link_headings("<h3>Foo</h3>\n<h3>Foo</h3>") == """
              <h3 id="foo" class="section-heading">
-               <a href="#foo" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+               <a href="#foo" class="hover-link" aria-label="Link to this section"><span class="icon-link" aria-hidden="true"></span></a>
                Foo
              </h3>
 
              <h3 id="foo-1" class="section-heading">
-               <a href="#foo-1" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+               <a href="#foo-1" class="hover-link" aria-label="Link to this section"><span class="icon-link" aria-hidden="true"></span></a>
                Foo
              </h3>
              """
@@ -170,7 +170,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       assert content =~
                ~r{<div class="sidebar-header">\s*<div class="sidebar-projectDetails">\s*<a href="#{
                  homepage_url()
-               }" class="sidebar-projectName">\s*Elixir\s*</a>\s*<h2 class="sidebar-projectVersion">\s*v1.0.1\s*</h2>\s*</div>\s*</div>}
+               }" class="sidebar-projectName">\s*Elixir\s*</a>\s*<strong class="sidebar-projectVersion">\s*v1.0.1\s*</strong>\s*</div>\s*</div>}
     end
 
     test "text links to main when there is no homepage_url" do
@@ -184,7 +184,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       content = Templates.sidebar_template(config, @empty_nodes_map)
 
       assert content =~
-               ~r{<div class="sidebar-header">\s*<div class="sidebar-projectDetails">\s*<a href="hello.html" class="sidebar-projectName">\s*Elixir\s*</a>\s*<h2 class="sidebar-projectVersion">\s*v1.0.1\s*</h2>\s*</div>\s*</div>}
+               ~r{<div class="sidebar-header">\s*<div class="sidebar-projectDetails">\s*<a href="hello.html" class="sidebar-projectName">\s*Elixir\s*</a>\s*<strong class="sidebar-projectVersion">\s*v1.0.1\s*</strong>\s*</div>\s*</div>}
     end
 
     test "enables nav link when module type have at least one element" do
@@ -308,7 +308,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       assert content =~ ~r{<title>CompiledWithDocs [^<]*</title>}
 
       assert content =~
-               ~r{<h1>\s*<small class="app-vsn">Elixir v1.0.1</small>\s*CompiledWithDocs\s*}
+               ~r{<h1>\s*CompiledWithDocs\s*<small class=\"app-vsn\">\(Elixir v1.0.1\)</small>\s*</h1>}
 
       refute content =~ ~r{<small>module</small>}
 
@@ -316,10 +316,10 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
                ~r{moduledoc.*Example.*<span class="nc">CompiledWithDocs</span><span class="o">\.</span><span class="n">example</span>.*}ms
 
       assert content =~
-               ~r{<h2 id="module-example-unicode-escaping" class="section-heading">.*<a href="#module-example-unicode-escaping" class="hover-link">.*<span class="icon-link" aria-hidden="true"></span>.*</a>.*Example.*</h2>}ms
+               ~r{<h2 id="module-example-unicode-escaping" class="section-heading">.*<a href="#module-example-unicode-escaping" class="hover-link" aria-label=\"Link to this section\">.*<span class="icon-link" aria-hidden="true"></span>.*</a>.*Example.*</h2>}ms
 
       assert content =~
-               ~r{<h3 id="module-example-h3-heading" class="section-heading">.*<a href="#module-example-h3-heading" class="hover-link">.*<span class="icon-link" aria-hidden="true"></span>.*</a>.*Example H3 heading.*</h3>}ms
+               ~r{<h3 id="module-example-h3-heading" class="section-heading">.*<a href="#module-example-h3-heading" class="hover-link" aria-label=\"Link to this section\">.*<span class="icon-link" aria-hidden="true"></span>.*</a>.*Example H3 heading.*</h3>}ms
 
       # Summaries
       assert content =~ ~r{example/2.*Some example}ms
@@ -404,7 +404,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       content = get_module_page([CompiledWithDocs])
 
       assert content =~
-               ~r{<h3 id="example_with_h3/0-examples" class="section-heading">.*<a href="#example_with_h3/0-examples" class="hover-link">.*<span class="icon-link" aria-hidden="true"></span>.*</a>.*Examples.*</h3>}ms
+               ~r{<h3 id="example_with_h3/0-examples" class="section-heading">.*<a href="#example_with_h3/0-examples" class="hover-link" aria-label=\"Link to this section\">.*<span class="icon-link" aria-hidden="true"></span>.*</a>.*Examples.*</h3>}ms
     end
 
     test "do not output overlapping functions, causing duplicate IDs" do
@@ -429,7 +429,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       content = get_module_page([CustomBehaviourOne])
 
       assert content =~
-               ~r{<h1>\s*<small class="app-vsn">Elixir v1.0.1</small>\s*CustomBehaviourOne\s*<small>behaviour</small>}m
+               ~r{<h1>\s*CustomBehaviourOne\s*<small>behaviour</small>\s*<small class=\"app-vsn\">\(Elixir v1.0.1\)</small>\s*</h1>}
 
       assert content =~ ~r{Callbacks}
       assert content =~ ~r{<section class="detail" id="c:hello/1">}
@@ -439,7 +439,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       content = get_module_page([CustomBehaviourTwo])
 
       assert content =~
-               ~r{<h1>\s*<small class="app-vsn">Elixir v1.0.1</small>\s*CustomBehaviourTwo\s*<small>behaviour</small>\s*}m
+               ~r{<h1>\s*CustomBehaviourTwo\s*<small>behaviour</small>\s*<small class=\"app-vsn\">\(Elixir v1.0.1\)</small>\s*</h1>}
 
       assert content =~ ~r{Callbacks}
       assert content =~ ~r{<section class="detail" id="c:bye/1">}
@@ -451,7 +451,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       content = get_module_page([CustomProtocol])
 
       assert content =~
-               ~r{<h1>\s*<small class="app-vsn">Elixir v1.0.1</small>\s*CustomProtocol\s*<small>protocol</small>\s*}m
+               ~r{<h1>\s*CustomProtocol\s*<small>protocol</small>\s*<small class=\"app-vsn\">\(Elixir v1.0.1\)</small>\s*</h1>}
     end
 
     ## TASKS
@@ -460,7 +460,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       content = get_module_page([Mix.Tasks.TaskWithDocs])
 
       assert content =~
-               ~r{<h1>\s*<small class="app-vsn">Elixir v1.0.1</small>\s*mix task_with_docs\s*}m
+               ~r{<h1>\s*mix task_with_docs\s*<small class=\"app-vsn\">\(Elixir v1.0.1\)</small>\s*</h1>}
     end
   end
 end

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -307,10 +307,10 @@ defmodule ExDoc.Formatter.HTMLTest do
       assert content =~ ~r{<title>README [^<]*</title>}
 
       assert content =~
-               ~r{<h2 id="header-sample" class="section-heading">.*<a href="#header-sample" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>.*<code(\sclass="inline")?>Header</code> sample.*</h2>}ms
+               ~r{<h2 id="header-sample" class="section-heading">.*<a href="#header-sample" class="hover-link" aria-label="Link to this section"><span class="icon-link" aria-hidden="true"></span></a>.*<code(\sclass="inline")?>Header</code> sample.*</h2>}ms
 
       assert content =~
-               ~r{<h2 id="more-than" class="section-heading">.*<a href="#more-than" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>.*more &gt; than.*</h2>}ms
+               ~r{<h2 id="more-than" class="section-heading">.*<a href="#more-than" class="hover-link" aria-label="Link to this section"><span class="icon-link" aria-hidden="true"></span></a>.*more &gt; than.*</h2>}ms
 
       assert content =~ ~r{<a href="RandomError.html"><code(\sclass="inline")?>RandomError</code>}
 


### PR DESCRIPTION
Most of the suggestions have been done by https://github.com/Khan/tota11y
It passes all the tests, with the exception of one test which I consider is not valid,
and it has been reported here: https://github.com/Khan/tota11y/issues/170

Changes include:
- Font colors have been updated to have enough contrast in day-mode and night-mode.

- The HTML structure has been updated to it only contain the title inside the heading tags (h1, h2), otherwise it will look weird in screen readers.

- The h1 title of the project in the content section has been changed so it looks like:
    Some module <small class="app-vsn">(ProjectName v0.0.1)</small>
	instead of:
		<small class="app-vsn">ProjectName v0.0.1</small> Some module

- Search box makes use of ARIA attributes

- Project name in the sidebar is not a heading anymore.

- Less have been simplified in some parts where code was duplicated in the night mode.