### PR TITLE
Introduce test.js and test.all tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ The easiest way to test changes to ExDoc is to locally rebuild the app and its o
   3. If you want to contribute a pull request, please do not add to your commits the files generated in the `assets/` and `formatters/` folders
   4. Run `mix lint.` to check if the Elixir and JavaScript files are properly formatted.
      You can run `mix fix` to let the JavaScript linter and Elixir formatter fix the code automatically before submitting your pull request
+  5. You can make sure all Elixir tests pass by running `mix test`, and  all JavaScript tests by running `mix test.js`. If you want to make sure all the test in the continuous integration will pass, you can locally run `mix test.all` before submitting your PR, which includes lint checking, tests and building of docs.
 
 ## License
 

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule ExDoc.Mixfile do
       elixirc_paths: elixirc_paths(Mix.env()),
       source_url: "https://github.com/elixir-lang/ex_doc/",
       test_coverage: [tool: ExCoveralls],
-      preferred_cli_env: [coveralls: :test],
+      preferred_cli_env: [coveralls: :test, "test.all": :test],
       description: "ExDoc is a documentation generation tool for Elixir",
       docs: docs()
     ]
@@ -43,7 +43,17 @@ defmodule ExDoc.Mixfile do
       clean: [&clean_test_fixtures/1, "clean"],
       fix: ["format", "cmd npm run --prefix assets lint:fix"],
       lint: ["format --check-formatted", "cmd npm run --prefix assets lint"],
-      setup: ["deps.get", "cmd npm install --prefix assets"]
+      setup: ["deps.get", "cmd npm install --prefix assets"],
+      "test.js": ["cmd npm run --prefix assets test"],
+      "test.all": [
+        "lint",
+        "test",
+        "test.js",
+        "docs",
+        &generated_docs_exists?/1,
+        "cmd test/prerelease.sh",
+        fn _ -> IO.puts("All tests have been succesfully executed.") end
+      ]
     ]
   end
 
@@ -105,5 +115,18 @@ defmodule ExDoc.Mixfile do
 
   defp clean_test_fixtures(_args) do
     File.rm_rf("test/tmp")
+  end
+
+  defp generated_docs_exists?(_args) do
+    file_exists!("doc/index.html")
+    file_exists!("doc/ex_doc.epub")
+  end
+
+  defp file_exists!(path) do
+    if File.exists?(path) do
+      IO.puts("#{path} exists.")
+    else
+      raise("File #{path} could not be found.")
+    end
   end
 end

--- a/test/prerelease.sh
+++ b/test/prerelease.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-PKG=test/tmp/package
+PKG=$(mktemp -d)
 
 # build package
 mix hex.build
@@ -7,7 +7,7 @@ mix hex.build
 TAR=$(ls ex_doc-*.tar | head -n 1)
 
 # extract package
-rm -rf $PKG && mkdir -p $PKG/contents && tar xf $TAR -C $PKG && tar xzf $PKG/contents.tar.gz -C $PKG/contents
+mkdir -p $PKG/contents && tar xf $TAR -C $PKG && tar xzf $PKG/contents.tar.gz -C $PKG/contents
 
 # compile and build docs
 cd $PKG/contents && MIX_ENV=prod mix do deps.get --only prod, compile, docs


### PR DESCRIPTION
mix test.js: runs `npm run --prefix assets test`
mix test.all: tries to recreate all tests run by the CI (linting, tests, test/prerelease.sh)

This PR modifies test/prerelease.sh so it can be run locally without geneating
additional files in the project folder.