### PR TITLE
Implement custom trimmer to index `@` in search

### DIFF
--- a/assets/js/search-page.js
+++ b/assets/js/search-page.js
@@ -59,6 +59,7 @@ function loadIndex () {
     const serializedIndex = sessionStorage.getItem(indexStorageKey())
     if (serializedIndex) {
       registerElixirTokenFunction()
+      registerElixirTrimmerFunction()
       return lunr.Index.load(JSON.parse(serializedIndex))
     } else {
       return null
@@ -90,6 +91,8 @@ function createIndex () {
     this.metadataWhitelist = ['position']
     this.pipeline.remove(lunr.stopWordFilter)
     this.use(elixirTokenSplitter)
+    this.pipeline.remove(lunr.trimmer)
+    this.use(elixirTrimmer)
 
     searchNodes.forEach(searchNode => {
       this.add(searchNode)
@@ -120,6 +123,22 @@ function elixirTokenFunction (token) {
 
 function registerElixirTokenFunction () {
   return lunr.Pipeline.registerFunction(elixirTokenFunction, 'elixirTokenSplitter')
+}
+
+function elixirTrimmer (builder) {
+  registerElixirTrimmerFunction()
+  builder.pipeline.after(lunr.stemmer, elixirTrimmerFunction)
+  builder.searchPipeline.after(lunr.stemmer, elixirTrimmerFunction)
+}
+
+function elixirTrimmerFunction (token) {
+  return token.update(function (s) {
+    return s.replace(/^@?\W+/, '').replace(/\W+$/, '')
+  })
+}
+
+function registerElixirTrimmerFunction () {
+  return lunr.Pipeline.registerFunction(elixirTrimmerFunction, 'elixirTrimmer')
 }
 
 function searchResultsToDecoratedSearchNodes (results) {


### PR DESCRIPTION
Replaces default trimmer with custom trimmer to allow `@` at the beginning of a word.

Example:

![image](https://user-images.githubusercontent.com/7502104/175780864-7a9f4ab5-a9b6-4988-96e7-2f1aeabc6a93.png)


Ref #1578 