### PR TITLE
Fix loading serialized index from sessionStorage

### DIFF
--- a/assets/js/search-page.js
+++ b/assets/js/search-page.js
@@ -58,6 +58,7 @@ function loadIndex () {
   try {
     const serializedIndex = sessionStorage.getItem(indexStorageKey())
     if (serializedIndex) {
+      registerElixirTokenFunction()
       return lunr.Index.load(JSON.parse(serializedIndex))
     } else {
       return null
@@ -97,24 +98,28 @@ function createIndex () {
 }
 
 function elixirTokenSplitter (builder) {
-  function elixirTokenFunction (token) {
-    const tokens = token
-      .toString()
-      .split(/\.|\/|_/)
-      .map(part => {
-        return token.clone().update(() => part)
-      })
-
-    if (tokens.length > 1) {
-      return [...tokens, token]
-    }
-
-    return tokens
-  }
-
-  lunr.Pipeline.registerFunction(elixirTokenFunction, 'elixirTokenSplitter')
+  registerElixirTokenFunction()
   builder.pipeline.before(lunr.stemmer, elixirTokenFunction)
   builder.searchPipeline.before(lunr.stemmer, elixirTokenFunction)
+}
+
+function elixirTokenFunction (token) {
+  const tokens = token
+    .toString()
+    .split(/\.|\/|_/)
+    .map(part => {
+      return token.clone().update(() => part)
+    })
+
+  if (tokens.length > 1) {
+    return [...tokens, token]
+  }
+
+  return tokens
+}
+
+function registerElixirTokenFunction () {
+  return lunr.Pipeline.registerFunction(elixirTokenFunction, 'elixirTokenSplitter')
 }
 
 function searchResultsToDecoratedSearchNodes (results) {


### PR DESCRIPTION
I noticed that lunr throws an error when it tries to load the serialized index from the `sessionStorage`. This causes the index to be generated upon each new search entry, which can have a performance impact for large projects.

Lunr throws the error because `elixirTokenSplitter` added to the pipeline during the index creation but it isn't registered when the index is loaded from the `sessionStorage`.

The following error is thrown when searching:
```
Failed to load index:  Error: Cannot load unregistered function: elixirTokenSplitter
```
