### PR TITLE
Reformat Application (version number)

### DIFF
--- a/assets/less/sidebar.less
+++ b/assets/less/sidebar.less
@@ -66,6 +66,7 @@
   }
 
   .sidebar-projectVersion {
+    display: block;
     position: relative;
     margin: 0;
     padding: 0;

--- a/assets/test/tooltips/hints-extraction.spec.js
+++ b/assets/test/tooltips/hints-extraction.spec.js
@@ -6,8 +6,8 @@ describe('hints extraction', () => {
     var modulePageObject = $($.parseHTML(`
       <div>
         <h1>
-          <small class="app-vsn">ex_doc v0.0.1</small>
-          Some module
+          Some module <small class="app-vsn">(ExDoc v0.0.1)</small>
+
           <a href="https://github.com/" title="View Source" class="view-source" rel="help">
             <span class="icon-code" aria-hidden="true"></span>
             <span class="sr-only">View Source</span>

--- a/lib/ex_doc/formatter/html/templates/api_reference_template.eex
+++ b/lib/ex_doc/formatter/html/templates/api_reference_template.eex
@@ -1,6 +1,5 @@
 <h1>
-  <small class="app-vsn"><%= config.project %> v<%= config.version %></small>
-  API Reference
+  API Reference <small class="app-vsn"><%= config.project %> v<%= config.version %></small>
 </h1>
 
 <%= if nodes_map.modules != [] do %>

--- a/lib/ex_doc/formatter/html/templates/module_template.eex
+++ b/lib/ex_doc/formatter/html/templates/module_template.eex
@@ -2,8 +2,7 @@
     <%= sidebar_template(config, nodes_map) %>
 
       <h1>
-        <small class="app-vsn"><%= config.project %> v<%= config.version %></small>
-        <%= module_title(module) %>
+        <%= module_title(module) %> <small class="app-vsn">(<%= config.project %> v<%= config.version %>)</small>
         <%= if module.source_url do %>
           <a href="<%= module.source_url %>" title="View Source" class="view-source" rel="help">
             <span class="icon-code" aria-hidden="true"></span>

--- a/lib/ex_doc/formatter/html/templates/sidebar_template.eex
+++ b/lib/ex_doc/formatter/html/templates/sidebar_template.eex
@@ -28,9 +28,9 @@
       <a href="<%= url %>" class="sidebar-projectName">
         <%= config.project %>
       </a>
-      <h2 class="sidebar-projectVersion">
+      <strong class="sidebar-projectVersion">
         v<%= config.version %>
-      </h2>
+      </strong>
     </div>
     <%= if config.logo do %>
       <a href="<%= url %>">

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -170,7 +170,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       assert content =~
                ~r{<div class="sidebar-header">\s*<div class="sidebar-projectDetails">\s*<a href="#{
                  homepage_url()
-               }" class="sidebar-projectName">\s*Elixir\s*</a>\s*<h2 class="sidebar-projectVersion">\s*v1.0.1\s*</h2>\s*</div>\s*</div>}
+               }" class="sidebar-projectName">\s*Elixir\s*</a>\s*<strong class="sidebar-projectVersion">\s*v1.0.1\s*</strong>\s*</div>\s*</div>}
     end
 
     test "text links to main when there is no homepage_url" do
@@ -184,7 +184,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       content = Templates.sidebar_template(config, @empty_nodes_map)
 
       assert content =~
-               ~r{<div class="sidebar-header">\s*<div class="sidebar-projectDetails">\s*<a href="hello.html" class="sidebar-projectName">\s*Elixir\s*</a>\s*<h2 class="sidebar-projectVersion">\s*v1.0.1\s*</h2>\s*</div>\s*</div>}
+               ~r{<div class="sidebar-header">\s*<div class="sidebar-projectDetails">\s*<a href="hello.html" class="sidebar-projectName">\s*Elixir\s*</a>\s*<strong class="sidebar-projectVersion">\s*v1.0.1\s*</strong>\s*</div>\s*</div>}
     end
 
     test "enables nav link when module type have at least one element" do
@@ -308,7 +308,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       assert content =~ ~r{<title>CompiledWithDocs [^<]*</title>}
 
       assert content =~
-               ~r{<h1>\s*<small class="app-vsn">Elixir v1.0.1</small>\s*CompiledWithDocs\s*}
+               ~r{<h1>\s*CompiledWithDocs <small class=\"app-vsn\">\(Elixir v1.0.1\)</small>}
 
       refute content =~ ~r{<small>module</small>}
 
@@ -429,7 +429,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       content = get_module_page([CustomBehaviourOne])
 
       assert content =~
-               ~r{<h1>\s*<small class="app-vsn">Elixir v1.0.1</small>\s*CustomBehaviourOne\s*<small>behaviour</small>}m
+               ~r{<h1>\s*CustomBehaviourOne\s*<small>behaviour</small>\s*<small class=\"app-vsn\">\(Elixir v1.0.1\)</small>}
 
       assert content =~ ~r{Callbacks}
       assert content =~ ~r{<section class="detail" id="c:hello/1">}
@@ -439,7 +439,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       content = get_module_page([CustomBehaviourTwo])
 
       assert content =~
-               ~r{<h1>\s*<small class="app-vsn">Elixir v1.0.1</small>\s*CustomBehaviourTwo\s*<small>behaviour</small>\s*}m
+               ~r{<h1>\s*CustomBehaviourTwo\s*<small>behaviour</small>\s*<small class=\"app-vsn\">\(Elixir v1.0.1\)</small>}
 
       assert content =~ ~r{Callbacks}
       assert content =~ ~r{<section class="detail" id="c:bye/1">}
@@ -451,7 +451,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       content = get_module_page([CustomProtocol])
 
       assert content =~
-               ~r{<h1>\s*<small class="app-vsn">Elixir v1.0.1</small>\s*CustomProtocol\s*<small>protocol</small>\s*}m
+               ~r{<h1>\s*CustomProtocol\s*<small>protocol</small>\s*<small class=\"app-vsn\">\(Elixir v1.0.1\)</small>}
     end
 
     ## TASKS
@@ -460,7 +460,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       content = get_module_page([Mix.Tasks.TaskWithDocs])
 
       assert content =~
-               ~r{<h1>\s*<small class="app-vsn">Elixir v1.0.1</small>\s*mix task_with_docs\s*}m
+               ~r{<h1>\s*mix task_with_docs\s*<small class=\"app-vsn\">\(Elixir v1.0.1\)</small>}
     end
   end
 end


### PR DESCRIPTION
Previously the version number would be before Application name.
This affects the readability in screen readers

Additionally the version number in the sidebar is no longer a heading.