### PR TITLE
Link var in type restrictions to typespecs.html#defining-a-specification

### DIFF
--- a/assets/js/tooltips/hints.js
+++ b/assets/js/tooltips/hints.js
@@ -32,6 +32,12 @@ const predefinedHints = [{
     kind: HINT_KIND.plain,
     description: 'Built-in type'
   }
+}, {
+  href: 'typespecs.html#defining-a-specification',
+  hint: {
+    kind: HINT_KIND.plain,
+    description: 'No restriction'
+  }
 }]
 
 const state = {

--- a/test/ex_doc/language/elixir_test.exs
+++ b/test/ex_doc/language/elixir_test.exs
@@ -371,6 +371,16 @@ defmodule ExDoc.Language.ElixirTest do
                ~s[t() :: <a href="https://hexdocs.pm/elixir/typespecs.html#built-in-types">keyword</a>()]
     end
 
+    # regression test for elixir-ecto/ecto#3756
+    test "Elixir type variable without restriction in anonymous function" do
+      assert autolink_spec(
+               quote do
+                 checkout(adapter_meta, config :: Keyword.t(), (() -> result)) :: result
+                 when result: var
+               end
+             ) == ~s[checkout(adapter_meta, config :: <a href="https://hexdocs.pm/elixir/Keyword.html#t:t/0">Keyword.t</a>(), (-&gt; result)) :: result when result: <a href="https://hexdocs.pm/elixir/typespecs.html#defining-a-specification">var</a>]
+    end
+
     test "Erlang stdlib types" do
       assert autolink_spec(quote(do: t() :: :sets.set())) ==
                ~s[t() :: <a href="https://erlang.org/doc/man/sets.html#type-set">:sets.set</a>()]


### PR DESCRIPTION
Related to elixir-ecto/ecto#3756.  It would fix it once ecto is updated to use an `ex_doc` with this change.

# Reason for change

The use of `var` in `@callback checkout(adapter_meta, config :: Keyword.t(), (() -> result)) :: result when result: var` can be used to mean `result` has no restrictions, but that `var` unlike real typespec types didn't link anywhere, so reading the Ecto docs, I couldn't figure out if it was an unresolved type or a built-type that wasn't linking.  @josevalim in elixir-ecto/ecto#3756 pointed to https://hexdocs.pm/elixir/typespecs.html#defining-a-specification, so we agreed on the plan to link `var` to there.

# Potential solutions

I don't terribly like this solution I came up with for the linking because it ends up having to duplicate a lot of`Macro.to_string/1`.  To cover having to duplicate more of `Macro.to_string`, I added more tests.  **I'm open to a smaller, more focused change.**

## Alternative solution I tried
* Use a regex to find the `var` and link it.  Didn't work because I couldn't find a regex that would link `var` at the top-level, but not nested when there was a complex nested type in the `when`.  
* I tried using `Macro.to_string/2` instead of custom walking code, but the problem is the callback is passed the AST bottom up, which means it would get the AST for `t()` when the type that needed to be linked is `AutolinkTest.Foo.t()`.

# Testing
* `ex_doc` unit tests
* Used this change as a path dependency for local ecto and got fix in generated docs.
  
  ![Screen Shot 2021-10-11 at 4 10 20 PM](https://user-images.githubusercontent.com/298259/136852631-289f776d-ec7a-4f0e-bf2e-965c116fb3da.png)
  ![Screen Shot 2021-10-11 at 4 10 40 PM](https://user-images.githubusercontent.com/298259/136852639-bccd7683-87e7-4ae2-bd98-e4a0ba0c22be.png)


# Changelog
## Enhancements
* Link var in type restrictions to typespecs.html#defining-a-specification
  * On hover show "No restriction"