### PR TITLE
Fix bug in assets generation

### DIFF
--- a/lib/ex_doc/formatter/epub/assets.ex
+++ b/lib/ex_doc/formatter/epub/assets.ex
@@ -1,7 +1,7 @@
 defmodule ExDoc.Formatter.EPUB.Assets do
   @moduledoc false
 
-  defmacrop embed_pattern(pattern) do
+  defp embed_pattern(pattern) do
     ["formatters/epub", pattern]
     |> Path.join()
     |> Path.wildcard()

--- a/lib/ex_doc/formatter/html/assets.ex
+++ b/lib/ex_doc/formatter/html/assets.ex
@@ -1,7 +1,7 @@
 defmodule ExDoc.Formatter.HTML.Assets do
   @moduledoc false
 
-  defmacrop embed_pattern(pattern) do
+  defp embed_pattern(pattern) do
     ["formatters/html", pattern]
     |> Path.join()
     |> Path.wildcard()


### PR DESCRIPTION
It would not pass the test in ExDoc.Formatter.HTMLTest named
"generates in default directory with redirect index.html file"

Since a macro was being used, if there were two assets at the compilation time,
after removing the leftover asset, it would still not pass the test because two assets
were in the compiled code.