### PR TITLE
Handle cover compiled modules when getting module info

### DIFF
--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -119,7 +119,7 @@ defmodule ExDoc.Autolink do
 
         {otp?, app}
 
-      :non_existing ->
+      value when value in [:cover_compiled, :non_existing] ->
         {false, nil}
     end
   end


### PR DESCRIPTION
When getting details for a module for which docs should be generated, when return value of Erlang function `:code.which/1` in `app_info/1` is `:cover_compiled`, the resulting tuple should be the same as if `:non_existing` was returned.
In this way the module docs and the types within them are linked properly.