### PR TITLE
Replace Specs heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ The easiest way to test changes to ExDoc is to locally rebuild the app and its o
   4. Run `mix lint` to check if the Elixir and JavaScript files are properly formatted.
      You can run `mix fix` to let the JavaScript linter and Elixir formatter fix the code automatically before submitting your pull request
 
+Note that Node 17 or later is not supported due to [API breaking changes with Webpack](https://github.com/webpack/webpack/issues/14532).
+
 ## License
 
 ExDoc source code is released under [Apache 2 License](LICENSE). The generated contents, however, are under different licenses based on projects used to help render HTML, including CSS, JS, and other assets.

--- a/assets/less/content/functions.less
+++ b/assets/less/content/functions.less
@@ -58,8 +58,6 @@
 }
 
 .specs {
-  padding: 1em;
-
   pre {
     font-family: @monoFontFamily;
     font-size: 0.9em;
@@ -68,6 +66,10 @@
     white-space: pre-wrap;
     margin: 0;
     padding: 0;
+  }
+
+  .attribute {
+    color: @mediumGray;
   }
 }
 

--- a/assets/less/night/content/functions.less
+++ b/assets/less/night/content/functions.less
@@ -19,6 +19,10 @@
   color: @nightTextBody;
 }
 
+.specs .attribute {
+  color: @nightMediumGray;
+}
+
 div.deprecated {
   background-color: @nightDeprecated;
 }

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -33,19 +33,23 @@ defmodule ExDoc.Formatter.HTML.Templates do
   @doc """
   Get the attribute string used to define the spec of the given `node`.
   """
-  def get_spec_attribute(node)
+  def get_spec_attribute(module, node) do
+    node
+    |> get_spec_attribute()
+    |> module.language.format_attribute()
+  end
 
   def get_spec_attribute(%ExDoc.TypeNode{} = node) do
     if "opaque" in node.annotations do
-      "@opaque"
+      "opaque"
     else
-      "@type"
+      "type"
     end
   end
 
-  def get_spec_attribute(%ExDoc.FunctionNode{type: :callback}), do: "@callback"
-  def get_spec_attribute(%ExDoc.FunctionNode{type: :macrocallback}), do: "@macrocallback"
-  def get_spec_attribute(%ExDoc.FunctionNode{}), do: "@spec"
+  def get_spec_attribute(%ExDoc.FunctionNode{type: :callback}), do: "callback"
+  def get_spec_attribute(%ExDoc.FunctionNode{type: :macrocallback}), do: "macrocallback"
+  def get_spec_attribute(%ExDoc.FunctionNode{}), do: "spec"
 
   @doc """
   Get defaults clauses.
@@ -328,7 +332,7 @@ defmodule ExDoc.Formatter.HTML.Templates do
   end
 
   templates = [
-    detail_template: [:node, :_module],
+    detail_template: [:node, :module],
     footer_template: [:config, :node],
     head_template: [:config, :page],
     module_template: [:config, :module, :summary, :nodes_map],

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -31,25 +31,11 @@ defmodule ExDoc.Formatter.HTML.Templates do
   end
 
   @doc """
-  Get the attribute string used to define the spec of the given `node`.
+  Format the attribute type used to define the spec of the given `node`.
   """
-  def get_spec_attribute(module, node) do
-    node
-    |> get_spec_attribute()
-    |> module.language.format_attribute()
+  def format_spec_attribute(module, node) do
+    module.language.format_spec_attribute(node)
   end
-
-  def get_spec_attribute(%ExDoc.TypeNode{} = node) do
-    if "opaque" in node.annotations do
-      "opaque"
-    else
-      "type"
-    end
-  end
-
-  def get_spec_attribute(%ExDoc.FunctionNode{type: :callback}), do: "callback"
-  def get_spec_attribute(%ExDoc.FunctionNode{type: :macrocallback}), do: "macrocallback"
-  def get_spec_attribute(%ExDoc.FunctionNode{}), do: "spec"
 
   @doc """
   Get defaults clauses.

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -31,6 +31,23 @@ defmodule ExDoc.Formatter.HTML.Templates do
   end
 
   @doc """
+  Get the attribute string used to define the spec of the given `node`.
+  """
+  def get_spec_attribute(node)
+
+  def get_spec_attribute(%ExDoc.TypeNode{} = node) do
+    if "opaque" in node.annotations do
+      "@opaque"
+    else
+      "@type"
+    end
+  end
+
+  def get_spec_attribute(%ExDoc.FunctionNode{type: :callback}), do: "@callback"
+  def get_spec_attribute(%ExDoc.FunctionNode{type: :macrocallback}), do: "@macrocallback"
+  def get_spec_attribute(%ExDoc.FunctionNode{}), do: "@spec"
+
+  @doc """
   Get defaults clauses.
   """
   def get_defaults(%{defaults: defaults}) do

--- a/lib/ex_doc/formatter/html/templates/detail_template.eex
+++ b/lib/ex_doc/formatter/html/templates/detail_template.eex
@@ -28,7 +28,7 @@
     <%= if specs = get_specs(node) do %>
       <div class="specs">
         <%= for spec <- specs do %>
-          <pre translate="no"><span class="attribute">@spec</span> <%= spec %></pre>
+          <pre translate="no"><span class="attribute"><%= get_spec_attribute(node) %></span> <%= spec %></pre>
         <% end %>
       </div>
     <% end %>

--- a/lib/ex_doc/formatter/html/templates/detail_template.eex
+++ b/lib/ex_doc/formatter/html/templates/detail_template.eex
@@ -28,7 +28,7 @@
     <%= if specs = get_specs(node) do %>
       <div class="specs">
         <%= for spec <- specs do %>
-          <pre translate="no"><span class="attribute"><%= get_spec_attribute(module, node) %></span> <%= spec %></pre>
+          <pre translate="no"><span class="attribute"><%= format_spec_attribute(module, node) %></span> <%= spec %></pre>
         <% end %>
       </div>
     <% end %>

--- a/lib/ex_doc/formatter/html/templates/detail_template.eex
+++ b/lib/ex_doc/formatter/html/templates/detail_template.eex
@@ -28,7 +28,7 @@
     <%= if specs = get_specs(node) do %>
       <div class="specs">
         <%= for spec <- specs do %>
-          <pre translate="no"><span class="attribute"><%= get_spec_attribute(node) %></span> <%= spec %></pre>
+          <pre translate="no"><span class="attribute"><%= get_spec_attribute(module, node) %></span> <%= spec %></pre>
         <% end %>
       </div>
     <% end %>

--- a/lib/ex_doc/formatter/html/templates/detail_template.eex
+++ b/lib/ex_doc/formatter/html/templates/detail_template.eex
@@ -26,10 +26,9 @@
 
   <section class="docstring">
     <%= if specs = get_specs(node) do %>
-      <h2>Specs</h2>
       <div class="specs">
         <%= for spec <- specs do %>
-          <pre translate="no"><%= spec %></pre>
+          <pre translate="no"><span class="attribute">@spec</span> <%= spec %></pre>
         <% end %>
       </div>
     <% end %>

--- a/lib/ex_doc/language.ex
+++ b/lib/ex_doc/language.ex
@@ -131,6 +131,11 @@ defmodule ExDoc.Language do
               opts: keyword()
             }
 
+  @doc """
+  Return an attribute in the canonical representation.
+  """
+  @callback format_attribute(String.t()) :: String.t()
+
   def get(:elixir, _module), do: {:ok, ExDoc.Language.Elixir}
   def get(:erlang, _module), do: {:ok, ExDoc.Language.Erlang}
 

--- a/lib/ex_doc/language.ex
+++ b/lib/ex_doc/language.ex
@@ -134,7 +134,7 @@ defmodule ExDoc.Language do
   @doc """
   Return an attribute in the canonical representation.
   """
-  @callback format_attribute(String.t()) :: String.t()
+  @callback format_spec_attribute(%ExDoc.FunctionNode{} | %ExDoc.TypeNode{}) :: String.t()
 
   def get(:elixir, _module), do: {:ok, ExDoc.Language.Elixir}
   def get(:erlang, _module), do: {:ok, ExDoc.Language.Erlang}

--- a/lib/ex_doc/language/elixir.ex
+++ b/lib/ex_doc/language/elixir.ex
@@ -203,6 +203,9 @@ defmodule ExDoc.Language.Elixir do
     }
   end
 
+  @impl true
+  def format_attribute(attribute) when is_binary(attribute), do: "@" <> attribute
+
   ## Module Helpers
 
   defp nesting_info(title, prefixes) do

--- a/lib/ex_doc/language/elixir.ex
+++ b/lib/ex_doc/language/elixir.ex
@@ -204,7 +204,10 @@ defmodule ExDoc.Language.Elixir do
   end
 
   @impl true
-  def format_attribute(attribute) when is_binary(attribute), do: "@" <> attribute
+  def format_spec_attribute(%ExDoc.TypeNode{type: type}), do: "@#{type}"
+  def format_spec_attribute(%ExDoc.FunctionNode{type: :callback}), do: "@callback"
+  def format_spec_attribute(%ExDoc.FunctionNode{type: :macrocallback}), do: "@macrocallback"
+  def format_spec_attribute(%ExDoc.FunctionNode{}), do: "@spec"
 
   ## Module Helpers
 

--- a/lib/ex_doc/language/erlang.ex
+++ b/lib/ex_doc/language/erlang.ex
@@ -163,6 +163,9 @@ defmodule ExDoc.Language.Erlang do
     }
   end
 
+  @impl true
+  def format_attribute(attribute) when is_binary(attribute), do: "-" <> attribute
+
   ## Shared between Erlang & Elixir
 
   @doc false

--- a/lib/ex_doc/language/erlang.ex
+++ b/lib/ex_doc/language/erlang.ex
@@ -164,7 +164,9 @@ defmodule ExDoc.Language.Erlang do
   end
 
   @impl true
-  def format_attribute(attribute) when is_binary(attribute), do: "-" <> attribute
+  def format_spec_attribute(%ExDoc.TypeNode{type: type}), do: "-#{type}"
+  def format_spec_attribute(%ExDoc.FunctionNode{type: :callback}), do: "-callback"
+  def format_spec_attribute(%ExDoc.FunctionNode{}), do: "-spec"
 
   ## Shared between Erlang & Elixir
 

--- a/test/ex_doc/formatter/html/erlang_test.exs
+++ b/test/ex_doc/formatter/html/erlang_test.exs
@@ -24,9 +24,11 @@ defmodule ExDoc.Formatter.HTML.ErlangTest do
 
     doc = generate_docs(c)
 
-    assert [_] = Floki.find(doc, "pre:fl-contains('foo(atom()) -> atom().')")
+    assert "-spec foo(atom()) -> atom()." =
+             doc |> Floki.find("pre:fl-contains('foo(atom())')") |> Floki.text()
 
-    assert [_] = Floki.find(doc, "pre:fl-contains('t() :: atom().')")
+    assert "-type t() :: atom()." =
+             doc |> Floki.find("pre:fl-contains('t() :: atom().')") |> Floki.text()
   end
 
   defp generate_docs(c) do

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -418,7 +418,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       integer = ~s[<a href="https://hexdocs.pm/elixir/typespecs.html#basic-types">integer</a>()]
 
       public_html =
-        ~S[public(t) :: {t, ] <>
+        ~S[<span class="attribute">@spec</span> public(t) :: {t, ] <>
           ~s[<a href="https://hexdocs.pm/elixir/String.html#t:t/0">String.t</a>(), ] <>
           ~S[<a href="TypesAndSpecs.Sub.html#t:t/0">TypesAndSpecs.Sub.t</a>(), ] <>
           ~S[<a href="#t:opaque/0">opaque</a>(), :ok | :error}]
@@ -428,6 +428,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       assert content =~ public_html
       refute content =~ ~s[<strong>private\(t\)]
       assert content =~ ~s[A public type]
+      assert content =~ ~s[<span class="attribute">@spec</span> add(]
       assert content =~ ~s[add(#{integer}, <a href="#t:opaque/0">opaque</a>()) :: #{integer}]
       refute content =~ ~s[minus(#{integer}, #{integer}) :: #{integer}]
 

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -418,7 +418,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       integer = ~s[<a href="https://hexdocs.pm/elixir/typespecs.html#basic-types">integer</a>()]
 
       public_html =
-        ~S[<span class="attribute">@spec</span> public(t) :: {t, ] <>
+        ~S[<span class="attribute">@type</span> public(t) :: {t, ] <>
           ~s[<a href="https://hexdocs.pm/elixir/String.html#t:t/0">String.t</a>(), ] <>
           ~S[<a href="TypesAndSpecs.Sub.html#t:t/0">TypesAndSpecs.Sub.t</a>(), ] <>
           ~S[<a href="#t:opaque/0">opaque</a>(), :ok | :error}]
@@ -436,6 +436,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
                ~s[Basic type: <a href=\"https://hexdocs.pm/elixir/typespecs.html#basic-types\"><code class=\"inline\">atom/0</code></a>.]
 
       assert content =~ ~r{opaque/0.*<span class="note">\(opaque\)</span>}ms
+      assert content =~ ~r{<span class="attribute">@opaque</span> opaque}
     end
 
     test "outputs summaries" do
@@ -483,6 +484,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
 
       assert content =~ ~r{Callbacks}
       assert content =~ ~r{<section class="detail" id="c:hello/1">}
+      assert content =~ ~s[<span class="attribute">@callback</span> hello(]
       assert content =~ ~s[hello(%URI{})]
       assert content =~ ~s[greet(arg1)]
 
@@ -493,6 +495,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
 
       assert content =~ ~r{Callbacks}
       assert content =~ ~r{<section class="detail" id="c:bye/1">}
+      assert content =~ ~s[<span class="attribute">@macrocallback</span> bye(]
     end
 
     ## PROTOCOLS

--- a/test/ex_doc/retriever/erlang_test.exs
+++ b/test/ex_doc/retriever/erlang_test.exs
@@ -33,6 +33,7 @@ defmodule ExDoc.Retriever.ErlangTest do
         function_groups: [:Callbacks, :Functions],
         group: nil,
         id: "mod",
+        language: ExDoc.Language.Erlang,
         module: :mod,
         nested_context: nil,
         nested_title: nil,


### PR DESCRIPTION
See issue #602.

As well as replacing the heading I removed the padding as it seemed excessive, but I'm happy to restore that if you like.

Original:
![CleanShot 2022-01-03 at 18 44 22](https://user-images.githubusercontent.com/2150/147965658-0d43fff6-c66b-400e-9bfa-8f3652699418.png)

New (without padding):
![CleanShot 2022-01-03 at 18 45 13](https://user-images.githubusercontent.com/2150/147965745-360bce91-d1a8-4c3e-8e4b-c00973d965ce.png)
--
![CleanShot 2022-01-03 at 18 44 57](https://user-images.githubusercontent.com/2150/147965765-aef9820d-026d-466e-9075-9eafe350c1a4.png)


With padding:
![CleanShot 2022-01-03 at 18 46 22](https://user-images.githubusercontent.com/2150/147965749-eff005ef-ae28-48d8-b71b-fed864105017.png)
--
![CleanShot 2022-01-03 at 18 44 41](https://user-images.githubusercontent.com/2150/147965769-13ffb111-090d-46e6-9407-b18ff9b717c0.png)

