### PR TITLE
Make tests that capture IO asyncronous

### DIFF
--- a/test/ex_doc/autolink_test.exs
+++ b/test/ex_doc/autolink_test.exs
@@ -1,5 +1,5 @@
 defmodule ExDoc.AutolinkTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest ExDoc.Autolink
   import ExUnit.CaptureIO
 

--- a/test/ex_doc/cli_test.exs
+++ b/test/ex_doc/cli_test.exs
@@ -1,5 +1,5 @@
 defmodule ExDoc.CLITest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   import ExUnit.CaptureIO
 
   @ebin "_build/test/lib/ex_doc/ebin"


### PR DESCRIPTION
It reverts the changes introduced in dd799164abacc28b8b54a46c2a21e567b001309e
and makes of a feature introduced in Elixir v1.10 that we can read concurrently from a
captured named device