### PR TITLE
Use OTP builds matching the OS on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,10 @@ jobs:
             elixir: 1.10.3
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.3
-      - uses: actions/setup-elixir@v1.4.2
+      - uses: actions/checkout@v2
+      - uses: actions/setup-elixir@v1
         with:
+          experimental-otp: true
           otp-version: '${{matrix.otp}}'
           elixir-version: '${{matrix.elixir}}'
       - name: Install Dependencies


### PR DESCRIPTION
actions/setup-elixir by default uses OTP that was built for ubuntu
14.04. By specifying the `experimental-otp: true` flag, we'll force it
to use the builds that match the runner. Nowadays, the default runner is
20-04.

The experimental-otp: true will likely be the default option on
setup-actions so it's safe to use it.

This also happens to fix the recent test failures on OTP 23. Turns out,
ubuntu-14.04 builds have doc chunks like this:

    $ curl -LO https://repo.hex.pm/builds/otp/ubuntu-14.04/OTP-23.0.2.tar.gz && tar xzf OTP-*.tar.gz
    $ elixir -e '"OTP-23.0.2/lib/stdlib-3.13/doc/chunks/array.chunk" |> File.read!() |> :erlang.binary_to_term() |> IO.inspect()'
    {:docs_v1, [file: 'array.erl', location: 0], :erlang, "application/erlang+html",
     :hidden, %{otp_doc_vsn: {1, 0, 0}}, []}

ubuntu-20.04 has the proper ones:

    $ curl -LO https://repo.hex.pm/builds/otp/ubuntu-20.04/OTP-23.0.2.tar.gz && tar xzf OTP-*.tar.gz
    $ elixir -e '"OTP-23.0.2/lib/stdlib-3.13/doc/chunks/array.chunk" |> File.read!() |> :erlang.binary_to_term() |> IO.inspect()' | head
    {:docs_v1, [file: 'array.erl', location: 0], :erlang, "application/erlang+html",
     %{
       "en" => [
         {:p, [],
          ["Functional, extendible arrays. Arrays can have fixed size, or can grow automatically as needed. A default value is used for entries that have not been explicitly set."]},
         {:p, [],
          [
            "Arrays uses ",
            {:em, [], ["zero"]},
            "-based indexing. This is a deliberate design choice and differs from other Erlang data structures, for example, tuples."