### PR TITLE
Change autolink to return path rather than just hash for the current module

### DIFF
--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -427,10 +427,6 @@ defmodule ExDoc.Autolink do
 
   ## Internals
 
-  defp module_url(module, _mode, %{current_module: module}, _string) do
-    "#content"
-  end
-
   defp module_url(module, mode, config, string) do
     ref = {:module, module}
 
@@ -446,6 +442,10 @@ defmodule ExDoc.Autolink do
 
         nil
     end
+  end
+
+  defp app_module_url(:ex_doc, module, %{current_module: module} = config) do
+    ex_doc_app_url(module, config, inspect(module), config.ext, "#content")
   end
 
   defp app_module_url(:ex_doc, module, config) do

--- a/test/ex_doc/autolink_test.exs
+++ b/test/ex_doc/autolink_test.exs
@@ -45,7 +45,7 @@ defmodule ExDoc.AutolinkTest do
       assert autolink("String", apps: [:elixir]) == ~m"[`String`](String.html)"
 
       assert autolink("AutolinkTest.Foo", current_module: AutolinkTest.Foo) ==
-               ~m"[`AutolinkTest.Foo`](#content)"
+               ~m"[`AutolinkTest.Foo`](AutolinkTest.Foo.html#content)"
     end
 
     test "remote function" do


### PR DESCRIPTION
When on a module page, a reference to the same module is autolinked as `#content`. Such URL depends on the context and in some cases may not work as desired. For instance, have a look at the `Kernel` section [here](https://hexdocs.pm/elixir/api-reference.html), as you can see the autolinked `Kernel` resolves to `api-reference.html#content`, rather than `Kernel.html#content`, because the URL doesn't actually contain any path.