### PR TITLE
Do not filter out EarmarkParser options

### DIFF
--- a/lib/ex_doc/markdown/earmark.ex
+++ b/lib/ex_doc/markdown/earmark.ex
@@ -28,13 +28,13 @@ defmodule ExDoc.Markdown.Earmark do
   @impl true
   def to_ast(text, opts) do
     options = [
-      gfm: Keyword.get(opts, :gfm, true),
-      line: Keyword.get(opts, :line, 1),
-      file: Keyword.get(opts, :file, "nofile"),
-      breaks: Keyword.get(opts, :breaks, false),
-      smartypants: Keyword.get(opts, :smartypants, false),
+      gfm: true,
+      line: 1,
+      file: "nofile",
+      breaks: false,
+      smartypants: false,
       pure_links: true
-    ]
+    ] |> Keyword.merge(opts)
 
     case EarmarkParser.as_ast(text, options) do
       {:ok, ast, messages} ->


### PR DESCRIPTION
# Actual Behavior

Options passed to the `EarmarkParser` Markdown Processor are filtered out in order to provide default values.

# Desired Behavior

Let the user pass extra options to `EarmarkParser`.

# Changes

Use `Keyword.merge` with the default values as first argument and the user supplied values as second argument.
