### PR TITLE
Fix autolink to handle URIs with arbitrary scheme part without warning

### DIFF
--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -105,6 +105,7 @@ defmodule ExDoc.Autolink do
 
   defp build_extra_link(link, config) do
     with uri <- URI.parse(link),
+         nil <- uri.scheme,
          nil <- uri.host,
          true <- is_binary(uri.path),
          false <- uri.path =~ @ref_regex,

--- a/test/ex_doc/autolink_test.exs
+++ b/test/ex_doc/autolink_test.exs
@@ -429,6 +429,8 @@ defmodule ExDoc.AutolinkTest do
              "documentation references module \"Unknown\" but it is undefined"
 
     assert_unchanged(~m"`Unknown`")
+
+    assert_unchanged(~m"[Blank](about:blank)")
   end
 
   ## Helpers


### PR DESCRIPTION
Fixes #1288.

Currently a URI with no host, but with the scheme part present (like `about:blank`) is treated as a file reference and results in a warning (`documentation references file "about:blank" but it does not exist`).

Checking that both host and scheme parts are absent should do the trick.