### PR TITLE
Fix makeup_erlang dependency

### DIFF
--- a/bin/ex_doc
+++ b/bin/ex_doc
@@ -3,6 +3,7 @@ mix_env = System.get_env()["MIX_ENV"] || "dev"
 Code.prepend_path Path.expand("../_build/#{mix_env}/lib/nimble_parsec/ebin", __DIR__)
 Code.prepend_path Path.expand("../_build/#{mix_env}/lib/makeup/ebin", __DIR__)
 Code.prepend_path Path.expand("../_build/#{mix_env}/lib/makeup_elixir/ebin", __DIR__)
+Code.prepend_path Path.expand("../_build/#{mix_env}/lib/makeup_erlang/ebin", __DIR__)
 Code.prepend_path Path.expand("../_build/#{mix_env}/lib/earmark_parser/ebin", __DIR__)
 Code.prepend_path Path.expand("../_build/#{mix_env}/lib/ex_doc/ebin", __DIR__)
 


### PR DESCRIPTION
Following issue #1303: proposed changes to fix the `makeup_erlang` dependency in `bin/ex_doc` 