### PR TITLE
Generating void elements correctly on `DocAST.to_string`

### DIFF
--- a/lib/ex_doc/doc_ast.ex
+++ b/lib/ex_doc/doc_ast.ex
@@ -21,6 +21,10 @@ defmodule ExDoc.DocAST do
     raise "content type #{inspect(other)} is not supported"
   end
 
+  # https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#void-element
+  @void_elements ~W(area base br col command embed hr img input keygen link 
+    meta param source track wbr)a
+
   @doc """
   Transform AST into string.
   """
@@ -33,6 +37,11 @@ defmodule ExDoc.DocAST do
   def to_string(list, fun) when is_list(list) do
     result = Enum.map_join(list, "", &to_string(&1, fun))
     fun.(list, result)
+  end
+
+  def to_string({tag, attrs, _inner, _meta} = ast, fun) when tag in @void_elements do
+    result = "<#{tag}#{ast_attributes_to_string(attrs)}/>"
+    fun.(ast, result)
   end
 
   def to_string({tag, attrs, inner, %{verbatim: true}} = ast, fun) do

--- a/test/ex_doc/doc_ast_test.exs
+++ b/test/ex_doc/doc_ast_test.exs
@@ -81,5 +81,16 @@ defmodule ExDoc.DocASTTest do
       assert DocAST.to_string(ast, f) ==
                "<p>foo <STRONG>BAR</STRONG> baz</p>"
     end
+
+    test "void elements" do
+      markdown = """
+      foo  
+      bar
+      """
+
+      ast = DocAST.parse!(markdown, "text/markdown")
+
+      assert DocAST.to_string(ast) == ~s{<p>foo<br/>bar</p>}
+    end
   end
 end


### PR DESCRIPTION
Fixes #1350