### PR TITLE
fix ast_to_html with empty elements

### DIFF
--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -128,8 +128,7 @@ defmodule ExDoc.Formatter.HTML do
   def ast_to_html(binary) when is_binary(binary), do: Templates.h(binary)
 
   def ast_to_html({tag, attrs, ast, %{verbatim: true}}) do
-    text = (ast != [] && Enum.join(ast, "")) || ""
-    ["<#{tag}", ast_attributes_to_html(attrs), ">", text, "</#{tag}>"]
+    ["<#{tag}", ast_attributes_to_html(attrs), ">", ast, "</#{tag}>"]
   end
 
   def ast_to_html({tag, attrs, ast, %{}}) do

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -128,7 +128,7 @@ defmodule ExDoc.Formatter.HTML do
   def ast_to_html(binary) when is_binary(binary), do: Templates.h(binary)
 
   def ast_to_html({tag, attrs, ast, %{verbatim: true}}) do
-    [text] = ast
+    text = (ast != [] && Enum.join(ast, "")) || ""
     ["<#{tag}", ast_attributes_to_html(attrs), ">", text, "</#{tag}>"]
   end
 

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -528,16 +528,17 @@ defmodule ExDoc.Formatter.HTMLTest do
              |> IO.iodata_to_binary() == "<strong><em>bar</em></strong>"
     end
 
-    test "handles empty elements" do
+    test "handles multiple empty elements" do
       assert """
              <span>
+             <i></i>
              <i></i>
              </span>
              """
              |> ExDoc.Markdown.Earmark.to_ast([])
              |> HTML.ast_to_html()
              |> IO.iodata_to_binary() ==
-               "<span><i></i></span>"
+               "<span><i></i><i></i></span>"
     end
   end
 end

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -527,5 +527,17 @@ defmodule ExDoc.Formatter.HTMLTest do
              |> HTML.ast_to_html()
              |> IO.iodata_to_binary() == "<strong><em>bar</em></strong>"
     end
+
+    test "handles empty elements" do
+      assert """
+             <span>
+             <i></i>
+             </span>
+             """
+             |> ExDoc.Markdown.Earmark.to_ast([])
+             |> HTML.ast_to_html()
+             |> IO.iodata_to_binary() ==
+               "<span><i></i></span>"
+    end
   end
 end


### PR DESCRIPTION
While creating documentation that contained `<i></i>` inside a `<span>` element, the formatter was not able to cope with this html. See the included test.