### PR TITLE
Save sidebar state per session

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -39,11 +39,11 @@ body {
 .sidebar-button {
   position: fixed;
   z-index: 99;
-  left: 7px;
+  left: 0;
   top: 7px;
   transition: color .3s ease-in-out, transform .15s ease-out .1s, opacity .15s ease-out .1s;
   will-change: transform;
-  transform: translateX(243px);
+  transform: translateX(250px);
 }
 
 .content {
@@ -85,8 +85,8 @@ body.sidebar-closing .content {
 }
 
 body.sidebar-closed .sidebar-button {
-  transition: none;
-  transform: translateX(0);
+  transition: transform .3s ease-in-out;
+  transform: translateY(-8px);
 }
 
 body.sidebar-closed .sidebar {


### PR DESCRIPTION
Means sidebar stays open or close if you navigate.
For example using previous / next page navigation.

Close https://github.com/elixir-lang/ex_doc/issues/1554

Additionally I needed to fix a CSS animation.
By doing so I moved the sidebar button 7px more from left & top into the page.
Found it unwanted to have a different height position between closed / opened sidebar.