### PR TITLE
Slightly lower contrast of headings in night mode

### DIFF
--- a/assets/less/variables/common.less
+++ b/assets/less/variables/common.less
@@ -22,7 +22,7 @@
 @nightCodeBackground: #0D1829; // gray 800
 @nightCodeBorder: #304254; // gray 600
 @nightTextBody: #CAD5E0; // gray 200
-@nightTextHeaders: #F0F5F9; // gray 50
+@nightTextHeaders: #DCE1E6; // gray 100
 @nightHeader: #0D1829; // gray 800
 @nightDeprecated: #333019;
 


### PR DESCRIPTION
This PR slightly lowers contrast on headings in night mode.

P.S.: Some of the colors in the less file are annotated (i.e. `gray 200`) but it’s not obvious where these names come from. `gray 100` in this PR is an interpolation.

## 
![Screenshot 2022-01-13 at 21-58-49 ExDoc — ExDoc v0 27 2](https://user-images.githubusercontent.com/7488303/149408757-4247e3e3-811a-45d7-96da-0b747c9a1a1a.png)
Updated

## Previous
![Screenshot 2022-01-13 at 21-58-25 ExDoc — ExDoc v0 27 2](https://user-images.githubusercontent.com/7488303/149408765-fdd7b2c9-c02b-4505-93bd-02be3cf93865.png)

