### PR TITLE
Escape &%/2 special form

### DIFF
--- a/lib/ex_doc/language/elixir.ex
+++ b/lib/ex_doc/language/elixir.ex
@@ -627,9 +627,10 @@ defmodule ExDoc.Language.Elixir do
     end
   end
 
-  # There are two special forms that are forbidden by the tokenizer
+  # There are special forms that are forbidden by the tokenizer
   defp parse_function("__aliases__"), do: {:function, :__aliases__}
   defp parse_function("__block__"), do: {:function, :__block__}
+  defp parse_function("%"), do: {:function, :%}
 
   defp parse_function(string) do
     case Code.string_to_quoted("& #{string}/0") do

--- a/test/ex_doc/language/elixir_test.exs
+++ b/test/ex_doc/language/elixir_test.exs
@@ -160,6 +160,9 @@ defmodule ExDoc.Language.ElixirTest do
       assert autolink_doc("Kernel.SpecialForms.%{}/1") ==
                ~m"[`Kernel.SpecialForms.%{}/1`](https://hexdocs.pm/elixir/Kernel.SpecialForms.html#%25%7B%7D/1)"
 
+      assert autolink_doc("Kernel.SpecialForms.%/2") ==
+               ~m"[`Kernel.SpecialForms.%/2`](https://hexdocs.pm/elixir/Kernel.SpecialForms.html#%25/2)"
+
       assert autolink_doc("Kernel.SpecialForms.{}/1") ==
                ~m"[`Kernel.SpecialForms.{}/1`](https://hexdocs.pm/elixir/Kernel.SpecialForms.html#%7B%7D/1)"
 


### PR DESCRIPTION
I noticed that the link to `Kernel.SpecialForms.%/2` in [defstruct/1 doc](https://hexdocs.pm/elixir/Kernel.html#defstruct/1) was broken, this PR should fix it to point to https://hexdocs.pm/elixir/Kernel.SpecialForms.html#%25/2.