### PR TITLE
Deal with remote types in signatures

### DIFF
--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -528,6 +528,10 @@ defmodule ExDoc.Retriever do
 
   defp to_var({:%, meta, [name, _]}, _), do: {:%, meta, [name, {:%{}, meta, []}]}
   defp to_var({name, meta, _}, _) when is_atom(name), do: {name, meta, nil}
+
+  defp to_var({{:., meta, [_module, name]}, _, _args}, _) when is_atom(name),
+    do: {name, meta, nil}
+
   defp to_var([{:->, _, _} | _], _), do: {:function, [], nil}
   defp to_var({:<<>>, _, _}, _), do: {:binary, [], nil}
   defp to_var({:%{}, _, _}, _), do: {:map, [], nil}

--- a/test/ex_doc/retriever_test.exs
+++ b/test/ex_doc/retriever_test.exs
@@ -250,6 +250,19 @@ defmodule ExDoc.RetrieverTest do
       assert upcase.doc == ExDoc.Markdown.to_ast("See `String.upcase/1`.")
     end
 
+    test "signatures", c do
+      elixirc(c, ~S"""
+      defmodule Signatures do
+        @callback remote(GenServer.options()) :: :ok
+      end
+      """)
+
+      [mod] = Retriever.docs_from_modules([Signatures], %ExDoc.Config{})
+      [remote] = mod.docs
+
+      assert remote.signature == "remote(options)"
+    end
+
     test "Mix tasks", c do
       elixirc(c, ~S"""
       defmodule Mix.Tasks.MyTask do


### PR DESCRIPTION
It deals with signature for remote types, such as in:
`@callback callback1(GenServer.options()) :: :ok
`
it generates the function signature
`callback1(options)`

while previously it would generate
`callback1(arg1)`