### PR TITLE
fix: remove extra term() argument at start of macrocallback spec

### DIFF
--- a/lib/ex_doc/language/elixir.ex
+++ b/lib/ex_doc/language/elixir.ex
@@ -109,14 +109,14 @@ defmodule ExDoc.Language.Elixir do
       if actual_def in module_data.private.optional_callbacks, do: ["optional"], else: []
 
     specs =
-      case {kind, Map.fetch(module_data.private.callbacks, actual_def)} do
-        {:macrocallback, {:ok, specs}} ->
+      case module_data.private.callbacks do
+        %{^actual_def => specs} when kind == :macro_callback ->
           Enum.map(specs, &remove_callback_term/1)
 
-        {:callback, {:ok, specs}} ->
+        %{^actual_def => specs} ->
           specs
 
-        {_kind, :error} ->
+        %{} ->
           []
       end
 

--- a/lib/ex_doc/language/elixir.ex
+++ b/lib/ex_doc/language/elixir.ex
@@ -109,11 +109,14 @@ defmodule ExDoc.Language.Elixir do
       if actual_def in module_data.private.optional_callbacks, do: ["optional"], else: []
 
     specs =
-      case Map.fetch(module_data.private.callbacks, actual_def) do
-        {:ok, specs} ->
+      case {kind, Map.fetch(module_data.private.callbacks, actual_def)} do
+        {:macrocallback, {:ok, specs}} ->
+          Enum.map(specs, &remove_callback_term/1)
+
+        {:callback, {:ok, specs}} ->
           specs
 
-        :error ->
+        {_kind, :error} ->
           []
       end
 
@@ -134,6 +137,14 @@ defmodule ExDoc.Language.Elixir do
       specs: quoted,
       extra_annotations: extra_annotations
     }
+  end
+
+  defp remove_callback_term({:type, num, :bounded_fun, [lhs, rhs]}) do
+    {:type, num, :bounded_fun, [remove_callback_term(lhs), rhs]}
+  end
+
+  defp remove_callback_term({:type, num, :fun, [{:type, num, :product, [_ | rest_args]} | rest]}) do
+    {:type, num, :fun, [{:type, num, :product, rest_args} | rest]}
   end
 
   @impl true

--- a/lib/ex_doc/language/elixir.ex
+++ b/lib/ex_doc/language/elixir.ex
@@ -110,7 +110,7 @@ defmodule ExDoc.Language.Elixir do
 
     specs =
       case module_data.private.callbacks do
-        %{^actual_def => specs} when kind == :macro_callback ->
+        %{^actual_def => specs} when kind == :macrocallback ->
           Enum.map(specs, &remove_callback_term/1)
 
         %{^actual_def => specs} ->

--- a/test/ex_doc/retriever/elixir_test.exs
+++ b/test/ex_doc/retriever/elixir_test.exs
@@ -160,7 +160,7 @@ defmodule ExDoc.Retriever.ElixirTest do
       assert macrocallback1.group == :Callbacks
       assert Path.basename(macrocallback1.source_url) == "nofile:9"
       refute macrocallback1.doc
-      assert Macro.to_string(macrocallback1.specs) == "[macrocallback1(term()) :: :ok]"
+      assert Macro.to_string(macrocallback1.specs) == "[macrocallback1() :: :ok]"
 
       elixirc(c, ~S"""
       defmodule Impl do


### PR DESCRIPTION
related: #755 and #756
ping @josevalim