### PR TITLE
Add case insensitive quick switch search match

### DIFF
--- a/assets/js/quick-switch.js
+++ b/assets/js/quick-switch.js
@@ -44,9 +44,9 @@ function addEventListeners () {
 }
 
 function handleKeyDown (event) {
-  const packageSlug = event.target.value
-
   if (event.key === 'Enter') {
+    const packageSlug = event.target.value
+
     quickSwitchToPackage(packageSlug)
     event.preventDefault()
   } else if (event.key === 'ArrowUp') {
@@ -109,7 +109,7 @@ function quickSwitchToPackage (packageSlug) {
  * @param {String} packageSlug The package name to navigate to
  */
 function navigateToHexDocPackage (packageSlug) {
-  window.location = HEX_DOCS_ENDPOINT.replace('%%', packageSlug)
+  window.location = HEX_DOCS_ENDPOINT.replace('%%', packageSlug.toLowerCase())
 }
 
 const debouncedQueryForAutocomplete = debounce(queryForAutocomplete, DEBOUNCE_KEYPRESS_TIMEOUT)
@@ -161,7 +161,7 @@ function renderResults ({ results }) {
 function resultsFromPayload (packageSlug, payload) {
   return STATIC_SEARCH_RESULTS
     .concat(payload)
-    .filter(result => result.name.includes(packageSlug))
+    .filter(result => result.name.toLowerCase().includes(packageSlug.toLowerCase()))
     .filter(result => result.releases === undefined || result.releases[0]['has_docs'] === true)
     .slice(0, NUMBER_OF_SUGGESTIONS)
 }


### PR DESCRIPTION
If we search for `Ecto` in the global search, `hex.pm` returns packages that matches `ecto`. The JavaScript filtering should also show those packages.

I also made an assumption that all `hex.pm` packages are lowercase so when you search `Ecto` and press `Enter`, it now redirects to [`https://hex.pm/ecto`](https://hexdocs.pm/ecto/) instead of a `404` error for https://hexdocs.pm/Ecto.