### PR TITLE
Add exception for functions called record/*

### DIFF
--- a/lib/ex_doc/language/erlang.ex
+++ b/lib/ex_doc/language/erlang.ex
@@ -460,7 +460,7 @@ defmodule ExDoc.Language.Erlang do
               arity = length(args)
 
               cond do
-                name in [:record] and acc != [] ->
+                name == :record and acc != [] ->
                   {ast, acc}
 
                 name in [:"::", :when, :%{}, :{}, :|, :->] ->

--- a/lib/ex_doc/language/erlang.ex
+++ b/lib/ex_doc/language/erlang.ex
@@ -460,7 +460,10 @@ defmodule ExDoc.Language.Erlang do
               arity = length(args)
 
               cond do
-                name in [:"::", :when, :%{}, :{}, :|, :->, :record] and acc != [] ->
+                name in [:record] and acc != [] ->
+                  {ast, acc}
+
+                name in [:"::", :when, :%{}, :{}, :|, :->] ->
                   {ast, acc}
 
                 # %{required(...) => ..., optional(...) => ...}

--- a/lib/ex_doc/language/erlang.ex
+++ b/lib/ex_doc/language/erlang.ex
@@ -460,7 +460,7 @@ defmodule ExDoc.Language.Erlang do
               arity = length(args)
 
               cond do
-                name in [:"::", :when, :%{}, :{}, :|, :->, :record] ->
+                name in [:"::", :when, :%{}, :{}, :|, :->, :record] and acc != [] ->
                   {ast, acc}
 
                 # %{required(...) => ..., optional(...) => ...}

--- a/test/ex_doc/language/erlang_test.exs
+++ b/test/ex_doc/language/erlang_test.exs
@@ -167,6 +167,11 @@ defmodule ExDoc.Language.ErlangTest do
                ~s|foo() -> <a href="#t:t/0">t</a>().|
     end
 
+    test "spec when fun is called record", c do
+      assert autolink_spec("-spec record(module()) -> [[{module(), atom()}]].", c) ==
+               ~s|record(module()) -> [[{module(), atom()}]].|
+    end
+
     test "callback", c do
       assert autolink_spec("-callback foo() -> t().", c) ==
                ~s|foo() -> <a href="#t:t/0">t</a>().|


### PR DESCRIPTION
Closes #1575 

This commit attempts to resolve a case where there are specs defined referring to a function called record/*