### PR TITLE
Document how to render Mermaid graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,35 @@ Other objects you may want to render in a special manner are code snippets. For 
 </script>
 ```
 
-For more details and configuration options see the [vega/vega-embed](https://github.com/vega/vega-embed).
+For more details and configuration options see [vega/vega-embed](https://github.com/vega/vega-embed).
+
+### Rendering Mermaid graphs
+
+Similarly to the example above, if your Markdown includes Mermaid graph specification in `mermaid` code snippets, you can do:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/mermaid@8.13.3/dist/mermaid.min.js"></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    mermaid.initialize({ startOnLoad: false });
+    let id = 0;
+    for (const codeEl of document.querySelectorAll("pre code.mermaid")) {
+      const preEl = codeEl.parentElement;
+      const graphDefinition = codeEl.textContent;
+      const graphEl = document.createElement("div");
+      const graphId = "mermaid-graph-" + id++;
+      mermaid.render(graphId, graphDefinition, function (svgSource, bindListeners) {
+        graphEl.innerHTML = svgSource;
+        bindListeners && bindListeners(graphEl);
+        preEl.insertAdjacentElement("afterend", graphEl);
+        preEl.remove();
+      });
+    }
+  });
+</script>
+```
+
+For more details and configuration options see the [Mermaid usage docs](https://mermaid-js.github.io/mermaid/#/usage).
 
 ## Contributing
 


### PR DESCRIPTION
Closes #1434.

@fhunleth please give it a try and let me know if it works for you.

FTR initially I tried a slightly simpler solution, which was to first replace all `<pre>` tags with `<div class="mermaid">` and then run the automatic rendering:

```js
document.addEventListener("DOMContentLoaded", function () {
  for (const codeEl of document.querySelectorAll("pre code.mermaid")) {
    const preEl = codeEl.parentElement;
    const graphDefinition = codeEl.textContent;
    const graphEl = document.createElement("div");
    graphEl.classList.add("mermaid");
    graphEl.textContent = graphDefinition;
    preEl.insertAdjacentElement("afterend", graphEl);
    preEl.remove();
  }
  mermaid.initialize({ startOnLoad: true });
});
```

Then I tried a more manual approach, which I included in this PR. The primary difference is when the graph definition is invalid. When rendering manually we keep the definition in a `<pre>` tag so it can be read and there is an error in the console. On the other hand, when using the auto rendering the element gets replaced with a huge "failed to render" image and there's nothing useful in the console.