### PR TITLE
Fix module hint heading extraction

### DIFF
--- a/assets/js/tooltips/hints.js
+++ b/assets/js/tooltips/hints.js
@@ -170,7 +170,7 @@ export function extractFunctionHint (element) {
  * @returns {Hint}
  */
 export function extractModuleHint (content) {
-  let heading = content.querySelector('h1 span')
+  let heading = content.querySelector('h1 > span')
   const title = heading.textContent
 
   const firstParagraph = content.querySelector('#moduledoc p')

--- a/assets/test/tooltips/hints.spec.js
+++ b/assets/test/tooltips/hints.spec.js
@@ -5,12 +5,17 @@ describe('hints extraction', () => {
     const modulePageObject = parseHTML(`
       <div>
         <h1>
-          <span>Some module</span> <small class="app-vsn">(ExDoc v0.0.1)</small>
+          <button class="settings display-settings">
+            <i class="ri-settings-3-line"></i>
+            <span class="sr-only">Settings</span>
+          </button>
 
           <a href="https://github.com/" title="View Source" class="view-source" rel="help">
             <i class="ri-code-s-slash-line" aria-hidden="true"></i>
             <span class="sr-only">View Source</span>
           </a>
+
+          <span>Some module</span> <small class="app-vsn">(ExDoc v0.0.1)</small>
         </h1>
         <section id="moduledoc">
           <p>


### PR DESCRIPTION
ExDoc puts the `<button>` for settings and the `<a>` to view source in front of the `<span>` containing the actual module name:

```html
<h1>
  <button class="settings display-settings">
    <i class="ri-settings-3-line"></i>
    <span class="sr-only">Settings</span>
  </button>

  <a href="https://github.com/elixir-lang/elixir/blob/v1.13.2/lib/elixir/lib/gen_server.ex#L1" title="View Source" class="view-source" rel="help">
    <i class="ri-code-s-slash-line" aria-hidden="true"></i>
    <span class="sr-only">View Source</span>
  </a>

  <span translate="no">GenServer</span> <small>behaviour</small>
  <small class="app-vsn" translate="no">(Elixir v1.13.2)</small>
</h1>
```

This resulted in a wrong heading for the tooltips. I changed the selector to `'h1 > span'` so it doesn't look into the `<a>` and `<button>` anymore.

## Before
![before](https://user-images.githubusercontent.com/379915/153240283-bddb59e3-fe0e-4641-b615-3b3768433dae.png)

## After
![after](https://user-images.githubusercontent.com/379915/153240334-1452d505-632f-4748-8ca8-3a27fb3344c1.png)

