### PR TITLE
Add next/previous at the end of extra pages

### DIFF
--- a/assets/less/content.less
+++ b/assets/less/content.less
@@ -11,4 +11,5 @@
   @import './content/functions';
   @import './content/code';
   @import './content/footer';
+  @import './content/bottom-actions.less';
 }

--- a/assets/less/content/bottom-actions.less
+++ b/assets/less/content/bottom-actions.less
@@ -18,8 +18,10 @@
       white-space: nowrap;
     }
 
-    .title {
-      font-size: 1.2em;
+    &[rel="prev"] {
+      .subheader {
+        text-align: right;
+      }
     }
   }
 }

--- a/assets/less/content/bottom-actions.less
+++ b/assets/less/content/bottom-actions.less
@@ -1,0 +1,35 @@
+.bottom-actions {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 4em;
+
+  .bottom-actions-button {
+    display: flex;
+    text-decoration: none;
+    flex-direction: column;
+    border-radius: 4px;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    padding: 8px 16px;
+    min-width: 150px;
+
+    .subheader {
+      font-size: 0.8em;
+      color: @main;
+      white-space: nowrap;
+    }
+
+    .title {
+      font-size: 1.2em;
+    }
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .bottom-actions {
+    flex-direction: column-reverse;
+
+    .bottom-actions-item:not(:first-child) {
+      margin-bottom: 16px;
+    }
+  }
+}

--- a/assets/less/night/content.less
+++ b/assets/less/night/content.less
@@ -4,4 +4,5 @@ body.night-mode .content-inner {
   @import './content/functions';
   @import './content/code';
   @import './content/footer';
+  @import './content/bottom-actions.less';
 }

--- a/assets/less/night/content/bottom-actions.less
+++ b/assets/less/night/content/bottom-actions.less
@@ -1,0 +1,5 @@
+.bottom-actions {
+  .bottom-actions-button {
+    border: 1px solid rgba(255, 255, 255, 0.1);
+  }
+}

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -270,12 +270,13 @@ defmodule ExDoc.Formatter.HTML.Templates do
     not_found_template: [:config, :nodes_map],
     api_reference_entry_template: [:module_node],
     api_reference_template: [:config, :nodes_map],
-    extra_template: [:config, :title, :nodes_map, :content],
+    extra_template: [:config, :title, :nodes_map, :content, :refs],
     search_template: [:config, :nodes_map],
     sidebar_template: [:config, :nodes_map],
     summary_template: [:name, :nodes],
     summary_entry_template: [:node],
-    redirect_template: [:config, :redirect_to]
+    redirect_template: [:config, :redirect_to],
+    bottom_actions_template: [:refs]
   ]
 
   Enum.each(templates, fn {name, args} ->

--- a/lib/ex_doc/formatter/html/templates/bottom_actions_template.eex
+++ b/lib/ex_doc/formatter/html/templates/bottom_actions_template.eex
@@ -3,7 +3,7 @@
     <%= if refs.prev do %>
       <a href="<%= refs.prev.path %>" class="bottom-actions-button" rel="prev">
         <span class="subheader">
-          ← Go Back
+          ← Previous Page
         </span>
         <span class="title">
           <%= refs.prev.title %>
@@ -15,7 +15,7 @@
     <%= if refs.next do %>
       <a href="<%= refs.next.path %>" class="bottom-actions-button" rel="next">
         <span class="subheader">
-          Continue Reading →
+          Next Page →
         </span>
         <span class="title">
           <%= refs.next.title %>

--- a/lib/ex_doc/formatter/html/templates/bottom_actions_template.eex
+++ b/lib/ex_doc/formatter/html/templates/bottom_actions_template.eex
@@ -1,0 +1,26 @@
+<div class="bottom-actions">
+  <div class="bottom-actions-item">
+    <%= if refs.prev do %>
+      <a href="<%= refs.prev.path %>" class="bottom-actions-button" rel="prev">
+        <span class="subheader">
+          ← Go Back
+        </span>
+        <span class="title">
+          <%= refs.prev.title %>
+        </span>
+      </a>
+    <% end %>
+  </div>
+  <div class="bottom-actions-item">
+    <%= if refs.next do %>
+      <a href="<%= refs.next.path %>" class="bottom-actions-button" rel="next">
+        <span class="subheader">
+          Continue Reading →
+        </span>
+        <span class="title">
+          <%= refs.next.title %>
+        </span>
+      </a>
+    <% end %>
+  </div>
+</div>

--- a/lib/ex_doc/formatter/html/templates/extra_template.eex
+++ b/lib/ex_doc/formatter/html/templates/extra_template.eex
@@ -2,4 +2,5 @@
 <%= sidebar_template(config, nodes_map) %>
 
 <%= link_headings(content) %>
+<%= bottom_actions_template(refs) %>
 <%= footer_template(config) %>

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -463,4 +463,33 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
                ~r{<h1>\s*mix task_with_docs\s*<small class=\"app-vsn\">\(Elixir v1.0.1\)</small>}
     end
   end
+
+  describe "bottom actions" do
+    test "does not render next/prev links when the refs are nil" do
+      refs = %{
+        prev: nil,
+        next: nil
+      }
+
+      content = Templates.bottom_actions_template(refs)
+
+      refute content =~ ~r{Previous Page}
+      refute content =~ ~r{Next Page}
+    end
+  end
+
+  test "renders next/prev links when their refs are given" do
+    refs = %{
+      prev: %{path: "Prev.html", title: "Left"},
+      next: %{path: "Next.html", title: "Right"}
+    }
+
+    content = Templates.bottom_actions_template(refs)
+
+    assert content =~
+             ~r{<a href="Prev.html" class="bottom-actions-button" rel="prev">\s*<span class="subheader">\s*← Previous Page\s*</span>\s*<span class="title">\s*Left\s*</span>\s*</a>}
+
+    assert content =~
+             ~r{<a href="Next.html" class="bottom-actions-button" rel="next">\s*<span class="subheader">\s*Next Page →\s*</span>\s*<span class="title">\s*Right\s*</span>\s*</a>}
+  end
 end

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -427,6 +427,41 @@ defmodule ExDoc.Formatter.HTMLTest do
       content = read_wildcard!("#{output_dir()}/dist/sidebar_items-*.js")
       refute content =~ ~r{"id":"api-reference","title":"API Reference"}
     end
+
+    test "pages include links to the previous/next page if applicable" do
+      generate_docs(
+        doc_config(
+          extras: [
+            "test/fixtures/LICENSE",
+            "test/fixtures/README.md"
+          ]
+        )
+      )
+
+      # We have three extras: API Reference, LICENSE and README
+
+      content_first = File.read!("#{output_dir()}/api-reference.html")
+
+      refute content_first =~ ~r{Previous Page}
+
+      assert content_first =~
+               ~r{<a href="license.html" class="bottom-actions-button" rel="next">\s*<span class="subheader">\s*Next Page →\s*</span>\s*<span class="title">\s*LICENSE\s*</span>\s*</a>}
+
+      content_middle = File.read!("#{output_dir()}/license.html")
+
+      assert content_middle =~
+               ~r{<a href="api-reference.html" class="bottom-actions-button" rel="prev">\s*<span class="subheader">\s*← Previous Page\s*</span>\s*<span class="title">\s*API Reference\s*</span>\s*</a>}
+
+      assert content_middle =~
+               ~r{<a href="readme.html" class="bottom-actions-button" rel="next">\s*<span class="subheader">\s*Next Page →\s*</span>\s*<span class="title">\s*README\s*</span>\s*</a>}
+
+      content_last = File.read!("#{output_dir()}/readme.html")
+
+      assert content_last =~
+               ~r{<a href="license.html" class="bottom-actions-button" rel="prev">\s*<span class="subheader">\s*← Previous Page\s*</span>\s*<span class="title">\s*LICENSE\s*</span>\s*</a>}
+
+      refute content_last =~ ~r{Next Page}
+    end
   end
 
   describe ".build" do


### PR DESCRIPTION
An initial idea for #1295.

Currently this adds next/previous links at the end of every page from *extras*. I'm not sure if this makes much sense for modules/tasks, as those are rather not read linearly.

You can see the build preview [here](https://static.jonatanklosko.com/ex-doc/issue1295/initial/readme.html). Screenshots for the reference:

**Desktop**

![image](https://user-images.githubusercontent.com/17034772/101418064-491d6580-38ed-11eb-81f3-2508b8f7b2c2.png)

**Mobile**

![image](https://user-images.githubusercontent.com/17034772/101418081-55092780-38ed-11eb-8fc6-212bf6adb051.png)
