### PR TITLE
Check if settings selector element exists

### DIFF
--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -31,9 +31,11 @@ export function initialize () {
 }
 
 function addEventListeners () {
-  qs(SETTINGS_LINK_SELECTOR).addEventListener('click', event => {
-    openSettingsModal()
-  })
+  if (document.querySelector(SETTINGS_LINK_SELECTOR)) {
+    qs(SETTINGS_LINK_SELECTOR).addEventListener('click', event => {
+      openSettingsModal()
+    })
+  }
 }
 
 function showSettinsTab () {


### PR DESCRIPTION
On some pages like `search.html` or `404.html` the following error is thrown: `Uncaught TypeError: Object(...)(...) is null` which can be seen in the console. This is because the settings button isn't declared on those pages.

This pull request adds a check to see if the `SETTINGS_LINK_SELECTOR` exists on the document before adding an event-listener to the element.

An alternate approach would be to add the settings button on those pages as well, I'm not sure which is the desired approach.