### PR TITLE
Don't crash upon doc chunks for unknown beam languages

### DIFF
--- a/lib/ex_doc/language.ex
+++ b/lib/ex_doc/language.ex
@@ -137,7 +137,7 @@ defmodule ExDoc.Language do
   def get(language, module) do
     IO.puts(
       :stderr,
-      "warning: skipping module in unsupported language #{inspect(language)} : #{module}"
+      "warning: skipping module #{inspect(module)}, reason: unsupported language (#{inspect(language)})"
     )
 
     :error

--- a/lib/ex_doc/language.ex
+++ b/lib/ex_doc/language.ex
@@ -136,7 +136,7 @@ defmodule ExDoc.Language do
 
   def get(language, module) do
     IO.warn(
-      "skipping module #{inspect(module)}, reason: unsupported language (#{inspect(language)})",
+      "skipping module #{module}, reason: unsupported language (#{language})",
       []
     )
 

--- a/lib/ex_doc/language.ex
+++ b/lib/ex_doc/language.ex
@@ -135,9 +135,9 @@ defmodule ExDoc.Language do
   def get(:erlang, _module), do: {:ok, ExDoc.Language.Erlang}
 
   def get(language, module) do
-    IO.puts(
-      :stderr,
-      "warning: skipping module #{inspect(module)}, reason: unsupported language (#{inspect(language)})"
+    IO.warn(
+      "skipping module #{inspect(module)}, reason: unsupported language (#{inspect(language)})",
+      []
     )
 
     :error

--- a/lib/ex_doc/language.ex
+++ b/lib/ex_doc/language.ex
@@ -131,7 +131,15 @@ defmodule ExDoc.Language do
               opts: keyword()
             }
 
-  def get(:elixir), do: {:ok, ExDoc.Language.Elixir}
-  def get(:erlang), do: {:ok, ExDoc.Language.Erlang}
-  def get(_language), do: :error
+  def get(:elixir, _module), do: {:ok, ExDoc.Language.Elixir}
+  def get(:erlang, _module), do: {:ok, ExDoc.Language.Erlang}
+
+  def get(language, module) do
+    IO.puts(
+      :stderr,
+      "warning: skipping module in unsupported language #{inspect(language)} : #{module}"
+    )
+
+    :error
+  end
 end

--- a/lib/ex_doc/language.ex
+++ b/lib/ex_doc/language.ex
@@ -133,5 +133,5 @@ defmodule ExDoc.Language do
 
   def get(:elixir), do: {:ok, ExDoc.Language.Elixir}
   def get(:erlang), do: {:ok, ExDoc.Language.Erlang}
-  def get(language), do: {:unknown_language, language}
+  def get(_language), do: :error
 end

--- a/lib/ex_doc/language.ex
+++ b/lib/ex_doc/language.ex
@@ -131,6 +131,7 @@ defmodule ExDoc.Language do
               opts: keyword()
             }
 
-  def get(:elixir), do: ExDoc.Language.Elixir
-  def get(:erlang), do: ExDoc.Language.Erlang
+  def get(:elixir), do: {:ok, ExDoc.Language.Elixir}
+  def get(:erlang), do: {:ok, ExDoc.Language.Erlang}
+  def get(language), do: {:unknown_language, language}
 end

--- a/lib/ex_doc/language.ex
+++ b/lib/ex_doc/language.ex
@@ -134,7 +134,7 @@ defmodule ExDoc.Language do
   def get(:elixir, _module), do: {:ok, ExDoc.Language.Elixir}
   def get(:erlang, _module), do: {:ok, ExDoc.Language.Erlang}
 
-  def get(language, module) do
+  def get(language, module) when  is_atom(language) and  is_atom(module) do
     IO.warn(
       "skipping module #{module}, reason: unsupported language (#{language})",
       []

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -53,7 +53,7 @@ defmodule ExDoc.Retriever do
 
   defp get_module(module, config) do
     with {:docs_v1, _, language, _, _, _, _} = docs_chunk <- docs_chunk(module),
-         language = ExDoc.Language.get(language),
+         {:ok, language} <- ExDoc.Language.get(language),
          %{} = module_data <- language.module_data(module, docs_chunk, config),
          false <- skip_module?(module_data, config) do
       [generate_node(module, module_data, config)]

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -53,7 +53,7 @@ defmodule ExDoc.Retriever do
 
   defp get_module(module, config) do
     with {:docs_v1, _, language, _, _, _, _} = docs_chunk <- docs_chunk(module),
-         {:ok, language} <- ExDoc.Language.get(language),
+         {:ok, language} <- ExDoc.Language.get(language, module),
          %{} = module_data <- language.module_data(module, docs_chunk, config),
          false <- skip_module?(module_data, config) do
       [generate_node(module, module_data, config)]


### PR DESCRIPTION
E.g. LFE.

Following is a demo of the crash; it's a rebar3 project which uses the [`rebar3_lfe`plugin ](https://hex.pm/packages/rebar3_lfe) to seamlessly import LFE (there's no need to have it installed.) 

It's got mixed Erlang & LFE code and, following the fix, the generated API reference includes a page for the Erlang module but none for the LFE modules, as expected.

[ex_doc_crash.tar.gz](https://github.com/elixir-lang/ex_doc/files/7117512/ex_doc_crash.tar.gz)

The crash can be reproduced by invoking `./generate_docs.sh`, assuming `ex_doc` is available on $PATH. It's happening right here, due to the function argument being `:lfe`:
https://github.com/elixir-lang/ex_doc/blob/50155806bb00506a5e199a894a5d2a47c24165f0/lib/ex_doc/language.ex#L134-L135

I performed the smallest possible change, which is to silently ignore chunks for unknown languages, but maybe it would be better to emit some kind of warning so that the user knows.

I also looked into ways of testing the new behaviour to prevent regressions, e.g.
- by compiling an Erlang module but somehow hijacking the language attribute within the `Docs` chunk - it's a bit of a rabbit whole
- by mocking [`ExDocs.Utils.Code.load_docs_Chunk/1`](https://github.com/elixir-lang/ex_doc/blob/50155806bb00506a5e199a894a5d2a47c24165f0/lib/ex_doc/utils/code.ex#L67-L72), which is saner but would require both importing a mocking library[*] and exporting that function (assuming all mocking libraries are incapable of mocking local functions)

Given the constraints above, I decided to wait for your feedback before adding any sort of tests.

---

[*]: I only know `meck` and don't know if it's common to use it in Elixir


