### PR TITLE
Use config.proglang in epub head template

### DIFF
--- a/lib/ex_doc/formatter/epub/templates/head_template.eex
+++ b/lib/ex_doc/formatter/epub/templates/head_template.eex
@@ -5,7 +5,8 @@
     <meta charset="utf-8" />
     <title><%= page.title %> - <%= config.project %> v<%= config.version %></title>
     <meta name="generator" content="ExDoc v<%= ExDoc.version() %>" />
-    <link type="text/css" rel="stylesheet" href="<%= H.asset_rev "#{config.output}/OEBPS", "dist/elixir*.css" %>" />
+    <link type="text/css" rel="stylesheet" 
+      href="<%= H.asset_rev "#{config.output}/OEBPS", "dist/#{config.proglang}*.css" %>" />
     <script src="<%= H.asset_rev "#{config.output}/OEBPS", "dist/app*.js" %>"></script>
     <%# Extra content specified by the user (e.g. custom CSS) %>
     <%= config.before_closing_head_tag.(:epub) %>

--- a/test/ex_doc/formatter/epub_test.exs
+++ b/test/ex_doc/formatter/epub_test.exs
@@ -91,6 +91,11 @@ defmodule ExDoc.Formatter.EPUBTest do
   test "generates an EPUB file in the default directory" do
     generate_docs(doc_config())
     assert File.regular?("#{output_dir()}/#{doc_config()[:project]}.epub")
+
+    File.rm!("#{output_dir()}/#{doc_config()[:project]}.epub")
+
+    generate_docs(Keyword.put(doc_config(), :proglang, :erlang))
+    assert File.regular?("#{output_dir()}/#{doc_config()[:project]}.epub")
   end
 
   test "generates an EPUB file in specified output directory" do

--- a/test/ex_doc/formatter/epub_test.exs
+++ b/test/ex_doc/formatter/epub_test.exs
@@ -91,9 +91,9 @@ defmodule ExDoc.Formatter.EPUBTest do
   test "generates an EPUB file in the default directory" do
     generate_docs(doc_config())
     assert File.regular?("#{output_dir()}/#{doc_config()[:project]}.epub")
+  end
 
-    File.rm!("#{output_dir()}/#{doc_config()[:project]}.epub")
-
+  test "generates an EPUB file with erlang as proglang" do
     generate_docs(Keyword.put(doc_config(), :proglang, :erlang))
     assert File.regular?("#{output_dir()}/#{doc_config()[:project]}.epub")
   end


### PR DESCRIPTION
This PR fixes a bug where the head template for epub had elixir hard coded for the style sheet resulting in a crash if the proglang differed (i.e., erlang). 