### PR TITLE
Show programming language in HTML footer

### DIFF
--- a/lib/ex_doc/formatter/html/templates/footer_template.eex
+++ b/lib/ex_doc/formatter/html/templates/footer_template.eex
@@ -23,9 +23,9 @@
           <a href="https://github.com/elixir-lang/ex_doc" title="ExDoc" target="_blank" rel="help noopener" translate="no">ExDoc</a> (v<%= ExDoc.version() %>) for the
           <%= if config.proglang == :erlang do %>
             <a href="https://erlang.org" title="Erlang" target="_blank" translate="no">Erlang programming language</a>
-            <% else %>
-              <a href="https://elixir-lang.org" title="Elixir" target="_blank" translate="no">Elixir programming language</a>
-            <% end %>
+          <% else %>
+            <a href="https://elixir-lang.org" title="Elixir" target="_blank" translate="no">Elixir programming language</a>
+          <% end %>
         </p>
       </footer>
     </div>

--- a/lib/ex_doc/formatter/html/templates/footer_template.eex
+++ b/lib/ex_doc/formatter/html/templates/footer_template.eex
@@ -21,7 +21,11 @@
         <p>
           Built using
           <a href="https://github.com/elixir-lang/ex_doc" title="ExDoc" target="_blank" rel="help noopener" translate="no">ExDoc</a> (v<%= ExDoc.version() %>) for the
-          <a href="https://elixir-lang.org" title="Elixir" target="_blank" translate="no">Elixir programming language</a>
+          <%= if config.proglang == :erlang do %>
+            <a href="https://erlang.org" title="Erlang" target="_blank" translate="no">Erlang programming language</a>
+            <% else %>
+              <a href="https://elixir-lang.org" title="Elixir" target="_blank" translate="no">Elixir programming language</a>
+            <% end %>
         </p>
       </footer>
     </div>

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -246,6 +246,21 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       refute content =~ ~r{<li><a id="tasks-list-link" href="#full-list">Mix Tasks</a></li>}
     end
 
+    test "display built with footer by proglang option" do
+      content = Templates.footer_template(doc_config(proglang: :erlang), nil)
+
+      assert content =~
+               ~r{<a href="https://erlang.org" title="Erlang" target="_blank" translate="no">Erlang programming language</a>}
+
+      content = Templates.footer_template(doc_config(proglang: :elixir), nil)
+
+      assert content =~
+               ~r{<a href="https://elixir-lang.org" title="Elixir" target="_blank" translate="no">Elixir programming language</a>}
+
+      assert Templates.footer_template(doc_config(proglang: :elixir), nil) ==
+               Templates.footer_template(doc_config(), nil)
+    end
+
     test "outputs listing for the given nodes" do
       names = [CompiledWithDocs, CompiledWithDocs.Nested]
       nodes = ExDoc.Retriever.docs_from_modules(names, doc_config())


### PR DESCRIPTION
Show the "Built with" footer by `:proglang` option.

Fix task in https://github.com/elixir-lang/ex_doc/issues/1333