### PR TITLE
Do not check :private on visibility in ExDoc.Language.Erlang.do_url

### DIFF
--- a/lib/ex_doc/language/erlang.ex
+++ b/lib/ex_doc/language/erlang.ex
@@ -361,7 +361,7 @@ defmodule ExDoc.Language.Erlang do
 
     # TODO: type with content = %{} in otp xml is marked as :hidden, it should be :public
 
-    if visibility == :public or (visibility in [:hidden, :private] and elem(ref, 0) == :type) do
+    if visibility == :public or (visibility == :hidden and elem(ref, 0) == :type) do
       final_url(ref, config)
     else
       Autolink.maybe_warn(ref, config, visibility, %{original_text: original_text})


### PR DESCRIPTION
The dialyzer report on file erlang.ex in line 364 that
the variable visibility cannot be a :private because
typespec declared it as :hidden or :public or :undefined.
Fixes it by removing :private on visibility check in do_url
function.