### PR TITLE
fix sorting when a list of dirs was provided

### DIFF
--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -17,10 +17,12 @@ defmodule ExDoc.Retriever do
   def docs_from_dir(dir, config) when is_binary(dir) do
     files = Path.wildcard(Path.expand("*.beam", dir))
     docs_from_files(files, config)
+    |> docs_from_modules(config)
   end
 
   def docs_from_dir(dirs, config) when is_list(dirs) do
     Enum.flat_map(dirs, &docs_from_dir(&1, config))
+    |> docs_from_modules(config)
   end
 
   @doc """
@@ -30,7 +32,6 @@ defmodule ExDoc.Retriever do
   def docs_from_files(files, config) when is_list(files) do
     files
     |> Enum.map(&filename_to_module(&1))
-    |> docs_from_modules(config)
   end
 
   @doc """
@@ -41,8 +42,12 @@ defmodule ExDoc.Retriever do
     modules
     |> Enum.flat_map(&get_module(&1, config))
     |> Enum.sort_by(fn module ->
-      {GroupMatcher.group_index(config.groups_for_modules, module.group), module.nested_context,
-       module.nested_title, module.id}
+      {
+        GroupMatcher.group_index(config.groups_for_modules, module.group),
+        module.nested_context,
+        module.nested_title,
+        module.id
+      }
     end)
   end
 

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -16,6 +16,7 @@ defmodule ExDoc.Retriever do
   @spec docs_from_dir(Path.t() | [Path.t()], ExDoc.Config.t()) :: [ExDoc.ModuleNode.t()]
   def docs_from_dir(dir, config) when is_binary(dir) do
     files = Path.wildcard(Path.expand("*.beam", dir))
+
     docs_from_files(files, config)
     |> docs_from_modules(config)
   end

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -22,14 +22,14 @@ defmodule ExDoc.Retriever do
 
   def docs_from_dir(dirs, config) when is_list(dirs) do
     Enum.flat_map(dirs, &docs_from_dir(&1, config))
-    |> docs_from_modules(config)
+    |> sort_modules(config)
   end
 
   @doc """
   Extract documentation from all modules in the specified list of files
   """
   @spec docs_from_files([Path.t()], ExDoc.Config.t()) :: [ExDoc.ModuleNode.t()]
-  def docs_from_files(files, config) when is_list(files) do
+  def docs_from_files(files, _config) when is_list(files) do
     files
     |> Enum.map(&filename_to_module(&1))
   end
@@ -41,6 +41,11 @@ defmodule ExDoc.Retriever do
   def docs_from_modules(modules, config) when is_list(modules) do
     modules
     |> Enum.flat_map(&get_module(&1, config))
+    |> sort_modules(config)
+  end
+
+  defp sort_modules(modules, config) when is_list(modules) do
+    modules
     |> Enum.sort_by(fn module ->
       {
         GroupMatcher.group_index(config.groups_for_modules, module.group),

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -45,14 +45,9 @@ defmodule ExDoc.Retriever do
   end
 
   defp sort_modules(modules, config) when is_list(modules) do
-    modules
-    |> Enum.sort_by(fn module ->
-      {
-        GroupMatcher.group_index(config.groups_for_modules, module.group),
-        module.nested_context,
-        module.nested_title,
-        module.id
-      }
+    Enum.sort_by(modules, fn module ->
+      {GroupMatcher.group_index(config.groups_for_modules, module.group), module.nested_context,
+       module.nested_title, module.id}
     end)
   end
 


### PR DESCRIPTION
When generating docs for a list of paths rather than a single one, sorting was being done per-path rather than over the entire list of modules to include.