### PR TITLE
Add custom scrollbar for sidebar

### DIFF
--- a/assets/less/sidebar.less
+++ b/assets/less/sidebar.less
@@ -5,6 +5,7 @@
   background: @darkGray;
   color: @lightestGray;
   overflow: hidden;
+  scrollbar-color: @mediumGray @darkGray;
 
   .gradient {
     background: linear-gradient(fade(@darkGray, 100%), fade(@darkGray, 0%));
@@ -399,6 +400,24 @@
         }
       }
     }
+  }
+
+  ::-webkit-scrollbar {
+    width: 14px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background-color: @darkGray;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: @mediumGray;
+    border-radius: 10px;
+    border: 3px solid @darkGray;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background: @lightGray;
   }
 }
 

--- a/assets/less/sidebar.less
+++ b/assets/less/sidebar.less
@@ -415,10 +415,6 @@
     border-radius: 10px;
     border: 3px solid @darkGray;
   }
-
-  ::-webkit-scrollbar-thumb:hover {
-    background: @lightGray;
-  }
 }
 
 .sidebar-button {


### PR DESCRIPTION
Added a custom scrollbar to the sidebar as mentioned in #1480 .

I tried to avoid adding new colors and used the existing ones, but I am not sure if the hover color in Chrome is the best choice.
Since Firefox doesn't support changing the color on hover, it maybe would be better to make it static in Chrome as well?

Firefox:

<img width="424" alt="Screenshot 2022-01-14 at 14 43 01" src="https://user-images.githubusercontent.com/792046/149525207-b5d627e6-88b6-45c2-aa39-3a0e09ad16a3.png">

Chrome:

Normal:
<img width="389" alt="Screenshot 2022-01-14 at 14 43 27" src="https://user-images.githubusercontent.com/792046/149525253-c7ba4893-741e-4b1e-a9d3-bf5bc8d7f9ee.png">

Hovered:
<img width="519" alt="Screenshot 2022-01-14 at 14 43 39" src="https://user-images.githubusercontent.com/792046/149525264-f1c9dc4a-85de-4475-aae1-ab4d32f38be1.png">

