### PR TITLE
Fix Sections arrow

### DIFF
--- a/assets/js/templates/sidebar-items.handlebars
+++ b/assets/js/templates/sidebar-items.handlebars
@@ -36,8 +36,9 @@
         {{else}}
           {{#showSections node}}
             <li class="docs {{#isLocal node.id}}open{{/isLocal}}">
-              <a href="#" class="expand">
+              <a href="{{node.id}}.html#content" class="expand">
                 Sections
+                <span class="icon-goto" title="Go to Sections"></span>
               </a>
               <ul class="sections-list deflist">
                 {{#each sections}}


### PR DESCRIPTION
Closes #1229 

Adds an arrow next to `Sections` which links out to the same place as `Top`

<img width="1920" alt="Screen Shot 2020-09-13 at 8 32 28 AM" src="https://user-images.githubusercontent.com/1019721/93018175-cb6ee580-f59b-11ea-831a-50a73159da45.png">
