### PR TITLE
Respect deps config in autolink

### DIFF
--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -76,7 +76,8 @@ defmodule ExDoc.Formatter.HTML do
         skip_undefined_reference_warnings_on: config.skip_undefined_reference_warnings_on,
         module_id: node.id,
         file: node.source_path,
-        line: node.doc_line
+        line: node.doc_line,
+        deps: config.deps
       ]
 
       docs =

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -438,7 +438,7 @@ defmodule Mix.Tasks.Docs do
       for {app, doc} <- Keyword.merge(get_deps(), user_deps),
           lib_dir = :code.lib_dir(app),
           is_list(lib_dir),
-          do: {List.to_string(lib_dir), doc}
+          do: {app, doc}
 
     Keyword.put(options, :deps, deps)
   end

--- a/test/mix/tasks/docs_test.exs
+++ b/test/mix/tasks/docs_test.exs
@@ -81,9 +81,8 @@ defmodule Mix.Tasks.DocsTest do
              {"ex_doc", "dev", [formatter: "epub", deps: deps, source_beam: _, app: _]}
            ] = run([], app: :ex_doc, docs: [])
 
-    assert List.keyfind(deps, Application.app_dir(:earmark_parser), 0) ==
-             {Application.app_dir(:earmark_parser),
-              "https://hexdocs.pm/earmark_parser/#{Application.spec(:earmark_parser, :vsn)}/"}
+    assert List.keyfind(deps, :earmark_parser, 0) ==
+             {:earmark_parser, "https://hexdocs.pm/earmark_parser/#{Application.spec(:earmark_parser, :vsn)}/"}
   end
 
   test "allows custom dependency paths" do
@@ -92,8 +91,8 @@ defmodule Mix.Tasks.DocsTest do
              {"ex_doc", "dev", [formatter: "epub", deps: deps, source_beam: _, app: _]}
            ] = run([], app: :ex_doc, docs: [deps: [earmark_parser: "foo"]])
 
-    assert List.keyfind(deps, Application.app_dir(:earmark_parser), 0) ==
-             {Application.app_dir(:earmark_parser), "foo"}
+    assert List.keyfind(deps, :earmark_parser, 0) ==
+             {:earmark_parser, "foo"}
   end
 
   test "accepts lazy docs" do


### PR DESCRIPTION
refs #1278 
https://github.com/elixir-lang/ex_doc/commit/dd48441baf0caff94e61c32de366ead209f7d92d isn't enough as a bug fix. I implemented the rest.

## breaking change

I respected `normalize_deps`, so previously, the link URL did not include the version, but it does.

`` `Jason` `` becomes
- before:
    - `https://hexdocs.pm/jason/Jason.html`
- after:
    - `https://hexdocs.pm/jason/1.2.2/Jason.html`
