### PR TITLE
Generate docs for Erlang projects

### DIFF
--- a/lib/ex_doc.ex
+++ b/lib/ex_doc.ex
@@ -33,6 +33,7 @@ defmodule ExDoc do
     {output, options} = Keyword.pop(options, :output, "./doc")
     {groups_for_modules, options} = Keyword.pop(options, :groups_for_modules, [])
     {nest_modules_by_prefix, options} = Keyword.pop(options, :nest_modules_by_prefix, [])
+    {proglang, options} = Keyword.pop(options, :proglang, :elixir)
 
     {source_url_pattern, options} =
       Keyword.pop_lazy(options, :source_url_pattern, fn ->
@@ -45,6 +46,7 @@ defmodule ExDoc do
       main: options[:main],
       output: normalize_output(output),
       homepage_url: options[:homepage_url],
+      proglang: normalize_proglang(proglang),
       source_root: options[:source_root] || File.cwd!(),
       source_url_pattern: source_url_pattern,
       nest_modules_by_prefix: normalize_nest_modules_by_prefix(nest_modules_by_prefix),
@@ -82,6 +84,9 @@ defmodule ExDoc do
   defp normalize_output(output) do
     String.trim_trailing(output, "/")
   end
+
+  defp normalize_proglang(elixir) when elixir in [:elixir, "elixir"], do: :elixir
+  defp normalize_proglang(erlang) when erlang in [:erlang, "erlang"], do: :erlang
 
   defp normalize_groups_for_modules(groups_for_modules) do
     default_groups = [Deprecated: &deprecated?/1, Exceptions: &exception?/1]

--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -452,8 +452,12 @@ defmodule ExDoc.Autolink do
     ex_doc_app_url(module, config, inspect(module), config.ext, "")
   end
 
-  defp app_module_url(:otp, module, _config) do
+  defp app_module_url(:erlang_otp, module, _config) do
     @otpdocs <> "#{module}.html"
+  end
+
+  defp app_module_url(:erlang, _module, _config) do
+    nil
   end
 
   defp local_url(kind, name, arity, config, original_text, options \\ [])
@@ -511,6 +515,9 @@ defmodule ExDoc.Autolink do
           :no_tool ->
             nil
 
+          :erlang ->
+            nil
+
           tool ->
             if same_module? do
               fragment(tool, kind, name, arity)
@@ -557,7 +564,7 @@ defmodule ExDoc.Autolink do
     "#" <> prefix(kind) <> "#{T.enc(Atom.to_string(name))}/#{arity}"
   end
 
-  defp fragment(:otp, kind, name, arity) do
+  defp fragment(erlang, kind, name, arity) when erlang in [:erlang_otp, :erlang] do
     case kind do
       :function -> "##{name}-#{arity}"
       :callback -> "#Module:#{name}-#{arity}"
@@ -569,18 +576,19 @@ defmodule ExDoc.Autolink do
     name = Atom.to_string(module)
 
     if name == String.downcase(name) do
-      case {:code.which(module), function_exported?(module, :__info__, 1)} do
-        {:preloaded, _} ->
-          :otp
+      case :code.which(module) do
+        :preloaded ->
+          :erlang_otp
 
-        {:non_existing, _} ->
+        :non_existing ->
           :no_tool
 
-        {_, true} ->
-          :ex_doc
-
-        {_, false} ->
-          :otp
+        path ->
+          if String.starts_with?(List.to_string(path), List.to_string(:code.lib_dir())) do
+            :erlang_otp
+          else
+            :erlang
+          end
       end
     else
       :ex_doc

--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -569,19 +569,18 @@ defmodule ExDoc.Autolink do
     name = Atom.to_string(module)
 
     if name == String.downcase(name) do
-      case :code.which(module) do
-        :preloaded ->
+      case {:code.which(module), function_exported?(module, :__info__, 1)} do
+        {:preloaded, _} ->
           :otp
 
-        :non_existing ->
+        {:non_existing, _} ->
           :no_tool
 
-        path ->
-          if String.starts_with?(List.to_string(path), List.to_string(:code.lib_dir())) do
-            :otp
-          else
-            :no_tool
-          end
+        {_, true} ->
+          :ex_doc
+
+        {_, false} ->
+          :otp
       end
     else
       :ex_doc

--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -336,17 +336,22 @@ defmodule ExDoc.Autolink do
   def typespec(ast, options) do
     config = struct!(__MODULE__, options)
 
-    string =
-      ast
-      |> Macro.to_string()
-      |> Code.format_string!(line_length: 80)
-      |> IO.iodata_to_binary()
-      |> T.h()
+    case tool(config.current_module) do
+      erlang when erlang in [:erlang, :erlang_otp] ->
+        ## TODO: print the docs_v1 signature / AST snippet
+        config.id
+      :ex_doc ->
+        string =
+          ast
+          |> Macro.to_string()
+          |> Code.format_string!(line_length: 80)
+          |> IO.iodata_to_binary()
+          |> T.h()
 
-    name = typespec_name(ast)
-    {name, rest} = split_name(string, name)
-
-    name <> do_typespec(rest, config)
+        name = typespec_name(ast)
+        {name, rest} = split_name(string, name)
+        name <> do_typespec(rest, config)
+    end
   end
 
   defp typespec_name({:"::", _, [{name, _, _}, _]}), do: Atom.to_string(name)

--- a/lib/ex_doc/cli.ex
+++ b/lib/ex_doc/cli.ex
@@ -23,6 +23,7 @@ defmodule ExDoc.CLI do
         ],
         switches: [
           language: :string,
+          proglang: :atom,
           source_ref: :string,
           version: :boolean
         ]
@@ -122,6 +123,7 @@ defmodule ExDoc.CLI do
       -l, --logo          Path to the image logo of the project (only PNG or JPEG accepted)
                           The image size will be 64x64 and copied to the assets directory
       -m, --main          The entry-point page in docs, default: "api-reference"
+          --proglang      The project's programming language, default: "elixir"
           --source-ref    Branch/commit/tag used for source link inference, default: "master"
       -r, --source-root   Path to the source code root, used for generating links, default: "."
       -u, --source-url    URL to the source code

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -262,6 +262,9 @@ defmodule ExDoc.Formatter.HTML.Templates do
     link_headings(content, @heading_regex, prefix <> "-")
   end
 
+  defp stylesheet_path(:elixir), do: "dist/elixir*.css"
+  defp stylesheet_path(:erlang), do: "dist/erlang*.css"
+
   templates = [
     detail_template: [:node, :_module],
     footer_template: [:config],

--- a/lib/ex_doc/formatter/html/templates/head_template.eex
+++ b/lib/ex_doc/formatter/html/templates/head_template.eex
@@ -10,7 +10,7 @@
       <meta name="author" content="<%= Enum.join(config.authors, ", ") %>">
     <% end %>
     <title><%= page.title %> — <%= config.project %> v<%= config.version %></title>
-    <link rel="stylesheet" href="<%= asset_rev config.output, "dist/elixir*.css" %>" />
+    <link rel="stylesheet" href="<%= asset_rev config.output, stylesheet_path(config.proglang) %>" />
     <%= if config.canonical do %>
       <link rel="canonical" href="<%= config.canonical %>" />
     <% end %>

--- a/lib/ex_doc/language.ex
+++ b/lib/ex_doc/language.ex
@@ -1,0 +1,12 @@
+defmodule ExDoc.Language do
+end
+
+defmodule ExDoc.Language.Elixir do
+end
+
+defmodule ExDoc.Language.Erlang do
+
+  def to_ast(doc, _options),
+   do: doc
+
+end

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -588,7 +588,7 @@ defmodule ExDoc.Retriever do
   end
 
   defp source_path(module, config) do
-    source = String.Chars.to_string(module.__info__(:compile)[:source])
+    source = String.Chars.to_string(module.module_info(:compile)[:source])
 
     if root = config.source_root do
       Path.relative_to(source, root)

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -165,6 +165,9 @@ defmodule ExDoc.Retriever do
     {first in ?a..?z, name, arity}
   end
 
+  defp doc_ast("application/erlang+html", %{"en" => doc}, options),
+    do: ExDoc.Language.Erlang.to_ast(doc, options)
+
   defp doc_ast("text/markdown", %{"en" => doc}, options),
     do: Markdown.to_ast(doc, options)
 


### PR DESCRIPTION
Hi! This PR fixes some small issues when generating docs from Erlang doc chunks (created by [`erl_docgen`](https://github.com/erlef/documentation-wg/issues/3) or [`edoc`](https://github.com/erlef/documentation-wg/issues/4)). These are mostly earlier @wojtekmach's changes and my fixes from https://github.com/elixir-lang/ex_doc/pull/1143, applied on top of the current master.

This PR also exposes the `ExDoc.Config.proglang` field as a command line switch `--proglang`. This way it's possible to determine which (Elixir, the default, or Erlang) stylesheet is used for the generated documentation. This might not be flexible enough for projects shipping both Erlang and Elixir APIs, but seems to be a good enough starting point.

A preview of a trivial lib's docs is available at https://erszcz.github.io/kvs.

Currently, the prerequisite to generate Erlang docs is having EDoc with EEP-48 support installed - either as a standalone app from https://github.com/erszcz/edoc or from https://github.com/erlang/otp/pull/2803. With that in place:

```
$ PATH_TO_EDOC/bin/edoc.escript -app kvs -chunks -pa _build/default/lib/kvs/ebin
$ PATH_TO_EXDOC/bin/ex_doc kvs "0.1.0" _build/default/lib/kvs/ebin/ --main kvs -o ex_doc --proglang elixir
```