### PR TITLE
Use Struct instead of __struct__/0 in sidebar

### DIFF
--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -146,7 +146,14 @@ defmodule ExDoc.Formatter.HTML.Templates do
   defp sidebar_entries({group, nodes}) do
     nodes =
       for node <- nodes do
-        %{id: "#{node.name}/#{node.arity}", anchor: URI.encode(node.id)}
+        id =
+          if "struct" in node.annotations do
+            node.signature
+          else
+            "#{node.name}/#{node.arity}"
+          end
+
+        %{id: id, anchor: URI.encode(node.id)}
       end
 
     %{key: HTML.text_to_id(group), name: group, nodes: nodes}

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -218,6 +218,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       assert content =~ ~r("id":"CompiledWithDocs".*"key":"functions".*"example/2")ms
       assert content =~ ~r("id":"CompiledWithDocs".*"key":"functions".*"example_without_docs/0")ms
       assert content =~ ~r("id":"CompiledWithDocs.Nested")ms
+      assert content =~ ~r(\{"anchor":"__struct__/0","id":"%CompiledWithDocs\{\}"\})ms
     end
 
     test "outputs nodes grouped based on metadata" do


### PR DESCRIPTION
Closes #1433

/cc @NickNeck


There is one issue though, is that `%Task{}` is not a function

![image](https://user-images.githubusercontent.com/9133420/145139799-b7d76f50-3a8e-4296-8fb0-a397798de309.png)
