### PR TITLE
Erlang syntax highlighting

### DIFF
--- a/lib/ex_doc/doc_ast.ex
+++ b/lib/ex_doc/doc_ast.ex
@@ -77,6 +77,19 @@ defmodule ExDoc.DocAST do
     Enum.map(list, &parse_erl_ast/1)
   end
 
+  defp parse_erl_ast({:pre, attrs, content}) do
+    case content do
+      # if we already have <pre><code>...</code></pre>, carry on
+      [{:code, _, _}] ->
+        {:pre, attrs, parse_erl_ast(content), %{}}
+
+      # otherwise, turn <pre>...</pre> into <pre><code>...</code></pre>
+      _ ->
+        content = [{:code, [], parse_erl_ast(content), %{}}]
+        {:pre, attrs, content, %{}}
+    end
+  end
+
   defp parse_erl_ast({tag, attrs, content}) when is_atom(tag) do
     {tag, attrs, parse_erl_ast(content), %{}}
   end

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -130,7 +130,7 @@ defmodule ExDoc.Formatter.HTML do
     doc
     |> language.autolink_doc(autolink_opts)
     |> ExDoc.DocAST.to_string()
-    |> ExDoc.DocAST.highlight(opts)
+    |> ExDoc.DocAST.highlight(language, opts)
   end
 
   defp output_setup(build, config) do

--- a/lib/ex_doc/language.ex
+++ b/lib/ex_doc/language.ex
@@ -111,6 +111,15 @@ defmodule ExDoc.Language do
   """
   @callback autolink_spec(spec :: term(), opts :: keyword()) :: iodata()
 
+  @doc """
+  Returns information for syntax highlighting.
+  """
+  @callback highlight_info() :: %{
+              language_name: String.t(),
+              lexer: module(),
+              opts: keyword()
+            }
+
   def get(:elixir), do: ExDoc.Language.Elixir
   def get(:erlang), do: ExDoc.Language.Erlang
 end

--- a/lib/ex_doc/language/elixir.ex
+++ b/lib/ex_doc/language/elixir.ex
@@ -116,6 +116,15 @@ defmodule ExDoc.Language.Elixir do
     name <> do_typespec(rest, config)
   end
 
+  @impl true
+  def highlight_info() do
+    %{
+      language_name: "elixir",
+      lexer: Makeup.Lexers.ElixirLexer,
+      opts: []
+    }
+  end
+
   ## Helpers
 
   defp module_type_and_skip(module) do

--- a/lib/ex_doc/language/erlang.ex
+++ b/lib/ex_doc/language/erlang.ex
@@ -100,6 +100,15 @@ defmodule ExDoc.Language.Erlang do
     |> Enum.join("\n")
   end
 
+  @impl true
+  def highlight_info() do
+    %{
+      language_name: "erlang",
+      lexer: Makeup.Lexers.ErlangLexer,
+      opts: []
+    }
+  end
+
   ## Autolink
 
   defp walk_doc(list, config) when is_list(list) do

--- a/test/ex_doc/doc_ast_test.exs
+++ b/test/ex_doc/doc_ast_test.exs
@@ -95,23 +95,23 @@ defmodule ExDoc.DocASTTest do
   end
 
   describe "highlight" do
-    test "if no language is given, highlight as iex/elixir" do
+    test "if no language is given in markup, use language module " do
       with_empty_class = ~S[<pre><code class="">mix run --no-halt path/to/file.exs</code></pre>]
       without_class = "<pre><code>mix run --no-halt path/to/file.exs</code></pre>"
       iex_detected_with_empty_class = ~S[<pre><code class="">iex&gt; max(4, 5)</code></pre>]
       iex_detected_without_class = ~S[<pre><code>iex&gt; max(4, 5)</code></pre>]
 
-      assert DocAST.highlight(with_empty_class) =~
+      assert DocAST.highlight(with_empty_class, ExDoc.Language.Elixir) =~
                ~r{<pre><code class=\"makeup elixir\">.*}
 
-      assert DocAST.highlight(without_class) =~
+      assert DocAST.highlight(without_class, ExDoc.Language.Elixir) =~
                ~r{<pre><code class=\"makeup elixir\">.*}
 
       # IEx is highlighted by the normal elixir lexer
-      assert DocAST.highlight(iex_detected_with_empty_class) =~
+      assert DocAST.highlight(iex_detected_with_empty_class, ExDoc.Language.Elixir) =~
                ~r{<pre><code class=\"makeup elixir\">.*}
 
-      assert DocAST.highlight(iex_detected_without_class) =~
+      assert DocAST.highlight(iex_detected_without_class, ExDoc.Language.Elixir) =~
                ~r{<pre><code class=\"makeup elixir\">.*}
     end
   end

--- a/test/ex_doc/doc_ast_test.exs
+++ b/test/ex_doc/doc_ast_test.exs
@@ -25,6 +25,13 @@ defmodule ExDoc.DocASTTest do
       assert DocAST.parse!(erl_ast, "application/erlang+html") ==
                [{:p, [], ["foo"], %{}}]
     end
+
+    test "erlang+html code blocks" do
+      erl_ast = [{:pre, [], ["foo"]}]
+
+      assert DocAST.parse!(erl_ast, "application/erlang+html") ==
+               [{:pre, [], [{:code, [], ["foo"], %{}}], %{}}]
+    end
   end
 
   describe "to_string/2" do


### PR DESCRIPTION
- ExDoc.Language: Add highlight_info/0 callback
- ExDoc.DocAST: Turn `<pre>` into `<pre><code>` for erlang+html
