### PR TITLE
Add ellipsis to more sections

### DIFF
--- a/assets/less/sidebar.less
+++ b/assets/less/sidebar.less
@@ -253,7 +253,7 @@
       }
 
       a.expand,
-      .sections-list a {
+      .sections-list > li {
         text-overflow: ellipsis;
       }
 

--- a/assets/less/sidebar.less
+++ b/assets/less/sidebar.less
@@ -252,7 +252,8 @@
         color: @groupGray;
       }
 
-      a.expand {
+      a.expand,
+      .sections-list a {
         text-overflow: ellipsis;
       }
 


### PR DESCRIPTION
It looks like we moved the ellipsis usage to be more specific in 6650cf1176330af380855a896769bfbb4adaa2a2 and I think we need to expand the places where ellipsis are used. For example, the docs for ExUnit currently look like this:

![image](https://user-images.githubusercontent.com/3421625/117332886-99c1cc00-ae55-11eb-9705-1e2a48cefaf5.png)

So this change makes it look like this:

![image](https://user-images.githubusercontent.com/3421625/117333304-0937bb80-ae56-11eb-9e13-fb60d652064d.png)

I think this provides better affordance to let users know that there is more to the title than just what they can see. It also may be worth considering removing the `overflow: hidden` to let the lines spill over and have the whole thing be visible, but this change works within the parameters of the current design.