### PR TITLE
"A.b.C" raises error in autolinker

### DIFF
--- a/test/ex_doc/autolink_test.exs
+++ b/test/ex_doc/autolink_test.exs
@@ -33,6 +33,7 @@ defmodule ExDoc.AutolinkTest do
     test "unknown module" do
       assert_unchanged("Unknown")
       assert_unchanged(":unknown")
+      assert_unchanged("A.b.C")
     end
 
     test "project-local module" do


### PR DESCRIPTION
Generating the docs for a https://github.com/aws-beam/aws-elixir/ triggered an error.

I was able to reproduce it in a test with 
```elixir
assert_unchanged("A.b.C")
```
With the following error:
```
  1) test doc/3 unknown module (ExDoc.AutolinkTest)
     test/ex_doc/autolink_test.exs:33
     ** (FunctionClauseError) no function clause matching in :elixir_aliases.do_concat/2

     The following arguments were given to :elixir_aliases.do_concat/2:
     
         # 1
         [{{:., [line: 1], [{:__aliases__, [line: 1], [:A]}, :b]}, [no_parens: true, line: 1], []}, :C]
     
         # 2
         "Elixir"
     
     code: assert_unchanged("A.b.C")
     stacktrace:
       (elixir 1.10.1) src/elixir_aliases.erl:120: :elixir_aliases.do_concat/2
       (elixir 1.10.1) src/elixir_aliases.erl:108: :elixir_aliases.concat/1
       (ex_doc 0.22.6) lib/ex_doc/autolink.ex:296: ExDoc.Autolink.do_parse_module/1
       (ex_doc 0.22.6) lib/ex_doc/autolink.ex:216: ExDoc.Autolink.url/3
       (ex_doc 0.22.6) lib/ex_doc/autolink.ex:80: ExDoc.Autolink.walk/2
       test/ex_doc/autolink_test.exs:444: ExDoc.AutolinkTest.assert_unchanged/2
       test/ex_doc/autolink_test.exs:36: (test)
```

Note that "A.B.C", "A.B.c", "A.b.c" all didnt' raise an error.
