### PR TITLE
Add settings button to all pages

### DIFF
--- a/assets/js/handlebars/templates/search-results.handlebars
+++ b/assets/js/handlebars/templates/search-results.handlebars
@@ -1,7 +1,19 @@
 {{#if value}}
-  <h1>Search results for <em>{{value}}</em></h1>
+  <h1>
+    Search results for <em>{{value}}</em>
+    <button class="settings display-settings">
+      <i class="ri-settings-3-line"></i>
+      <span class="sr-only">Settings</span>
+    </button>
+  </h1>
 {{else}}
-  <h1>Invalid Search</h1>
+  <h1 id="content">
+    Invalid Search
+    <button class="settings display-settings">
+      <i class="ri-settings-3-line"></i>
+      <span class="sr-only">Settings</span>
+    </button>
+  </h1>
 {{/if}}
 
 {{#isNonEmptyArray results}}

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -280,7 +280,8 @@ defmodule ExDoc.Formatter.HTML.Templates do
     sidebar_template: [:config, :nodes_map],
     summary_template: [:name, :nodes],
     redirect_template: [:config, :redirect_to],
-    bottom_actions_template: [:refs]
+    bottom_actions_template: [:refs],
+    settings_button_template: []
   ]
 
   Enum.each(templates, fn {name, args} ->

--- a/lib/ex_doc/formatter/html/templates/extra_template.eex
+++ b/lib/ex_doc/formatter/html/templates/extra_template.eex
@@ -3,10 +3,7 @@
 
 <h1 id="content">
   <%= node.title_content %>
-  <button class="settings display-settings">
-    <i class="ri-settings-3-line"></i>
-    <span class="sr-only">Settings</span>
-  </button>
+  <%= settings_button_template() %>
   <%= if node.source_url do %>
     <a href="<%= node.source_url %>" title="View Source" class="view-source" rel="help">
       <i class="ri-code-s-slash-line" aria-hidden="true"></i>

--- a/lib/ex_doc/formatter/html/templates/module_template.eex
+++ b/lib/ex_doc/formatter/html/templates/module_template.eex
@@ -4,10 +4,7 @@
 <h1>
   <span translate="no"><%= module.title %></span> <%= module_type(module) %>
   <small class="app-vsn" translate="no">(<%= config.project %> v<%= config.version %>)</small>
-  <button class="settings display-settings">
-    <i class="ri-settings-3-line"></i>
-    <span class="sr-only">Settings</span>
-  </button>
+  <%= settings_button_template() %>
   <%= if module.source_url do %>
     <a href="<%= module.source_url %>" title="View Source" class="view-source" rel="help">
       <i class="ri-code-s-slash-line" aria-hidden="true"></i>

--- a/lib/ex_doc/formatter/html/templates/not_found_template.eex
+++ b/lib/ex_doc/formatter/html/templates/not_found_template.eex
@@ -1,7 +1,10 @@
 <%= head_template(config, %{title: "404", type: :extra}) %>
 <%= sidebar_template(config, nodes_map) %>
 
-<h2>Page not found</h2>
+<h1 id="content">
+  Page not found
+  <%= settings_button_template() %>
+</h1>
 
 <p>Sorry, but the page you were trying to get to, does not exist. You
 may want to try searching this site using the sidebar

--- a/lib/ex_doc/formatter/html/templates/search_template.eex
+++ b/lib/ex_doc/formatter/html/templates/search_template.eex
@@ -1,7 +1,11 @@
 <%= head_template(config, %{title: "Search", type: :search}) %>
 <%= sidebar_template(config, nodes_map) %>
 <div id="search">
-  <h1>Search</h1>
+  <h1 id="content">
+    Page not found
+    <%= settings_button_template() %>
+  </h1>
+
   <div class="loading"><div></div><div></div><div></div><div></div></div>
 </div>
 <script src="<%= asset_rev config.output, "dist/search_items*.js" %>"></script>

--- a/lib/ex_doc/formatter/html/templates/settings_button_template.eex
+++ b/lib/ex_doc/formatter/html/templates/settings_button_template.eex
@@ -1,0 +1,4 @@
+<button class="settings display-settings">
+    <i class="ri-settings-3-line"></i>
+    <span class="sr-only">Settings</span>
+</button>


### PR DESCRIPTION
This adds the settings button on all pages, I'm not sure if this is the best approach since the button is defined in both `settings_button_template.eex` and `search-results.handlebars`.