### PR TITLE
Accessibility: Restructure headings

### DIFF
--- a/assets/less/content/general.less
+++ b/assets/less/content/general.less
@@ -8,38 +8,28 @@ h6 {
   font-weight: 700;
   line-height: 1.5em;
   word-wrap: break-word;
+  margin: 1em 0 .5em;
 }
 
 h1 {
   font-size: 2em;
-  margin: 1em 0 .5em;
 
   &.signature {
     margin: 0;
   }
 
-  &.section-heading {
-    margin: 1.5em 0 .5em;
-  }
-
   & small {
     font-weight: 300;
-  }
-
-  a.view-source {
-    font-size: 1.2rem;
   }
 }
 
 h2 {
   font-size: 1.6em;
-  margin: 1em 0 .5em;
   font-weight: 700;
 }
 
 h3 {
   font-size: 1.375em;
-  margin: 1em 0 .5em;
   font-weight: 700;
 }
 
@@ -52,6 +42,7 @@ a.no-underline {
 }
 
 a.view-source {
+  display: inline-block;
   float: right;
   color: #727272;
   text-decoration: none;
@@ -67,7 +58,7 @@ a.view-source {
 .note {
   color: #727272;
   margin-right: 5px;
-  font-size: 14px;
+  font-size: 0.875em;
   font-weight: normal;
 }
 
@@ -114,6 +105,8 @@ td, th {
 }
 
 .section-heading {
+  margin-bottom: inherit;
+
   &:hover a.hover-link {
     opacity: 1;
     text-decoration: none;
@@ -131,9 +124,24 @@ td, th {
     font-size: 16px;
     vertical-align: middle;
   }
+
+  h1, h2, h3,
+  h4, h5, h6 {
+    display: inline-block;
+  }
+
+  h1 {
+    display: inline-block;
+
+    ~ a.view-source {
+      font-size: 1.2rem;
+      margin-top: 3rem;
+    }
+  }
 }
 
-.detail h2.section-heading {
+
+.detail .section-heading h2 {
   margin-left: 0.3em;
 }
 

--- a/assets/test/tooltips/hints-extraction.spec.js
+++ b/assets/test/tooltips/hints-extraction.spec.js
@@ -4,21 +4,27 @@ import $ from 'jquery'
 describe('hints extraction', () => {
   describe('extractModuleHint', () => {
     var modulePageObject = $($.parseHTML(`
-      <div>
-        <h1>
-          Some module <small class="app-vsn">(ExDoc v0.0.1)</small>
+      <div id="content" class="content-inner">
+        <div class="section-headeing">
+          <h1>
+            Some module <small class="app-vsn">(ExDoc v0.0.1)</small>
+          </h1>
 
           <a href="https://github.com/" title="View Source" class="view-source" rel="help">
             <span class="icon-code" aria-hidden="true"></span>
             <span class="sr-only">View Source</span>
           </a>
-        </h1>
+        </div>
+
         <section id="moduledoc">
           <p>
             Module <strong>description</strong> here
           </p>
         </section>
-        <section id="summary">List of functions with summaries</section>
+
+        <section id="summary" class="details-list">
+          List of functions with summaries
+        </section>
       </div>
     `))
 

--- a/lib/ex_doc/formatter/epub/templates/module_template.eex
+++ b/lib/ex_doc/formatter/epub/templates/module_template.eex
@@ -17,26 +17,28 @@
 
     <%= if Enum.any?(summary, fn {_, v} -> v != [] end) do %>
       <section id="summary" class="details-list">
-        <h1 class="section-heading">
+        <div class="section-heading">
           <a class="hover-link" href="#summary">
             <span class="icon-link" aria-hidden="true"></span>
             <span class="sr-only">Anchor for this section</span>
           </a>
-          Summary
-        </h1>
+
+          <h1>Summary</h1>
+        </div>
         <%= for {name, nodes} <- summary, do: H.summary_template(name, nodes) %>
       </section>
     <% end %>
 
     <%= for {name, nodes} <- summary, nodes != [], key = HTML.text_to_id(name) do %>
       <section id="<%= key %>" class="details-list">
-        <h1 class="section-heading">
+        <div class="section-heading">
           <a class="hover-link" href="#<%= key %>">
             <span class="icon-link" aria-hidden="true"></span>
             <span class="sr-only">Anchor for this section</span>
           </a>
-          <%= name %>
-        </h1>
+
+          <h1><%= name %></h1>
+        </div>
         <div class="<%= key %>-list">
           <%= for node <- nodes, do: H.detail_template(node, module) %>
         </div>

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -247,10 +247,12 @@ defmodule ExDoc.Formatter.HTML.Templates do
 
   defp link_heading(_match, tag, title, id, prefix) do
     """
-    <#{tag} id="#{prefix}#{id}" class="section-heading">
+    <div class="section-heading">
       <a href="##{prefix}#{id}" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
-      #{title}
-    </#{tag}>
+      <#{tag} id="#{prefix}#{id}">
+        #{title}
+      </#{tag}>
+    </div>
     """
   end
 

--- a/lib/ex_doc/formatter/html/templates/api_reference_template.eex
+++ b/lib/ex_doc/formatter/html/templates/api_reference_template.eex
@@ -1,10 +1,14 @@
-<h1>
-  API Reference <small class="app-vsn"><%= config.project %> v<%= config.version %></small>
-</h1>
+<div class="section-heading">
+  <h1>
+    API Reference <small class="app-vsn"><%= config.project %> v<%= config.version %></small>
+  </h1>
+</div>
 
 <%= if nodes_map.modules != [] do %>
   <section class="details-list">
-    <h2 id="modules" class="section-heading">Modules</h2>
+    <div class="section-heading">
+      <h2 id="modules">Modules</h2>
+    </div>
     <div class="summary">
       <%= for module_node <- Enum.sort_by(nodes_map.modules, & &1.id) do
         api_reference_entry_template(module_node)
@@ -15,7 +19,9 @@
 
 <%= if nodes_map.tasks != [] do %>
   <section class="details-list">
-    <h2 id="tasks" class="section-heading">Mix Tasks</h2>
+    <div class="section-heading">
+      <h2 id="tasks">Mix Tasks</h2>
+    </div>
     <div class="summary">
       <%= for task_node <- nodes_map.tasks do
         api_reference_entry_template(task_node)

--- a/lib/ex_doc/formatter/html/templates/module_template.eex
+++ b/lib/ex_doc/formatter/html/templates/module_template.eex
@@ -1,15 +1,17 @@
     <%= head_template(config, %{title: module.title, type: module.type}) %>
     <%= sidebar_template(config, nodes_map) %>
 
-      <h1>
-        <%= module_title(module) %> <small class="app-vsn">(<%= config.project %> v<%= config.version %>)</small>
+      <div class="section-heading">
+        <h1>
+          <%= module_title(module) %> <small class="app-vsn">(<%= config.project %> v<%= config.version %>)</small>
+        </h1>
         <%= if module.source_url do %>
           <a href="<%= module.source_url %>" title="View Source" class="view-source" rel="help">
             <span class="icon-code" aria-hidden="true"></span>
             <span class="sr-only">View Source</span>
           </a>
         <% end %>
-      </h1>
+      </div>
 
       <%= if deprecated = module.deprecated do %>
         <div class="deprecated">
@@ -25,26 +27,32 @@
 
       <%= if Enum.any?(summary, fn {_, v} -> v != [] end) do %>
         <section id="summary" class="details-list">
-          <h1 class="section-heading">
+          <div class="section-heading">
             <a class="hover-link" href="#summary">
               <span class="icon-link" aria-hidden="true"></span>
               <span class="sr-only">Link to this section</span>
             </a>
-            Summary
-          </h1>
-          <%= for {name, nodes} <- summary, do: summary_template(name, nodes) %>
+            <h1>
+              Summary
+            </h1>
+            <%= for {name, nodes} <- summary, do: summary_template(name, nodes) %>
+          </div>
         </section>
       <% end %>
 
       <%= for {name, nodes} <- summary, nodes != [], key = HTML.text_to_id(name) do %>
         <section id="<%= key %>" class="details-list">
-          <h1 class="section-heading">
+          <div class="section-heading">
             <a class="hover-link" href="#<%= key %>">
               <span class="icon-link" aria-hidden="true"></span>
               <span class="sr-only">Link to this section</span>
             </a>
-            <%= name %>
-          </h1>
+
+            <h1>
+              <%= name %>
+            </h1>
+          </div>
+
           <div class="<%= key %>-list">
             <%= for node <- nodes, do: detail_template(node, module) %>
           </div>

--- a/lib/ex_doc/formatter/html/templates/search_template.eex
+++ b/lib/ex_doc/formatter/html/templates/search_template.eex
@@ -1,6 +1,6 @@
 <%= head_template(config, %{title: "Search", type: :search}) %>
 <%= sidebar_template(config, nodes_map) %>
-<div id="search">
+<div id="search" class="section-heading">
   <h1>Search</h1>
   <div class="loading"><div></div><div></div><div></div><div></div></div>
 </div>

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -46,81 +46,103 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
   describe "link_headings" do
     test "generates headers with hovers" do
       assert Templates.link_headings("<h2>Foo</h2><h2>Bar</h2>") == """
-             <h2 id="foo" class="section-heading">
+             <div class="section-heading">
                <a href="#foo" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
-               Foo
-             </h2>
-             <h2 id="bar" class="section-heading">
+               <h2 id="foo">
+                 Foo
+               </h2>
+             </div>
+             <div class="section-heading">
                <a href="#bar" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
-               Bar
-             </h2>
+               <h2 id="bar">
+                 Bar
+               </h2>
+             </div>
              """
 
       assert Templates.link_headings("<h2>Foo</h2>\n<h2>Bar</h2>") == """
-             <h2 id="foo" class="section-heading">
+             <div class="section-heading">
                <a href="#foo" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
-               Foo
-             </h2>
+               <h2 id="foo">
+                 Foo
+               </h2>
+             </div>
 
-             <h2 id="bar" class="section-heading">
+             <div class="section-heading">
                <a href="#bar" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
-               Bar
-             </h2>
+               <h2 id="bar">
+                 Bar
+               </h2>
+             </div>
              """
 
       assert Templates.link_headings("<h2></h2><h2>Bar</h2>") == """
-             <h2></h2><h2 id="bar" class="section-heading">
+             <h2></h2><div class="section-heading">
                <a href="#bar" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
-               Bar
-             </h2>
+               <h2 id="bar">
+                 Bar
+               </h2>
+             </div>
              """
 
       assert Templates.link_headings("<h2></h2>\n<h2>Bar</h2>") == """
              <h2></h2>
-             <h2 id="bar" class="section-heading">
+             <div class="section-heading">
                <a href="#bar" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
-               Bar
-             </h2>
+               <h2 id="bar">
+                 Bar
+               </h2>
+             </div>
              """
 
       assert Templates.link_headings("<h2>Foo</h2><h2></h2>") ==
                String.trim_trailing("""
-               <h2 id="foo" class="section-heading">
+               <div class="section-heading">
                  <a href="#foo" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
-                 Foo
-               </h2>
+                 <h2 id="foo">
+                   Foo
+                 </h2>
+               </div>
                <h2></h2>
                """)
 
       assert Templates.link_headings("<h2>Foo</h2>\n<h2></h2>") ==
                String.trim_trailing("""
-               <h2 id="foo" class="section-heading">
+               <div class="section-heading">
                  <a href="#foo" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
-                 Foo
-               </h2>
+                 <h2 id="foo">
+                   Foo
+                 </h2>
+               </div>
 
                <h2></h2>
                """)
 
       assert Templates.link_headings("<h3>Foo</h3>") == """
-             <h3 id="foo" class="section-heading">
+             <div class="section-heading">
                <a href="#foo" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
-               Foo
-             </h3>
+               <h3 id="foo">
+                 Foo
+               </h3>
+             </div>
              """
     end
 
     test "generates headers with unique id's" do
       assert Templates.link_headings("<h3>Foo</h3>\n<h3>Foo</h3>") == """
-             <h3 id="foo" class="section-heading">
+             <div class="section-heading">
                <a href="#foo" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
-               Foo
-             </h3>
+               <h3 id="foo">
+                 Foo
+               </h3>
+             </div>
 
-             <h3 id="foo-1" class="section-heading">
+             <div class="section-heading">
                <a href="#foo-1" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
-               Foo
-             </h3>
+               <h3 id="foo-1">
+                 Foo
+               </h3>
+             </div>
              """
     end
   end
@@ -316,10 +338,10 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
                ~r{moduledoc.*Example.*<span class="nc">CompiledWithDocs</span><span class="o">\.</span><span class="n">example</span>.*}ms
 
       assert content =~
-               ~r{<h2 id="module-example-unicode-escaping" class="section-heading">.*<a href="#module-example-unicode-escaping" class="hover-link">.*<span class="icon-link" aria-hidden="true"></span>.*</a>.*Example.*</h2>}ms
+               ~r{<div class="section-heading">\s*<a href="#module-example-unicode-escaping" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>\s*<h2 id="module-example-unicode-escaping">\s*Example[^<]+</h2>\s*</div>}ms
 
       assert content =~
-               ~r{<h3 id="module-example-h3-heading" class="section-heading">.*<a href="#module-example-h3-heading" class="hover-link">.*<span class="icon-link" aria-hidden="true"></span>.*</a>.*Example H3 heading.*</h3>}ms
+               ~r{<div class="section-heading">\s*<a href="#module-example-h3-heading" class="hover-link">.*<span class="icon-link" aria-hidden="true"></span></a>\s*<h3 id="module-example-h3-heading">\s*Example H3 heading[^<]+</h3>\s*</div>}ms
 
       # Summaries
       assert content =~ ~r{example/2.*Some example}ms
@@ -404,7 +426,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       content = get_module_page([CompiledWithDocs])
 
       assert content =~
-               ~r{<h3 id="example_with_h3/0-examples" class="section-heading">.*<a href="#example_with_h3/0-examples" class="hover-link">.*<span class="icon-link" aria-hidden="true"></span>.*</a>.*Examples.*</h3>}ms
+               ~r{<div class="section-heading">\s*<a href="#example_with_h3/0-examples" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>\s*<h3 id="example_with_h3/0-examples">\s*Examples[^<]+</h3>\s*</div>}ms
     end
 
     test "do not output overlapping functions, causing duplicate IDs" do

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -307,10 +307,10 @@ defmodule ExDoc.Formatter.HTMLTest do
       assert content =~ ~r{<title>README [^<]*</title>}
 
       assert content =~
-               ~r{<h2 id="header-sample" class="section-heading">.*<a href="#header-sample" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>.*<code(\sclass="inline")?>Header</code> sample.*</h2>}ms
+               ~r{<div class="section-heading">\s*<a href="#header-sample" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>\s*<h2 id="header-sample">\s*<code(\sclass="inline")?>Header</code> sample\s*</h2>\s*</div>}ms
 
       assert content =~
-               ~r{<h2 id="more-than" class="section-heading">.*<a href="#more-than" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>.*more &gt; than.*</h2>}ms
+               ~r{<div class="section-heading">\s*<a href="#more-than" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>\s*<h2 id="more-than">\s*more &gt; than\s*</h2>\s*</div>}ms
 
       assert content =~ ~r{<a href="RandomError.html"><code(\sclass="inline")?>RandomError</code>}
 


### PR DESCRIPTION
It only holds the title inside the heading,
Everything else, such as links are moved our of the heading.
Everything is contained in a `<div class="section-heading"> `tag.

**A) original****
![A_orig](https://user-images.githubusercontent.com/9133420/91402311-a68e1a80-e806-11ea-873a-03147f6554b5.png)

**A) fixed****
![A_fixed](https://user-images.githubusercontent.com/9133420/91402275-a42bc080-e806-11ea-8c00-0229f1caedf7.png)
***************

**B) original**
![B_orig](https://user-images.githubusercontent.com/9133420/91402360-aa21a180-e806-11ea-89d1-3abd0168f639.png)

**B) fixed**
![B_fixed](https://user-images.githubusercontent.com/9133420/91402336-a857de00-e806-11ea-9761-a057daa50e80.png)
***************

**C) original**
![C_orig](https://user-images.githubusercontent.com/9133420/91402391-abeb6500-e806-11ea-8891-74a81ec00e58.png)

**C) fixed**
![C_fixed](https://user-images.githubusercontent.com/9133420/91402376-aaba3800-e806-11ea-82c5-fc453f9b3b47.png)

***************

**D) original**
![D_orig](https://user-images.githubusercontent.com/9133420/91402419-adb52880-e806-11ea-81f4-3f761c768639.png)

**D) fixed**
![D_fixed](https://user-images.githubusercontent.com/9133420/91402408-ad1c9200-e806-11ea-857c-b4a3981dface.png)
***************

**E) original**
![E_orig](https://user-images.githubusercontent.com/9133420/91402461-b0b01900-e806-11ea-9556-74657d89c5f9.png)

**E) fixed**
![E_fixed](https://user-images.githubusercontent.com/9133420/91402435-aee65580-e806-11ea-9c8a-3648f2b37698.png)
