### PR TITLE
Fix broken types and some dialyzer issues

### DIFF
--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -224,7 +224,7 @@ defmodule ExDoc.Formatter.HTML.Templates do
   prefixed with `prefix`.
   """
   @heading_regex ~r/<(h[23]).*?>(.*?)<\/\1>/m
-  @spec link_headings(String.t(), Regex.t(), String.t()) :: String.t()
+  @spec link_headings(String.t() | nil, Regex.t(), String.t()) :: String.t() | nil
   def link_headings(content, regex \\ @heading_regex, prefix \\ "")
   def link_headings(nil, _, _), do: nil
 

--- a/lib/ex_doc/language.ex
+++ b/lib/ex_doc/language.ex
@@ -1,7 +1,7 @@
 defmodule ExDoc.Language do
   @moduledoc false
 
-  @typep spec_ast() :: term()
+  @type spec_ast() :: term()
 
   @typedoc """
   The map has the following keys:

--- a/lib/ex_doc/language/elixir.ex
+++ b/lib/ex_doc/language/elixir.ex
@@ -835,16 +835,12 @@ defmodule ExDoc.Language.Elixir do
 
     case {mode, Refs.get_visibility({:module, module}), Refs.get_visibility(ref)} do
       {_mode, _module_visibility, :public} ->
-        case Autolink.tool(module, config) do
-          :no_tool ->
-            nil
+        tool = Autolink.tool(module, config)
 
-          tool ->
-            if same_module? do
-              fragment(tool, kind, name, arity)
-            else
-              Autolink.app_module_url(tool, module, config) <> fragment(tool, kind, name, arity)
-            end
+        if same_module? do
+          fragment(tool, kind, name, arity)
+        else
+          Autolink.app_module_url(tool, module, config) <> fragment(tool, kind, name, arity)
         end
 
       {:regular_link, module_visibility, :undefined}

--- a/lib/ex_doc/language/elixir.ex
+++ b/lib/ex_doc/language/elixir.ex
@@ -225,7 +225,7 @@ defmodule ExDoc.Language.Elixir do
     prefixes
     |> Enum.find(&String.starts_with?(title, &1 <> "."))
     |> case do
-      nil -> {nil, nil}
+      nil -> nil
       prefix -> {"." <> String.trim_leading(title, prefix <> "."), prefix}
     end
   end

--- a/lib/ex_doc/nodes.ex
+++ b/lib/ex_doc/nodes.ex
@@ -22,25 +22,27 @@ defmodule ExDoc.ModuleNode do
             language: nil,
             annotations: []
 
+  @typep annotation :: atom()
+
   @type t :: %__MODULE__{
-          id: nil | String.t(),
-          title: nil | String.t(),
-          nested_context: nil | String.t(),
-          nested_title: nil | String.t(),
-          module: nil | String.t(),
-          group: nil | String.t(),
-          deprecated: nil | String.t(),
-          function_groups: list(String.t()),
-          docs: list(),
-          doc: term(),
-          rendered_doc: nil | String.t(),
+          id: String.t(),
+          title: String.t(),
+          nested_context: String.t() | nil,
+          nested_title: String.t() | nil,
+          module: module(),
+          group: atom() | nil,
+          deprecated: String.t() | nil,
+          doc: ExDoc.DocAST.t() | nil,
+          rendered_doc: String.t() | nil,
           doc_line: non_neg_integer(),
-          typespecs: list(),
-          source_path: nil | String.t(),
-          source_url: nil | String.t(),
-          type: nil | atom(),
+          function_groups: [atom()],
+          docs: [ExDoc.FunctionNode.t()],
+          typespecs: [ExDoc.TypeNode.t()],
+          source_path: String.t(),
+          source_url: String.t() | nil,
+          type: atom(),
           language: module(),
-          annotations: list()
+          annotations: [annotation()]
         }
 end
 
@@ -65,22 +67,25 @@ defmodule ExDoc.FunctionNode do
             source_path: nil,
             source_url: nil
 
+  @typep annotation :: String.t()
+  @typep function_default :: {name :: atom(), arity :: non_neg_integer()}
+
   @type t :: %__MODULE__{
-          id: nil | String.t(),
-          name: nil | String.t(),
-          arity: non_neg_integer,
-          defaults: non_neg_integer,
-          doc: term(),
-          rendered_doc: nil | String.t(),
-          doc_line: non_neg_integer,
-          source_path: nil | String.t(),
-          source_url: nil | String.t(),
-          group: nil | String.t(),
-          type: nil | String.t(),
-          signature: nil | String.t(),
-          specs: list(),
-          annotations: list(),
-          deprecated: nil | String.t()
+          id: String.t(),
+          name: atom(),
+          arity: non_neg_integer(),
+          defaults: [function_default()],
+          deprecated: String.t() | nil,
+          doc: ExDoc.DocAST.t() | nil,
+          rendered_doc: String.t() | nil,
+          type: atom(),
+          signature: String.t(),
+          specs: [ExDoc.Language.spec_ast()],
+          annotations: [annotation()],
+          group: atom() | nil,
+          doc_line: non_neg_integer(),
+          source_path: String.t(),
+          source_url: String.t() | nil
         }
 end
 
@@ -103,19 +108,21 @@ defmodule ExDoc.TypeNode do
             signature: nil,
             annotations: []
 
+  @typep annotation :: String.t()
+
   @type t :: %__MODULE__{
-          id: nil | String.t(),
-          name: nil | String.t(),
-          arity: non_neg_integer,
-          type: nil | String.t(),
-          spec: nil | String.t(),
-          deprecated: nil | String.t(),
-          doc: term(),
-          rendered_doc: nil | String.t(),
-          doc_line: non_neg_integer,
-          signature: nil | String.t(),
-          source_url: nil | String.t(),
-          source_path: nil | String.t(),
-          annotations: list()
+          id: String.t(),
+          name: atom(),
+          arity: non_neg_integer(),
+          type: atom(),
+          deprecated: nil,
+          doc: ExDoc.DocAST.t() | nil,
+          rendered_doc: String.t() | nil,
+          doc_line: non_neg_integer(),
+          source_path: String.t(),
+          source_url: String.t() | nil,
+          spec: ExDoc.Language.spec_ast(),
+          signature: String.t(),
+          annotations: [annotation()]
         }
 end

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -314,7 +314,6 @@ defmodule ExDoc.Retriever do
 
   ## General helpers
 
-  defp signature([]), do: nil
   defp signature(list) when is_list(list), do: Enum.join(list, " ")
 
   defp annotations_from_metadata(metadata) do


### PR DESCRIPTION
Hey folks! 🖖 

The types from `lib/ex_doc/nodes.ex` are outdated. 

This pull request updates these type definitions and fixes some issues Dialyzer found locally. 

I used a [small tool I made](https://github.com/antedeguemon/type_counselor) to automatically find the outdated types and revised them manually.

