### PR TITLE
Readable yellow color for Dark mod

### DIFF
--- a/assets/css/custom-props/common.css
+++ b/assets/css/custom-props/common.css
@@ -26,8 +26,8 @@
   --coldGray:                hsl(240,   5%,  46%      );
   --coldGrayDark:            hsl(240,   5%,  28%      );
   --coldGrayDim:             hsl(240,   5%,  18%      );
-  --yellowLight:             hsl( 60, 100%,  81%      );
-  --yellow:                  hsl( 60, 100%,  43%      );
+  --yellowLight:             hsl(60deg 100%  43% / 62%);
+  --yellow:                  hsl(60deg 100%  43% / 62%);
   --green-lightened-10:      hsl( 90, 100%,  45%      );
   --green:                   hsl( 90, 100%,  35%      );
   --white:                   hsl(  0,   0%, 100%      );

--- a/assets/css/custom-props/common.css
+++ b/assets/css/custom-props/common.css
@@ -26,8 +26,9 @@
   --coldGray:                hsl(240,   5%,  46%      );
   --coldGrayDark:            hsl(240,   5%,  28%      );
   --coldGrayDim:             hsl(240,   5%,  18%      );
-  --yellowLight:             hsl(60deg 100%  43% / 62%);
-  --yellow:                  hsl(60deg 100%  43% / 62%);
+  --yellowLight:             hsl( 60, 100%,  81%      );
+  --yellowDark:              hsl(60deg 100%  43% / 62%);
+  --yellow:                  hsl( 60, 100%,  43%      );
   --green-lightened-10:      hsl( 90, 100%,  45%      );
   --green:                   hsl( 90, 100%,  35%      );
   --white:                   hsl(  0,   0%, 100%      );

--- a/assets/css/custom-props/theme-dark.css
+++ b/assets/css/custom-props/theme-dark.css
@@ -34,7 +34,7 @@ body.dark {
   --tipHeading:                  var(--white);
 
   --fnSpecAttr:                  var(--gray500);
-  --fnDeprecated:                var(--yellow);
+  --fnDeprecated:                var(--yellowDark);
   --blink:                       var(--gray600);
 
   --codeBackground:              var(--gray800);


### PR DESCRIPTION
Hi, I think this color for yellow color can be warmer and readable in both dark mod and light mod

## Before changing

As you see, we can't read the text in dark mod
![1](https://user-images.githubusercontent.com/8413604/190895573-08d7173e-2045-4688-afb5-333351c2bcff.png)
![2](https://user-images.githubusercontent.com/8413604/190895574-2c0c9067-bdd1-4b25-86cc-c32ad42781ee.png)

---
## After changing
![3](https://user-images.githubusercontent.com/8413604/190895588-3c6b71a6-aeeb-4b6d-b25b-69888c2daf5e.png)
![4](https://user-images.githubusercontent.com/8413604/190895591-634dacf3-a05f-40b9-a940-0316ae057c05.png)


Changing the color and format is based on the taste of each person.
**I did not separate the colors because a variable was created only for the color yellow.**