### PR TITLE
Add integration test for escript

### DIFF
--- a/test/ex_doc/cli_test.exs
+++ b/test/ex_doc/cli_test.exs
@@ -138,6 +138,8 @@ defmodule ExDoc.CLITest do
       @moduledoc \"\"\"
       `String.upcase/2`
       \"\"\"
+
+      @type t() :: String.t()
     end
     """)
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,6 +4,9 @@ exclude = [
   otp24: System.otp_release() < "24"
 ]
 
+Mix.shell(Mix.Shell.Process)
+ExUnit.after_suite(fn _ -> Mix.shell(Mix.Shell.IO) end)
+
 ExUnit.start(exclude: Enum.filter(exclude, &elem(&1, 1)))
 
 # Prepare module fixtures


### PR DESCRIPTION
This is especially going to be useful to catch bugs like these (I'll fix them later)

```elixir
    defmodule Foo do
      @type t() :: String.t()
    end
```

fails with:

```
     Unexpectedly received message {:mix_shell, :run, ["warning: documentation references \"String.t()\" but it is undefined or private\n  tmp/ExDoc.CLITest/test-run-from-CLI/lib/foo.ex:6: t:Foo.t/0\n\n"]} (which matched _)
     code: refute_received _
```

and this is because we don't have docs chunks for Elixir modules when running from escript.

---

However, both on Elixir 1.12 and master, I'm getting the following console output and I'm not sure where it is coming from.

```
~/src/ex_doc[wm-escript-test]% mix test
..........................................................................................................................................................................................

Finished in 8.6 seconds (3.0s async, 5.5s sync)
186 tests, 0 failures

Randomized with seed 125690

17:50:15.788 [error] Task #PID<0.362.0> started from #PID<0.93.0> terminating
** (UndefinedFunctionError) undefined function
    #Function<0.11923361/1 in :elixir_compiler_1>(%{excluded: 0, failures: 0, skipped: 0, total: 186})
    (elixir 1.12.1) lib/enum.ex:930: Enum."-each/2-lists^foreach/1-0-"/2
    (ex_unit 1.12.1) lib/ex_unit/runner.ex:64: ExUnit.Runner.run_with_trap/2
    (ex_unit 1.12.1) lib/ex_unit/runner.ex:31: ExUnit.Runner.run/2
    (elixir 1.12.1) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2
    (elixir 1.12.1) lib/task/supervised.ex:35: Task.Supervised.reply/5
    (stdlib 3.15.1) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Function: #Function<0.95028733/0 in ExUnit.async_run/0>
    Args: []
** (EXIT from #PID<0.93.0>) an exception was raised:
    ** (UndefinedFunctionError) undefined function
        #Function<0.11923361/1 in :elixir_compiler_1>(%{excluded: 0, failures: 0, skipped: 0, total: 186})
        (elixir 1.12.1) lib/enum.ex:930: Enum."-each/2-lists^foreach/1-0-"/2
        (ex_unit 1.12.1) lib/ex_unit/runner.ex:64: ExUnit.Runner.run_with_trap/2
        (ex_unit 1.12.1) lib/ex_unit/runner.ex:31: ExUnit.Runner.run/2
        (elixir 1.12.1) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2
        (elixir 1.12.1) lib/task/supervised.ex:35: Task.Supervised.reply/5
        (stdlib 3.15.1) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```