### PR TITLE
Fix regex for autolink typespecs

### DIFF
--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -355,7 +355,7 @@ defmodule ExDoc.Autolink do
 
   defp do_typespec(string, config) do
     regex =
-      ~r/((?:((?:\:[a-z][_a-zA-Z0-9]*)|(?:[A-Z][_a-zA-Z0-9]*(?:\.[A-Z][_a-zA-Z0-9]*)*))\.)?(\w+!?))(\(.*\))/
+      ~r/((?:((?:\:[a-z][_a-zA-Z0-9]*)|(?:[A-Z][_a-zA-Z0-9]*(?:\.[A-Z][_a-zA-Z0-9]*)*))\.)?([a-z_][_a-zA-Z0-9]*[\?\!]?))(\(.*\))/
 
     Regex.replace(regex, string, fn _all, call_string, module_string, name_string, rest ->
       module = string_to_module(module_string)

--- a/test/ex_doc/autolink_test.exs
+++ b/test/ex_doc/autolink_test.exs
@@ -253,6 +253,7 @@ defmodule ExDoc.AutolinkTest do
         {{:module, MyModule}, :public},
         {{:type, MyModule, :foo, 1}, :public},
         {{:type, MyModule, :foo, 2}, :public},
+        {{:type, MyModule, :foo?, 1}, :public},
         {{:type, MyModule, :foo!, 1}, :public}
       ])
 
@@ -273,6 +274,9 @@ defmodule ExDoc.AutolinkTest do
 
       assert typespec(quote(do: t() :: foo!(bar()))) ==
                ~s[t() :: <a href="#t:foo!/1">foo!</a>(bar())]
+
+      assert typespec(quote(do: t() :: foo?(bar()))) ==
+               ~s[t() :: <a href="#t:foo?/1">foo?</a>(bar())]
     end
 
     test "remotes" do


### PR DESCRIPTION
It wouldn't detect typespecs ending in ?
Plus a more specific regex is included for detecting the typespec name.