### PR TITLE
Don't raise when module has no docs chunks

### DIFF
--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -91,7 +91,7 @@ defmodule ExDoc.Retriever do
         docs
 
       {:error, :chunk_not_found} ->
-        raise Error, "module #{inspect(module)} was not compiled with docs"
+        false
 
       {:error, :module_not_found} ->
         unless Code.ensure_loaded?(module) do

--- a/test/ex_doc/retriever_test.exs
+++ b/test/ex_doc/retriever_test.exs
@@ -384,9 +384,7 @@ defmodule ExDoc.RetrieverTest do
       -module(no_chunk).
       """)
 
-      assert_raise Retriever.Error, "module :no_chunk was not compiled with docs", fn ->
-        Retriever.docs_from_modules([:no_chunk], %ExDoc.Config{})
-      end
+      assert Retriever.docs_from_modules([:no_chunk], %ExDoc.Config{}) == []
     end
   end
 


### PR DESCRIPTION
Previously, we were simply ignoring non-Elixir modules. Now, that we
started hanlding Erlang modules, we should simply ignore modules that
don't happen to have chunks. Some examples:

    iex> Code.fetch_docs :elixir
    {:error, :chunk_not_found}

    iex> Code.fetch_docs :dets_server
    {:error, :chunk_not_found}