### PR TITLE
Remove background from sidebar header

### DIFF
--- a/assets/less/sidebar.less
+++ b/assets/less/sidebar.less
@@ -37,8 +37,6 @@
 
   .sidebar-header {
     margin: 12px;
-    border-radius: 4px;
-    background-color: @bgMediumGray;
   }
 
   .sidebar-projectDetails {
@@ -52,7 +50,6 @@
     display: inline-block;
     max-width: 48px;
     max-height: 48px;
-    margin: 0 0 0 10px;
     vertical-align: bottom;
   }
 


### PR DESCRIPTION
This PR removes the background from the sidebar "header". Previously the header section had the same background color as the search field above.

Removing the background makes the design cleaner and removes potential confusion from using the same color as background for a container element and for an interactive search field.

## Updated design
![Screenshot 2022-01-13 at 21-42-05 Naming Conventions — Elixir v1 14 0-dev](https://user-images.githubusercontent.com/7488303/149406538-b27760ad-e832-43e3-9455-ef3b935aae91.png)

## Before
![Screenshot 2022-01-13 at 21-42-34 Naming Conventions — Elixir v1 14 0-dev](https://user-images.githubusercontent.com/7488303/149406527-42324167-1413-4441-bccb-44414b5ab410.png)