### PR TITLE
Fix html escaping in the sidebar entries

### DIFF
--- a/assets/js/templates/sidebar-items.handlebars
+++ b/assets/js/templates/sidebar-items.handlebars
@@ -30,7 +30,7 @@
         {{#isArray node.headers}}
           {{#each node.headers}}
             <li>
-              <a href="{{node.id}}.html#{{{anchor}}}">{{id}}</a>
+              <a href="{{node.id}}.html#{{{anchor}}}">{{{id}}}</a>
             </li>
           {{/each}}
         {{else}}
@@ -43,7 +43,7 @@
               <ul class="sections-list deflist">
                 {{#each sections}}
                   <li>
-                    <a href="{{node.id}}.html#{{anchor}}">{{id}}</a>
+                    <a href="{{node.id}}.html#{{anchor}}">{{{id}}}</a>
                   </li>
                 {{/each}}
               </ul>


### PR DESCRIPTION
Fixes https://github.com/elixir-lang/ex_doc/issues/1283

<img width="232" alt="Screen Shot 2020-10-05 at 10 03 36 AM" src="https://user-images.githubusercontent.com/1019721/95089607-5605b900-06f2-11eb-8eaf-dcc9864d4093.png">
