### PR TITLE
support for `source_url_pattern` in config being a function

### DIFF
--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -2,7 +2,7 @@ defmodule ExDoc.Formatter.HTML do
   @moduledoc false
 
   alias __MODULE__.{Assets, Templates, SearchItems}
-  alias ExDoc.{Markdown, GroupMatcher, Retriever}
+  alias ExDoc.{Markdown, GroupMatcher, Utils}
 
   @main "api-reference"
   @assets_dir "assets"
@@ -387,7 +387,7 @@ defmodule ExDoc.Formatter.HTML do
 
     source_path = input |> Path.relative_to(File.cwd!()) |> String.replace_leading("./", "")
 
-    source_url = Retriever.source_url_pattern(source_url_pattern, source_path, "1")
+    source_url = Utils.source_url_pattern(source_url_pattern, source_path, "1")
 
     %{
       id: id,

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -2,7 +2,7 @@ defmodule ExDoc.Formatter.HTML do
   @moduledoc false
 
   alias __MODULE__.{Assets, Templates, SearchItems}
-  alias ExDoc.{Markdown, GroupMatcher}
+  alias ExDoc.{Markdown, GroupMatcher, Retriever}
 
   @main "api-reference"
   @assets_dir "assets"
@@ -387,12 +387,7 @@ defmodule ExDoc.Formatter.HTML do
 
     source_path = input |> Path.relative_to(File.cwd!()) |> String.replace_leading("./", "")
 
-    source_url =
-      if url = source_url_pattern do
-        url
-        |> String.replace("%{path}", source_path)
-        |> String.replace("%{line}", "1")
-      end
+    source_url = Retriever.source_url_pattern(source_url_pattern, source_path, "1")
 
     %{
       id: id,

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -7,7 +7,7 @@ defmodule ExDoc.Retriever do
     defexception [:message]
   end
 
-  alias ExDoc.{DocAST, GroupMatcher, Refs}
+  alias ExDoc.{DocAST, GroupMatcher, Refs, Utils}
   alias ExDoc.Retriever.Error
 
   @doc """
@@ -330,19 +330,7 @@ defmodule ExDoc.Retriever do
   defp source_link(%{path: _, url: nil}, _line), do: nil
 
   defp source_link(source, line) do
-    source_url_pattern(source.url, source.path, to_string(line))
-  end
-
-  def source_url_pattern(source_url_pattern, path, line) do
-    if is_function(source_url_pattern) do
-      source_url_pattern.(path, line)
-    else
-      if url = source_url_pattern do
-        url
-        |> String.replace("%{path}", path)
-        |> String.replace("%{line}", line)
-      end
-    end
+    Utils.source_url_pattern(source.url, source.path, to_string(line))
   end
 
   defp source_path(module, _config) do

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -330,8 +330,19 @@ defmodule ExDoc.Retriever do
   defp source_link(%{path: _, url: nil}, _line), do: nil
 
   defp source_link(source, line) do
-    source_url = Regex.replace(~r/%{path}/, source.url, source.path)
-    Regex.replace(~r/%{line}/, source_url, to_string(line))
+    source_url_pattern(source.url, source.path, to_string(line))
+  end
+
+  def source_url_pattern(source_url_pattern, path, line) do
+    if is_function(source_url_pattern) do
+      source_url_pattern.(path, line)
+    else
+      if url = source_url_pattern do
+        url
+        |> String.replace("%{path}", path)
+        |> String.replace("%{line}", line)
+      end
+    end
   end
 
   defp source_path(module, _config) do

--- a/lib/ex_doc/utils.ex
+++ b/lib/ex_doc/utils.ex
@@ -90,4 +90,16 @@ defmodule ExDoc.Utils do
   def to_json(integer) when is_integer(integer) do
     Integer.to_string(integer)
   end
+
+  def source_url_pattern(source_url_pattern, path, line) do
+    if is_function(source_url_pattern) do
+      source_url_pattern.(path, line)
+    else
+      if url = source_url_pattern do
+        url
+        |> String.replace("%{path}", path)
+        |> String.replace("%{line}", line)
+      end
+    end
+  end
 end

--- a/test/ex_doc/retriever/source_pattern_test.exs
+++ b/test/ex_doc/retriever/source_pattern_test.exs
@@ -1,0 +1,34 @@
+defmodule ExDoc.Retriever.SourcePatternTest do
+  use ExUnit.Case, async: true
+  alias ExDoc.Retriever
+  import TestHelper
+
+  @moduletag :tmp_dir
+
+  def source_url_fn_1(path, line), do: "%{path}:%{line}" |> String.replace("%{path}", path) |> String.replace("%{line}", line)
+  def source_url_fn_2(path, line), do: "%{path}-%{line}" |> String.replace("%{path}", path) |> String.replace("%{line}", line)
+
+
+  describe "docs_from_modules/2" do
+
+    test "callbacks with source_url_pattern as function", c do
+      elixirc(c, ~S"""
+      defmodule ModSource do
+        @doc "Sample docs."
+        @callback callback1() :: :ok
+      end
+      """)
+
+      config = %ExDoc.Config{source_url_pattern: &source_url_fn_1/2}
+      [mod] = Retriever.docs_from_modules([ModSource], config)
+      [callback1] = mod.docs
+      assert Path.basename(callback1.source_url) == "nofile:3"
+
+      config = %ExDoc.Config{source_url_pattern: &source_url_fn_2/2}
+      [mod] = Retriever.docs_from_modules([ModSource], config)
+      [callback1] = mod.docs
+      assert Path.basename(callback1.source_url) == "nofile-3"
+
+    end
+  end
+end

--- a/test/ex_doc/retriever/source_pattern_test.exs
+++ b/test/ex_doc/retriever/source_pattern_test.exs
@@ -5,12 +5,13 @@ defmodule ExDoc.Retriever.SourcePatternTest do
 
   @moduletag :tmp_dir
 
-  def source_url_fn_1(path, line), do: "%{path}:%{line}" |> String.replace("%{path}", path) |> String.replace("%{line}", line)
-  def source_url_fn_2(path, line), do: "%{path}-%{line}" |> String.replace("%{path}", path) |> String.replace("%{line}", line)
+  def source_url_fn_1(path, line),
+    do: "%{path}:%{line}" |> String.replace("%{path}", path) |> String.replace("%{line}", line)
 
+  def source_url_fn_2(path, line),
+    do: "%{path}-%{line}" |> String.replace("%{path}", path) |> String.replace("%{line}", line)
 
   describe "docs_from_modules/2" do
-
     test "callbacks with source_url_pattern as function", c do
       elixirc(c, ~S"""
       defmodule ModSource do
@@ -28,7 +29,6 @@ defmodule ExDoc.Retriever.SourcePatternTest do
       [mod] = Retriever.docs_from_modules([ModSource], config)
       [callback1] = mod.docs
       assert Path.basename(callback1.source_url) == "nofile-3"
-
     end
   end
 end


### PR DESCRIPTION
👋 Having a use case of generating one set of docs for a project + some of its dependencies, this allows providing a function instead of a single pattern, so we can link to the source within each dep's repo.

Always open to suggestions about how else I could go about this...