### PR TITLE
Fix search click behavior when a suggestion refers the current page

### DIFF
--- a/assets/js/autocomplete/autocomplete-list.js
+++ b/assets/js/autocomplete/autocomplete-list.js
@@ -2,8 +2,8 @@ import autocompleteSuggestionsTemplate from '../handlebars/templates/autocomplet
 import { getSuggestions } from './suggestions'
 import { isBlank, qs } from '../helpers'
 
-const AUTOCOMPLETE_CONTAINER_SELECTOR = '.autocomplete'
-const AUTOCOMPLETE_SUGGESTION_SELECTOR = '.autocomplete-suggestion'
+export const AUTOCOMPLETE_CONTAINER_SELECTOR = '.autocomplete'
+export const AUTOCOMPLETE_SUGGESTION_SELECTOR = '.autocomplete-suggestion'
 
 const state = {
   autocompleteSuggestions: [],


### PR DESCRIPTION
Fixes #1310.

I made it so that opening a suggestion in a new tab/window (using `Shift` or `Ctrl`) would keep the autocomplete list open, but otherwise it always gets closed. I also changed the `Enter` behavior to mimic clicking a link rather than submitting a form, because otherwise we always navigate to a new page, even if the URL leads to the same page.

So this should unify clicking on a suggestion and pressing `Enter` to work the same way.

You can see a preview [here](https://static.jonatanklosko.com/ex-doc/issue1310/initial/ExDoc.Markdown.html).