### PR TITLE
fix: prevent unreadable text when using inline code with admonition eaders

### DIFF
--- a/assets/css/content/admonition.css
+++ b/assets/css/content/admonition.css
@@ -94,4 +94,5 @@
 .content-inner blockquote:is(.warning, .error, .info, .neutral, .tip) code {
   background-color: var(--inlineCodeBackground);
   border: 1px solid var(--inlineCodeBorder);
+  color: var(--black);
 }


### PR DESCRIPTION
While navigating on `ex_unit` using Hex, I found some styling issues when using inline code inside admonition header blocks. Check the bottom of [this page](https://hexdocs.pm/ex_unit/1.14.0/ExUnit.CaseTemplate.html#using/2) **using dark mode.** Not sure if it was added when adding support to admonition (#1400) or while removing less (#1597).

The problem happened when using inline code in admonition headers for some specific combinations, like the light theme and "errors" or the night theme and "warnings". Which would make the code to be too unreadable (gray font for the white background).

I'm following the same pattern for inline code that shows up in the admonition body, forcing the inline code tag color to be black. Examples of cases happening before and after the change above:

### Before (light theme) 

![image](https://user-images.githubusercontent.com/9089847/188772306-e2445422-3e85-4e1e-8d2c-0e31a3234a4d.png)

### After (light theme)

![image](https://user-images.githubusercontent.com/9089847/188772579-5acdd148-150e-4ba9-886c-baf47c295857.png)

### Before (dark theme)

![image](https://user-images.githubusercontent.com/9089847/188772394-d30d1fb3-d27f-4960-a6d5-72ec1b0a299f.png)

### After (dark theme)

![image](https://user-images.githubusercontent.com/9089847/188772488-545f4f46-1d25-433a-89b6-312c7cf7862e.png)

---


I'm almost sure these changes would require generating assets. But once `mix build` changes a lot of things, I am not confident about which generated files I should commit. 