### PR TITLE
Fix `mix docs --open` on Windows

### DIFF
--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -481,7 +481,7 @@ defmodule Mix.Tasks.Docs do
   defp browser_open(url) do
     {cmd, args} =
       case :os.type() do
-        {:win32, _} -> {"cmd", ["/c", "start", url]}
+        {:win32, _} -> {"cmd", ["/c", "start", "", url]}
         {:unix, :darwin} -> {"open", [url]}
         {:unix, _} -> {"xdg-open", [url]}
       end


### PR DESCRIPTION
If start.exe is given multiple arguments, the first argument is the
window title. If the path contains spaces, e.g.
`c:/Users/John Doe/foo/index`, the stuff before the space would be
incorrectly interpreted as the window title.
