### PR TITLE
Add missing margin for headers

### DIFF
--- a/assets/less/content/general.less
+++ b/assets/less/content/general.less
@@ -161,7 +161,12 @@ td, th {
   }
 }
 
-.detail h2.section-heading {
+.detail h1.section-heading,
+.detail h2.section-heading,
+.detail h3.section-heading,
+.detail h4.section-heading,
+.detail h5.section-heading,
+.detail h6.section-heading {
   margin-left: 0.3em;
 }
 


### PR DESCRIPTION
3rd level headers (are not properly aligned) with the text. The change adds missing left margin.
Example: https://hexdocs.pm/elixir/1.13.2/Kernel.SpecialForms.html#%3C%3C%3E%3E/1-options (compare "Options" and "Unit and Size")

<img width="717" alt="Screenshot 2022-01-19 at 10 10 17" src="https://user-images.githubusercontent.com/8614029/150099505-cf6897f3-320f-40e1-a0de-c23bbab699ce.png">
