### PR TITLE
Reimplement ExDoc.Refs.visibility helper

### DIFF
--- a/lib/ex_doc/refs.ex
+++ b/lib/ex_doc/refs.ex
@@ -100,11 +100,11 @@ defmodule ExDoc.Refs do
   defp fetch_entries(module, result) do
     case result do
       {:docs_v1, _, _, _, module_doc, _, docs} ->
-        module_visibility = visibility({module, module_doc})
+        module_visibility = visibility(module_doc)
 
         for {{kind, name, arity}, _, _, doc, metadata} <- docs do
           ref_kind = to_ref_kind(kind)
-          visibility = visibility({module, module_doc}, {ref_kind, name, doc})
+          visibility = visibility(module_doc, {ref_kind, name, doc})
 
           for arity <- (arity - (metadata[:defaults] || 0))..arity do
             {{ref_kind, module, name, arity}, visibility}
@@ -133,23 +133,24 @@ defmodule ExDoc.Refs do
 
   defp starts_with_underscore?(name), do: hd(Atom.to_charlist(name)) == ?_
 
-  defp visibility({_module, :hidden}),
+  defp visibility(:hidden),
     do: :hidden
 
-  defp visibility({_module, _module_doc}),
+  defp visibility(_module_doc),
     do: :public
 
-  defp visibility({_module, _module_doc}, {kind, _name, _doc})
+  defp visibility(_module_doc, {kind, _name, _doc})
        when kind not in [:callback, :function, :type],
        do: raise(ArgumentError, "Unknown kind #{inspect(kind)}")
 
-  defp visibility({_module, :hidden}, {_kind, _name, _doc}),
+  defp visibility(:hidden, {_kind, _name, _doc}),
     do: :hidden
 
-  defp visibility({_, _}, {_kind, _name, :hidden}),
-    do: :hidden
+  defp visibility(_, {_kind, _name, :hidden}) do
+    :hidden
+  end
 
-  defp visibility({_, _}, {kind, name, doc}) when has_no_docs(doc) do
+  defp visibility(_, {kind, name, doc}) when has_no_docs(doc) do
     cond do
       kind in [:callback, :type] ->
         :public
@@ -162,7 +163,7 @@ defmodule ExDoc.Refs do
     end
   end
 
-  defp visibility({_, _}, {_, _, _}) do
+  defp visibility(_, {_, _, _}) do
     :public
   end
 

--- a/lib/ex_doc/refs.ex
+++ b/lib/ex_doc/refs.ex
@@ -146,9 +146,8 @@ defmodule ExDoc.Refs do
   defp visibility(:hidden, {_kind, _name, _doc}),
     do: :hidden
 
-  defp visibility(_, {_kind, _name, :hidden}) do
-    :hidden
-  end
+  defp visibility(_, {_kind, _name, :hidden}),
+    do: :hidden
 
   defp visibility(_, {kind, name, doc}) when has_no_docs(doc) do
     cond do

--- a/test/ex_doc/autolink_test.exs
+++ b/test/ex_doc/autolink_test.exs
@@ -452,6 +452,20 @@ defmodule ExDoc.AutolinkTest do
     assert_unchanged(~m"`Unknown`")
 
     assert_unchanged(~m"[Blank](about:blank)")
+
+    # warnings with functions starting with an underscore
+    # TODO in a following commit: Split this test into tests inside a describe block
+    assert warn("WithModuleDoc._no_doc/0") =~
+             "documentation references \"WithModuleDoc._no_doc/0\" but it is hidden\n"
+
+    assert warn("WithoutModuleDoc._no_doc/0") =~
+             "documentation references \"WithoutModuleDoc._no_doc/0\" but it is hidden\n"
+
+    assert warn("WithModuleDoc._doc_false/0") =~
+             "documentation references \"WithModuleDoc._doc_false/0\" but it is hidden\n"
+
+    assert warn("WithoutModuleDoc._doc_false/0") =~
+             "documentation references \"WithoutModuleDoc._doc_false/0\" but it is hidden\n"
   end
 
   ## Helpers

--- a/test/ex_doc/autolink_test.exs
+++ b/test/ex_doc/autolink_test.exs
@@ -452,20 +452,6 @@ defmodule ExDoc.AutolinkTest do
     assert_unchanged(~m"`Unknown`")
 
     assert_unchanged(~m"[Blank](about:blank)")
-
-    # warnings with functions starting with an underscore
-    # TODO in a following commit: Split this test into tests inside a describe block
-    assert warn("WithModuleDoc._no_doc/0") =~
-             "documentation references \"WithModuleDoc._no_doc/0\" but it is hidden\n"
-
-    assert warn("WithoutModuleDoc._no_doc/0") =~
-             "documentation references \"WithoutModuleDoc._no_doc/0\" but it is hidden\n"
-
-    assert warn("WithModuleDoc._doc_false/0") =~
-             "documentation references \"WithModuleDoc._doc_false/0\" but it is hidden\n"
-
-    assert warn("WithoutModuleDoc._doc_false/0") =~
-             "documentation references \"WithoutModuleDoc._doc_false/0\" but it is hidden\n"
   end
 
   ## Helpers

--- a/test/ex_doc/refs_test.exs
+++ b/test/ex_doc/refs_test.exs
@@ -3,11 +3,25 @@ defmodule ExDoc.RefsTest do
   alias ExDoc.Refs
 
   defmodule InMemory do
-    @type t() :: :ok
+    @type a_type() :: any
 
-    @callback handle_foo() :: :ok
+    @callback a_callback() :: :ok
+    @macrocallback a_macrocallback() :: :ok
 
-    def foo(), do: :ok
+    def no_doc(), do: :no_doc
+    def _no_doc(), do: :no_doc
+
+    @doc false
+    def doc_false(), do: :doc_false
+
+    @doc false
+    def _doc_false(), do: :doc_false
+
+    @doc "doc..."
+    def with_doc(), do: :with_doc
+
+    @doc "doc..."
+    def _with_doc(), do: :with_doc
   end
 
   test "get_visibility/1" do
@@ -23,8 +37,38 @@ defmodule ExDoc.RefsTest do
     assert Refs.get_visibility({:function, Enum, :join, 9}) == :undefined
     assert Refs.get_visibility({:function, :lists, :all, 2}) == :public
     assert Refs.get_visibility({:function, :lists, :all, 9}) == :undefined
-    assert Refs.get_visibility({:function, InMemory, :foo, 0}) == :public
-    assert Refs.get_visibility({:function, InMemory, :foo, 9}) == :undefined
+    assert Refs.get_visibility({:function, InMemory, :with_doc, 0}) == :public
+    assert Refs.get_visibility({:function, InMemory, :non_existant, 0}) == :undefined
+
+    assert Refs.get_visibility({:function, WithModuleDoc, :no_doc, 0}) == :public
+    assert Refs.get_visibility({:function, WithModuleDoc, :_no_doc, 0}) == :hidden
+    assert Refs.get_visibility({:function, WithModuleDoc, :doc_false, 0}) == :hidden
+    assert Refs.get_visibility({:function, WithModuleDoc, :_doc_false, 0}) == :hidden
+    assert Refs.get_visibility({:function, WithModuleDoc, :with_doc, 0}) == :public
+    assert Refs.get_visibility({:function, WithModuleDoc, :_with_doc, 0}) == :public
+    assert Refs.get_visibility({:function, WithModuleDoc, :non_existant, 0}) == :undefined
+    assert Refs.get_visibility({:function, WithModuleDoc, :_non_existant, 0}) == :undefined
+
+    assert Refs.get_visibility({:function, WithoutModuleDoc, :no_doc, 0}) == :public
+    assert Refs.get_visibility({:function, WithoutModuleDoc, :_no_doc, 0}) == :hidden
+    assert Refs.get_visibility({:function, WithoutModuleDoc, :doc_false, 0}) == :hidden
+    assert Refs.get_visibility({:function, WithoutModuleDoc, :_doc_false, 0}) == :hidden
+    assert Refs.get_visibility({:function, WithoutModuleDoc, :with_doc, 0}) == :public
+    assert Refs.get_visibility({:function, WithoutModuleDoc, :_with_doc, 0}) == :public
+    assert Refs.get_visibility({:function, WithoutModuleDoc, :non_existant, 0}) == :undefined
+    assert Refs.get_visibility({:function, WithoutModuleDoc, :_non_existant, 0}) == :undefined
+
+    assert Refs.get_visibility({:function, InMemory, :no_doc, 0}) == :public
+    # unable to read documentation, visibility is set to :public
+    assert Refs.get_visibility({:function, InMemory, :_no_doc, 0}) == :public
+    # unable to read documentation, visibility is set to :public
+    assert Refs.get_visibility({:function, InMemory, :doc_false, 0}) == :public
+    # unable to read documentation, visibility is set to :public
+    assert Refs.get_visibility({:function, InMemory, :_doc_false, 0}) == :public
+    assert Refs.get_visibility({:function, InMemory, :with_doc, 0}) == :public
+    assert Refs.get_visibility({:function, InMemory, :_with_doc, 0}) == :public
+    assert Refs.get_visibility({:function, InMemory, :non_existant, 0}) == :undefined
+    assert Refs.get_visibility({:function, InMemory, :_non_existant, 0}) == :undefined
 
     # macros are classified as functions
     assert Refs.get_visibility({:function, Kernel, :def, 2}) == :public
@@ -36,8 +80,10 @@ defmodule ExDoc.RefsTest do
     assert Refs.get_visibility({:type, :sets, :set, 0}) == :public
     assert Refs.get_visibility({:type, :sets, :set, 9}) == :undefined
 
+    assert Refs.get_visibility({:type, WithModuleDoc, :a_type, 0}) == :public
+    assert Refs.get_visibility({:type, WithoutModuleDoc, :a_type, 0}) == :public
     # types are in abstract_code chunk so not available for in-memory modules
-    assert Refs.get_visibility({:type, InMemory, :t, 0}) == :undefined
+    assert Refs.get_visibility({:type, InMemory, :a_type, 0}) == :undefined
 
     # @typep
     assert Refs.get_visibility({:type, :sets, :seg, 0}) == :hidden
@@ -46,8 +92,12 @@ defmodule ExDoc.RefsTest do
     assert Refs.get_visibility({:callback, GenServer, :handle_call, 9}) == :undefined
     assert Refs.get_visibility({:callback, :gen_server, :handle_call, 3}) == :public
     assert Refs.get_visibility({:callback, :gen_server, :handle_call, 9}) == :undefined
-    assert Refs.get_visibility({:callback, InMemory, :handle_foo, 0}) == :public
-    assert Refs.get_visibility({:callback, InMemory, :handle_foo, 9}) == :undefined
+    assert Refs.get_visibility({:callback, InMemory, :a_callback, 0}) == :public
+    assert Refs.get_visibility({:callback, WithModuleDoc, :a_callback, 0}) == :public
+    assert Refs.get_visibility({:callback, WithModuleDoc, :a_macrocallback, 0}) == :public
+    assert Refs.get_visibility({:callback, WithoutModuleDoc, :a_callback, 0}) == :public
+    assert Refs.get_visibility({:callback, WithoutModuleDoc, :a_macrocallback, 0}) == :public
+    assert Refs.get_visibility({:callback, InMemory, :a_callback, 9}) == :undefined
   end
 
   test "public?/1" do

--- a/test/ex_doc/refs_test.exs
+++ b/test/ex_doc/refs_test.exs
@@ -9,19 +9,12 @@ defmodule ExDoc.RefsTest do
     @macrocallback a_macrocallback() :: :ok
 
     def no_doc(), do: :no_doc
-    def _no_doc(), do: :no_doc
 
     @doc false
     def doc_false(), do: :doc_false
 
-    @doc false
-    def _doc_false(), do: :doc_false
-
     @doc "doc..."
     def with_doc(), do: :with_doc
-
-    @doc "doc..."
-    def _with_doc(), do: :with_doc
   end
 
   test "get_visibility/1" do
@@ -35,56 +28,33 @@ defmodule ExDoc.RefsTest do
     assert Refs.get_visibility({:function, Code.Typespec, :spec_to_quoted, 2}) == :hidden
     assert Refs.get_visibility({:function, Code.Typespec, :spec_to_quoted, 9}) == :undefined
     assert Refs.get_visibility({:function, Enum, :join, 9}) == :undefined
+    assert Refs.get_visibility({:function, Enum, :_join, 9}) == :undefined
     assert Refs.get_visibility({:function, :lists, :all, 2}) == :public
     assert Refs.get_visibility({:function, :lists, :all, 9}) == :undefined
+    assert Refs.get_visibility({:function, :lists, :_all, 9}) == :undefined
     assert Refs.get_visibility({:function, InMemory, :with_doc, 0}) == :public
     assert Refs.get_visibility({:function, InMemory, :non_existant, 0}) == :undefined
-
     assert Refs.get_visibility({:function, WithModuleDoc, :no_doc, 0}) == :public
     assert Refs.get_visibility({:function, WithModuleDoc, :_no_doc, 0}) == :hidden
-    assert Refs.get_visibility({:function, WithModuleDoc, :doc_false, 0}) == :hidden
     assert Refs.get_visibility({:function, WithModuleDoc, :_doc_false, 0}) == :hidden
-    assert Refs.get_visibility({:function, WithModuleDoc, :with_doc, 0}) == :public
-    assert Refs.get_visibility({:function, WithModuleDoc, :_with_doc, 0}) == :public
-    assert Refs.get_visibility({:function, WithModuleDoc, :non_existant, 0}) == :undefined
-    assert Refs.get_visibility({:function, WithModuleDoc, :_non_existant, 0}) == :undefined
-
-    assert Refs.get_visibility({:function, WithoutModuleDoc, :no_doc, 0}) == :public
-    assert Refs.get_visibility({:function, WithoutModuleDoc, :_no_doc, 0}) == :hidden
-    assert Refs.get_visibility({:function, WithoutModuleDoc, :doc_false, 0}) == :hidden
-    assert Refs.get_visibility({:function, WithoutModuleDoc, :_doc_false, 0}) == :hidden
-    assert Refs.get_visibility({:function, WithoutModuleDoc, :with_doc, 0}) == :public
-    assert Refs.get_visibility({:function, WithoutModuleDoc, :_with_doc, 0}) == :public
-    assert Refs.get_visibility({:function, WithoutModuleDoc, :non_existant, 0}) == :undefined
-    assert Refs.get_visibility({:function, WithoutModuleDoc, :_non_existant, 0}) == :undefined
 
     assert Refs.get_visibility({:function, InMemory, :no_doc, 0}) == :public
     # unable to read documentation, visibility is set to :public
-    assert Refs.get_visibility({:function, InMemory, :_no_doc, 0}) == :public
-    # unable to read documentation, visibility is set to :public
     assert Refs.get_visibility({:function, InMemory, :doc_false, 0}) == :public
-    # unable to read documentation, visibility is set to :public
-    assert Refs.get_visibility({:function, InMemory, :_doc_false, 0}) == :public
     assert Refs.get_visibility({:function, InMemory, :with_doc, 0}) == :public
-    assert Refs.get_visibility({:function, InMemory, :_with_doc, 0}) == :public
     assert Refs.get_visibility({:function, InMemory, :non_existant, 0}) == :undefined
-    assert Refs.get_visibility({:function, InMemory, :_non_existant, 0}) == :undefined
 
     # macros are classified as functions
     assert Refs.get_visibility({:function, Kernel, :def, 2}) == :public
-
     assert Refs.get_visibility({:function, Unknown, :unknown, 0}) == :undefined
 
     assert Refs.get_visibility({:type, String, :t, 0}) == :public
     assert Refs.get_visibility({:type, String, :t, 1}) == :undefined
     assert Refs.get_visibility({:type, :sets, :set, 0}) == :public
     assert Refs.get_visibility({:type, :sets, :set, 9}) == :undefined
-
-    assert Refs.get_visibility({:type, WithModuleDoc, :a_type, 0}) == :public
     assert Refs.get_visibility({:type, WithoutModuleDoc, :a_type, 0}) == :public
     # types are in abstract_code chunk so not available for in-memory modules
     assert Refs.get_visibility({:type, InMemory, :a_type, 0}) == :undefined
-
     # @typep
     assert Refs.get_visibility({:type, :sets, :seg, 0}) == :hidden
 
@@ -93,7 +63,6 @@ defmodule ExDoc.RefsTest do
     assert Refs.get_visibility({:callback, :gen_server, :handle_call, 3}) == :public
     assert Refs.get_visibility({:callback, :gen_server, :handle_call, 9}) == :undefined
     assert Refs.get_visibility({:callback, InMemory, :a_callback, 0}) == :public
-    assert Refs.get_visibility({:callback, WithModuleDoc, :a_callback, 0}) == :public
     assert Refs.get_visibility({:callback, WithModuleDoc, :a_macrocallback, 0}) == :public
     assert Refs.get_visibility({:callback, WithoutModuleDoc, :a_callback, 0}) == :public
     assert Refs.get_visibility({:callback, WithoutModuleDoc, :a_macrocallback, 0}) == :public

--- a/test/support/with_without_module_doc.ex
+++ b/test/support/with_without_module_doc.ex
@@ -1,26 +1,5 @@
 defmodule WithModuleDoc do
-  @moduledoc """
-  - `t:t/0`, `t:WithModuleDoc.t/0`
-  - `c:handle_foo/0`, `c:WithModuleDoc.handle_foo/0`
-  - `c:handle_macro_foo/0`, `c:WithModuleDoc.handle_macro_foo/0`
-  - `foo/1`, `WithModuleDoc.foo/1`
-  - `_foo/1`, `WithModuleDoc._foo/1`
-  - `_foo/2`, `WithModuleDoc._foo/2`
-  - `foo/2`, `WithModuleDoc.foo/2`
-  - `foo/3`, `WithModuleDoc.foo/3`
-  - `_foo/3`, `WithModuleDoc._foo/3`
-
-  - `t:t/0`, `t:WithoutModuleDoc.t/0`
-  - `c:handle_foo/0`, `c:WithoutModuleDoc.handle_foo/0`
-  - `c:handle_macro_foo/0`, `c:WithoutModuleDoc.handle_macro_foo/0`
-  - `foo/1`, `WithoutModuleDoc.foo/1`
-  - `_foo/1`, `WithoutModuleDoc._foo/1`
-  - `_foo/2`, `WithoutModuleDoc._foo/2`
-  - `foo/2`, `WithoutModuleDoc.foo/2`
-  - `foo/3`, `WithoutModuleDoc.foo/3`
-  - `_foo/3`, `WithoutModuleDoc._foo/3`
-
-  """
+  @moduledoc "Documentation for `WithModuleDoc`"
 
   @type a_type() :: any
 

--- a/test/support/with_without_module_doc.ex
+++ b/test/support/with_without_module_doc.ex
@@ -1,0 +1,66 @@
+defmodule WithModuleDoc do
+  @moduledoc """
+  - `t:t/0`, `t:WithModuleDoc.t/0`
+  - `c:handle_foo/0`, `c:WithModuleDoc.handle_foo/0`
+  - `c:handle_macro_foo/0`, `c:WithModuleDoc.handle_macro_foo/0`
+  - `foo/1`, `WithModuleDoc.foo/1`
+  - `_foo/1`, `WithModuleDoc._foo/1`
+  - `_foo/2`, `WithModuleDoc._foo/2`
+  - `foo/2`, `WithModuleDoc.foo/2`
+  - `foo/3`, `WithModuleDoc.foo/3`
+  - `_foo/3`, `WithModuleDoc._foo/3`
+
+  - `t:t/0`, `t:WithoutModuleDoc.t/0`
+  - `c:handle_foo/0`, `c:WithoutModuleDoc.handle_foo/0`
+  - `c:handle_macro_foo/0`, `c:WithoutModuleDoc.handle_macro_foo/0`
+  - `foo/1`, `WithoutModuleDoc.foo/1`
+  - `_foo/1`, `WithoutModuleDoc._foo/1`
+  - `_foo/2`, `WithoutModuleDoc._foo/2`
+  - `foo/2`, `WithoutModuleDoc.foo/2`
+  - `foo/3`, `WithoutModuleDoc.foo/3`
+  - `_foo/3`, `WithoutModuleDoc._foo/3`
+
+  """
+
+  @type a_type() :: any
+
+  @callback a_callback() :: :ok
+  @macrocallback a_macrocallback() :: :ok
+
+  def no_doc(), do: :no_doc
+  def _no_doc(), do: :no_doc
+
+  @doc false
+  def doc_false(), do: :doc_false
+
+  @doc false
+  def _doc_false(), do: :doc_false
+
+  @doc "doc..."
+  def with_doc(), do: :with_doc
+
+  @doc "doc..."
+  def _with_doc(), do: :with_doc
+end
+
+defmodule WithoutModuleDoc do
+  @type a_type() :: any
+
+  @callback a_callback() :: :ok
+  @macrocallback a_macrocallback() :: :ok
+
+  def no_doc(), do: :no_doc
+  def _no_doc(), do: :no_doc
+
+  @doc false
+  def doc_false(), do: :doc_false
+
+  @doc false
+  def _doc_false(), do: :doc_false
+
+  @doc "doc..."
+  def with_doc(), do: :with_doc
+
+  @doc "doc..."
+  def _with_doc(), do: :with_doc
+end


### PR DESCRIPTION
It corrects the visibility of functions that start with an underscore and that no docs have been defined.

Closes https://github.com/elixir-lang/ex_doc/issues/1308

/cc @jonatanklosko 