### PR TITLE
Add padding at top to #targets

### DIFF
--- a/assets/less/content/functions.less
+++ b/assets/less/content/functions.less
@@ -9,6 +9,8 @@
 }
 
 .detail {
+  padding-top: 1.0em;
+
   &:target .detail-header {
     animation-duration: 0.55s;
     animation-name: blink-background;
@@ -18,7 +20,7 @@
 }
 
 .detail-header {
-  margin: 2.0em 0 1.0em;
+  margin: 1.0em 0 1.0em;
   padding: 0.5em 1em;
   background: @detailGray;
   border-left: 3px solid @main;


### PR DESCRIPTION
This should theoretically add a padding at top to the function #targets.
I find it uncommon to start reading at top without a padding after using #links.

But I could not test it jet. Windows does not load the webpack.js...

PS: To test this within ex_doc you'll need to have a really small window (pages are to short).