### PR TITLE
Removed smartypants option alltogether

### DIFF
--- a/lib/ex_doc/markdown/earmark.ex
+++ b/lib/ex_doc/markdown/earmark.ex
@@ -21,9 +21,6 @@ defmodule ExDoc.Markdown.Earmark do
     * `:breaks` - (boolean) only applicable if `gfm` is enabled. Makes all line
       breaks significant (so every line in the input is a new line in the output).
 
-    * `:smartypants` - (boolean) turns on smartypants processing, so quotes become curly,
-      two or three hyphens become en and em dashes, and so on. Defaults to `false`.
-
   """
   @impl true
   def to_ast(text, opts) do
@@ -32,7 +29,6 @@ defmodule ExDoc.Markdown.Earmark do
       line: 1,
       file: "nofile",
       breaks: false,
-      smartypants: false,
       pure_links: true
     ]
 


### PR DESCRIPTION
I have deprecated the `smartypants` option in `EarmarkParser` v1.4.17 as it is not used by `ex_doc` and
logically shall go into the renderer ([`Earmark` 1.4.18](https://github.com/pragdave/earmark/issues/438))

Therefore this PR.

However if for a reason foreign to my knowledge you think you want to use smartypants again at some point I can undeprecate. It is not what I'd prefer though ;)