### PR TITLE
Add tokenizer to search pipeline

### DIFF
--- a/assets/js/search-page.js
+++ b/assets/js/search-page.js
@@ -129,6 +129,7 @@ function elixirTokenSplitter (builder) {
 
   lunr.Pipeline.registerFunction(elixirTokenFunction, 'elixirTokenSplitter')
   builder.pipeline.before(lunr.stemmer, elixirTokenFunction)
+  builder.searchPipeline.before(lunr.stemmer, elixirTokenFunction)
 }
 
 function searchResultsToDecoratedSearchNodes (results) {


### PR DESCRIPTION
Fixes underscore search by adding the `elixirTokenFunction` to the `searchPipeline` so search terms are processed before querying the index. Although this will also matches on tokens without an underscore, so `assert_` will also match `assert`, I'm not sure if this is ideal, but it seems like the best option I could find.

Ref: #1490