### PR TITLE
Added optional module annotations

### DIFF
--- a/assets/less/content/general.less
+++ b/assets/less/content/general.less
@@ -75,6 +75,10 @@ a.livebook-badge {
   font-weight: normal;
 }
 
+h1 .note {
+  float: right;
+}
+
 blockquote {
   font-style: italic;
   margin: .5em 0;

--- a/lib/ex_doc/formatter/html/templates/module_template.eex
+++ b/lib/ex_doc/formatter/html/templates/module_template.eex
@@ -9,6 +9,9 @@
             <span class="sr-only">View Source</span>
           </a>
         <% end %>
+        <%= for annotation <- module.annotations do %>
+          <span class="note">(<%= annotation %>)</span>
+        <% end %>
       </h1>
 
       <%= if deprecated = module.deprecated do %>

--- a/lib/ex_doc/nodes.ex
+++ b/lib/ex_doc/nodes.ex
@@ -19,7 +19,8 @@ defmodule ExDoc.ModuleNode do
             source_path: nil,
             source_url: nil,
             type: nil,
-            language: nil
+            language: nil,
+            annotations: []
 
   @type t :: %__MODULE__{
           id: nil | String.t(),
@@ -38,7 +39,8 @@ defmodule ExDoc.ModuleNode do
           source_path: nil | String.t(),
           source_url: nil | String.t(),
           type: nil | atom(),
-          language: module()
+          language: module(),
+          annotations: list()
         }
 end
 

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -134,7 +134,8 @@ defmodule ExDoc.Retriever do
       typespecs: Enum.sort_by(types, &{&1.name, &1.arity}),
       source_path: source_path,
       source_url: source_link(source, module_data.line),
-      language: module_data.language
+      language: module_data.language,
+      annotations: List.wrap(metadata[:annotations])
     }
   end
 

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -135,7 +135,7 @@ defmodule ExDoc.Retriever do
       source_path: source_path,
       source_url: source_link(source, module_data.line),
       language: module_data.language,
-      annotations: List.wrap(metadata[:annotations])
+      annotations: List.wrap(metadata[:tags])
     }
   end
 

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -337,7 +337,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
                ~r{<a href="#{source_url()}/blob/master/test/fixtures/compiled_with_docs.ex#L1"[^>]*>\s*<span class="icon-code" aria-hidden="true"></span>\s*<span class="sr-only">View Source</span>\s*</a>\s*}ms
 
       # Module annotations
-      assert content =~ ~s{<span class=\"note\">(example_module_annotation)</span>}
+      assert content =~ ~s{<span class=\"note\">(example_module_tag)</span>}
 
       # Functions
       assert content =~ ~s{<section class="detail" id="example/2">}

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -334,7 +334,10 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
 
       # Source
       assert content =~
-               ~r{<a href="#{source_url()}/blob/master/test/fixtures/compiled_with_docs.ex#L14"[^>]*>\s*<span class="icon-code" aria-hidden="true"></span>\s*<span class="sr-only">View Source</span>\s*</a>}ms
+               ~r{<a href="#{source_url()}/blob/master/test/fixtures/compiled_with_docs.ex#L1"[^>]*>\s*<span class="icon-code" aria-hidden="true"></span>\s*<span class="sr-only">View Source</span>\s*</a>\s*}ms
+
+      # Module annotations
+      assert content =~ ~s{<span class=\"note\">(example_module_annotation)</span>}
 
       # Functions
       assert content =~ ~s{<section class="detail" id="example/2">}

--- a/test/ex_doc/retriever/elixir_test.exs
+++ b/test/ex_doc/retriever/elixir_test.exs
@@ -10,7 +10,7 @@ defmodule ExDoc.Retriever.ElixirTest do
       elixirc(c, ~S"""
       defmodule Mod do
         @moduledoc "Mod docs."
-        @moduledoc annotations: :public
+        @moduledoc tags: :public
 
         @doc "function/0 docs."
         @spec function() :: atom()

--- a/test/ex_doc/retriever/elixir_test.exs
+++ b/test/ex_doc/retriever/elixir_test.exs
@@ -10,6 +10,7 @@ defmodule ExDoc.Retriever.ElixirTest do
       elixirc(c, ~S"""
       defmodule Mod do
         @moduledoc "Mod docs."
+        @moduledoc annotations: :public
 
         @doc "function/0 docs."
         @spec function() :: atom()
@@ -31,7 +32,8 @@ defmodule ExDoc.Retriever.ElixirTest do
                title: "Mod",
                type: :module,
                typespecs: [],
-               docs: [empty_doc_and_specs, function]
+               docs: [empty_doc_and_specs, function],
+               annotations: [:public]
              } = mod
 
       assert DocAST.to_string(mod.doc) == "<p>Mod docs.</p>"
@@ -41,7 +43,7 @@ defmodule ExDoc.Retriever.ElixirTest do
                annotations: [],
                defaults: [],
                deprecated: nil,
-               doc_line: 4,
+               doc_line: 5,
                group: :Functions,
                id: "function/0",
                name: :function,

--- a/test/fixtures/compiled_with_docs.ex
+++ b/test/fixtures/compiled_with_docs.ex
@@ -10,6 +10,8 @@ defmodule CompiledWithDocs do
   example
   """
 
+  @moduledoc annotations: :example_module_annotation
+
   @doc "Some struct"
   defstruct [:field]
 

--- a/test/fixtures/compiled_with_docs.ex
+++ b/test/fixtures/compiled_with_docs.ex
@@ -10,7 +10,7 @@ defmodule CompiledWithDocs do
   example
   """
 
-  @moduledoc annotations: :example_module_annotation
+  @moduledoc tags: :example_module_tag
 
   @doc "Some struct"
   defstruct [:field]


### PR DESCRIPTION
As a follow-up to this issue #1419. This PR adds a possibility to specify additional module's annotations that will be displayed right next to `View Source` icon. It can help to distinguish between different kinds of modules e.g. private ones when we decide to include them in documentation for internal purposes but make it obvious that they are private. In the end the annotation can be whatever we want.

I didn't know if I was to regenerate build files but I guess it happens during deployment?


I decided to go with the following pattern:

```elixir
defmodule InternalModule do
  @moduledoc """
  This documentation is for internal purposes...
  """
  @moduledoc annotations: :private
end
```

The example UI looks like this:
![image](https://user-images.githubusercontent.com/34857220/141449474-a09e8258-66b7-4068-9bd0-c3a5b39fefad.png)
