### PR TITLE
fix for #1588

### DIFF
--- a/assets/js/search-page.js
+++ b/assets/js/search-page.js
@@ -84,7 +84,7 @@ function indexStorageKey () {
   return `index:${getProjectNameAndVersion()}`
 }
 
-export function createIndex () {
+function createIndex () {
   lunr.QueryLexer.termSeparator = /\s+/
   return lunr(function () {
     this.tokenizer.separator = /\s+/
@@ -160,7 +160,6 @@ function hyphenSearchFunction (token) {
   tokens.push(token)
   return tokens
 }
-
 
 function hyphenSearch (builder) {
   registerHyphenSearchFunction ()


### PR DESCRIPTION
This is a proposal fix for #1588. Hyphens now are found by the index and get a higher score. 

These 2 lunr issues are relevant to understand the fix:

* https://github.com/olivernn/lunr.js/issues/296
* https://github.com/olivernn/lunr.js/issues/493

Some remarks about the solution:

* I've exported a `__createIndex` functions to be able to test it (`createIndex` uses globals)
* I've used the `searchNodes` from the live view docs, which is overkill and can be changed, but before I did, I wanted to make sure that this is the direction you want.
* I've got no idea on how to build/setup a version of ex_doc and test on the real docs to see how it actually works. If that's something I can easily do, let me know and I'll try it. (so I don't know if I broke anything...)
* I tried to maintain the coding style of the javascript files, but as there is no formatter config, I'm not sure it's perfect.