### PR TITLE
Accessibility - general improvement 

### DIFF
--- a/assets/js/copy-button.js
+++ b/assets/js/copy-button.js
@@ -1,6 +1,6 @@
 import { qsAll } from './helpers'
 
-const BUTTON = `<button class="copy-button"><svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="currentColor"><path d="M0 0h24v24H0z" fill="none"/><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg></button>`
+const BUTTON = `<button class="copy-button" aria-label="copy"><svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="currentColor"><path d="M0 0h24v24H0z" fill="none"/><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg></button>`
 
 /**
  * Initializes copy buttons.

--- a/assets/js/handlebars/templates/settings-modal-body.handlebars
+++ b/assets/js/handlebars/templates/settings-modal-body.handlebars
@@ -30,7 +30,7 @@
         <div class="switch-button__bg"></div>
       </div>
     </label>
-    <input class="input" type="url" name="livebook_url" placeholder="Enter Livebook instance URL" />
+    <input class="input" type="url" name="livebook_url" placeholder="Enter Livebook instance URL" aria-label="Enter Livebook instance URL" />
   </div>
    <div id="keyboard-shortcuts" class="hidden">
      {{#each shortcuts}}

--- a/assets/less/content/bottom-actions.less
+++ b/assets/less/content/bottom-actions.less
@@ -14,7 +14,7 @@
 
     .subheader {
       font-size: 0.8em;
-      color: @main;
+      color: darken(@main, 10%);
       white-space: nowrap;
     }
 

--- a/assets/less/content/code.less
+++ b/assets/less/content/code.less
@@ -1,6 +1,6 @@
 a.no-underline,
 pre a {
-  color: @main;
+  color: darken(@main, 10%);
   text-shadow: none;
   text-decoration: none;
   background-image: none;
@@ -9,7 +9,7 @@ pre a {
   &:active,
   &:focus,
   &:hover {
-    color: @main;
+    color: darken(@main, 20%);
     text-decoration: none;
   }
 }

--- a/assets/less/makeup.less
+++ b/assets/less/makeup.less
@@ -10,7 +10,7 @@ code.makeup {
 }
 
 @default-text-color: #4d4d4c;
-@comment-color: #737373;
+@comment-color: #4D4D4D;
 @string-color: #408200;
 /* Originally taken from https://tmbb.github.io/makeup_demo/elixir.html#tango */
 .makeup {

--- a/assets/less/night/content/bottom-actions.less
+++ b/assets/less/night/content/bottom-actions.less
@@ -1,5 +1,9 @@
 .bottom-actions {
   .bottom-actions-button {
     border: 1px solid rgba(255, 255, 255, 0.1);
+    
+    .subheader {
+      color: @main;
+    }
   }
 }

--- a/assets/less/night/content/footer.less
+++ b/assets/less/night/content/footer.less
@@ -1,13 +1,13 @@
 .footer {
-  color: @nightMediumGray;
+  color: @lightGray;
 
   .footer-button {
-    color: @nightMediumGray;
-    .linkUnderlines(@nightMediumGray)
+    color: @lightGray;
+    .linkUnderlines(@lightGray)
   }
 
   a {
-    color: @nightMediumGray;
-    .linkUnderlines(@nightMediumGray)
+    color: @lightGray;
+    .linkUnderlines(@lightGray)
   }
 }

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -253,7 +253,9 @@ defmodule ExDoc.Formatter.HTML.Templates do
   defp link_heading(_match, tag, title, id, prefix) do
     """
     <#{tag} id="#{prefix}#{id}" class="section-heading">
-      <a href="##{prefix}#{id}" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i></a>
+      <a href="##{prefix}#{id}" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i>
+      <p class="sr-only">#{id}</p>
+      </a>
       #{title}
     </#{tag}>
     """

--- a/lib/ex_doc/formatter/html/templates/sidebar_template.eex
+++ b/lib/ex_doc/formatter/html/templates/sidebar_template.eex
@@ -2,7 +2,7 @@
 
 
 <section class="sidebar">
-  <button class="sidebar-button sidebar-toggle">
+  <button class="sidebar-button sidebar-toggle" aria-label="toggle sidebar">
     <i class="ri-menu-line ri-lg" title="Collapse/expand sidebar"></i>
   </button>
 
@@ -14,6 +14,7 @@
       <i class="ri-close-line ri-lg" aria-hidden="true" title="Cancel search"></i>
     </button>
     <label class="search-label">
+      <p class="sr-only">Search</p>
       <input name="q" type="text" class="search-input" placeholder="Search..." aria-label="Input your search terms" autocomplete="off" />
     </label>
   </form>

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -46,30 +46,40 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
     test "generates headers with hovers" do
       assert Templates.link_headings("<h2>Foo</h2><h2>Bar</h2>") == """
              <h2 id="foo" class="section-heading">
-               <a href="#foo" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i></a>
+               <a href="#foo" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i>
+               <p class="sr-only">foo</p>
+               </a>
                Foo
              </h2>
              <h2 id="bar" class="section-heading">
-               <a href="#bar" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i></a>
+               <a href="#bar" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i>
+               <p class="sr-only">bar</p>
+               </a>
                Bar
              </h2>
              """
 
       assert Templates.link_headings("<h2>Foo</h2>\n<h2>Bar</h2>") == """
              <h2 id="foo" class="section-heading">
-               <a href="#foo" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i></a>
+               <a href="#foo" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i>
+               <p class="sr-only">foo</p>
+               </a>
                Foo
              </h2>
 
              <h2 id="bar" class="section-heading">
-               <a href="#bar" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i></a>
+               <a href="#bar" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i>
+               <p class="sr-only">bar</p>
+               </a>
                Bar
              </h2>
              """
 
       assert Templates.link_headings("<h2></h2><h2>Bar</h2>") == """
              <h2></h2><h2 id="bar" class="section-heading">
-               <a href="#bar" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i></a>
+               <a href="#bar" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i>
+               <p class="sr-only">bar</p>
+               </a>
                Bar
              </h2>
              """
@@ -77,7 +87,9 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       assert Templates.link_headings("<h2></h2>\n<h2>Bar</h2>") == """
              <h2></h2>
              <h2 id="bar" class="section-heading">
-               <a href="#bar" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i></a>
+               <a href="#bar" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i>
+               <p class="sr-only">bar</p>
+               </a>
                Bar
              </h2>
              """
@@ -85,7 +97,9 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       assert Templates.link_headings("<h2>Foo</h2><h2></h2>") ==
                String.trim_trailing("""
                <h2 id="foo" class="section-heading">
-                 <a href="#foo" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i></a>
+                 <a href="#foo" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i>
+                 <p class="sr-only">foo</p>
+                 </a>
                  Foo
                </h2>
                <h2></h2>
@@ -94,7 +108,9 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       assert Templates.link_headings("<h2>Foo</h2>\n<h2></h2>") ==
                String.trim_trailing("""
                <h2 id="foo" class="section-heading">
-                 <a href="#foo" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i></a>
+                 <a href="#foo" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i>
+                 <p class="sr-only">foo</p>
+                 </a>
                  Foo
                </h2>
 
@@ -103,7 +119,9 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
 
       assert Templates.link_headings("<h3>Foo</h3>") == """
              <h3 id="foo" class="section-heading">
-               <a href="#foo" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i></a>
+               <a href="#foo" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i>
+               <p class="sr-only">foo</p>
+               </a>
                Foo
              </h3>
              """
@@ -112,12 +130,16 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
     test "generates headers with unique id's" do
       assert Templates.link_headings("<h3>Foo</h3>\n<h3>Foo</h3>") == """
              <h3 id="foo" class="section-heading">
-               <a href="#foo" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i></a>
+               <a href="#foo" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i>
+               <p class="sr-only">foo</p>
+               </a>
                Foo
              </h3>
 
              <h3 id="foo-1" class="section-heading">
-               <a href="#foo-1" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i></a>
+               <a href="#foo-1" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i>
+               <p class="sr-only">foo-1</p>
+               </a>
                Foo
              </h3>
              """

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -326,10 +326,10 @@ defmodule ExDoc.Formatter.HTMLTest do
       assert content =~ ~r{<title>README [^<]*</title>}
 
       assert content =~
-               ~r{<h2 id="header-sample" class="section-heading">.*<a href="#header-sample" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i></a>.*<code(\sclass="inline")?>Header</code> sample.*</h2>}ms
+               ~r{<h2 id="header-sample" class="section-heading">.*<a href="#header-sample" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i>.*<p class="sr-only">header-sample</p>.*</a>.*<code(\sclass="inline")?>Header</code> sample.*</h2>}ms
 
       assert content =~
-               ~r{<h2 id="more-than" class="section-heading">.*<a href="#more-than" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i></a>.*more &gt; than.*</h2>}ms
+               ~r{<h2 id="more-than" class="section-heading">.*<a href="#more-than" class="hover-link"><i class="ri-link-m" aria-hidden="true"></i>.*<p class="sr-only">more-than</p>.*</a>.*more &gt; than.*</h2>}ms
 
       assert content =~ ~r{<a href="RandomError.html"><code(\sclass="inline")?>RandomError</code>}
 


### PR DESCRIPTION
This PR solves some accessibility issues without modifying any behavior and with minor visual changes.

Light theme - More contrast for inline links and light grays

<img width="858" alt="CleanShot 2022-02-03 at 17 29 37@2x" src="https://user-images.githubusercontent.com/5660941/152424245-b255a33e-7018-47b6-b0a4-fef2c453ae80.png">
<img width="858" alt="CleanShot 2022-02-03 at 17 30 11@2x" src="https://user-images.githubusercontent.com/5660941/152424257-5b4a664e-96a5-4d4d-b4f7-a1c1b3e2cf0c.png">


Dark theme - More contrast for footer text

<img width="867" alt="CleanShot 2022-02-03 at 17 32 42@2x" src="https://user-images.githubusercontent.com/5660941/152424372-28764693-cd3b-4146-bde7-5e0e95d05d14.png">
<img width="867" alt="CleanShot 2022-02-03 at 17 32 53@2x" src="https://user-images.githubusercontent.com/5660941/152424378-e083eeaa-863c-4017-90aa-34cc91fb190c.png">


