### PR TITLE
Improve search input blur handling

### DIFF
--- a/assets/js/autocomplete/autocomplete-list.js
+++ b/assets/js/autocomplete/autocomplete-list.js
@@ -25,6 +25,13 @@ export function hideAutocompleteList () {
 }
 
 /**
+ * Checks if the search autocomplete list is open.
+ */
+export function isAutocompleteListOpen () {
+  return qs(AUTOCOMPLETE_CONTAINER_SELECTOR).classList.contains('shown')
+}
+
+/**
  * Shows autocomplete suggestions for the given term.
  *
  * For blank terms the list is not shown.

--- a/assets/js/sidebar/sidebar-search.js
+++ b/assets/js/sidebar/sidebar-search.js
@@ -1,5 +1,6 @@
 import {
   hideAutocompleteList,
+  isAutocompleteListOpen,
   moveAutocompleteSelection,
   selectedAutocompleteSuggestion,
   updateAutocompleteList,
@@ -9,7 +10,7 @@ import {
 import { qs } from '../helpers'
 
 const SEARCH_INPUT_SELECTOR = 'form.sidebar-search input'
-const SEARCH_CLOSE_BUTTON_SELECTOR = 'form.search-close-button'
+const SEARCH_CLOSE_BUTTON_SELECTOR = 'form.sidebar-search .search-close-button'
 
 /**
  * Initializes the sidebar search box.
@@ -70,6 +71,13 @@ function addEventListeners () {
       // If blur is triggered caused by clicking on an autocomplete result,
       // then ignore it, because it's handled in the click handler below.
       if (relatedTarget.matches(AUTOCOMPLETE_SUGGESTION_SELECTOR)) {
+        // Focus the input after a while, so that it's easier to close
+        // or get back to after an accidental blur
+        setTimeout(() => {
+          if (isAutocompleteListOpen()) {
+            searchInput.focus()
+          }
+        }, 1000)
         return null
       }
 


### PR DESCRIPTION
Follow up for #1311, see [this comment](https://github.com/elixir-lang/ex_doc/issues/1310#issuecomment-751409542).

We rely on the blur event for closing the autocomplete box, but sometimes we have to ignore this event in which case we may end up in a not-easily-closable state. I added a `setTimeout` ensuring that the search gets re-focused when the autocomplete box is still open. While this doesn't seem extremely elegant, I tried several other approaches and none was perfect.

@eksperimental please have a look [here](https://static.jonatanklosko.com/ex-doc/issue1310/followup/ExDoc.Markdown.html) and let me know if it works as expected.