### PR TITLE
Set option :javascript_config_path default to nil

### DIFF
--- a/lib/ex_doc/config.ex
+++ b/lib/ex_doc/config.ex
@@ -27,7 +27,7 @@ defmodule ExDoc.Config do
             groups_for_modules: [],
             groups_for_functions: [],
             homepage_url: nil,
-            javascript_config_path: "docs_config.js",
+            javascript_config_path: nil,
             language: "en",
             proglang: :elixir,
             logo: nil,

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -94,7 +94,7 @@ defmodule Mix.Tasks.Docs do
 
     * `:javascript_config_path` - Path of an additional JavaScript file to be included on all pages
       to provide up-to-date data for features like the version dropdown - See the "Additional
-      JavaScript config" section. Example: `"../versions.js"`
+      JavaScript config" section. Example: `"../docs_config.js"`. Defaults to `nil`.
 
     * `:nest_modules_by_prefix` - See the "Nesting" section
 


### PR DESCRIPTION
Making the option opt-in, avoids getting a Javascript Error in every single page
when requesting the non-existent docs_config.js file, which is the most common scenario.