### PR TITLE
Fix Retriever.docs_from_files/2

### DIFF
--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -18,11 +18,11 @@ defmodule ExDoc.Retriever do
     files = Path.wildcard(Path.expand("*.beam", dir))
 
     docs_from_files(files, config)
-    |> docs_from_modules(config)
   end
 
   def docs_from_dir(dirs, config) when is_list(dirs) do
-    Enum.flat_map(dirs, &docs_from_dir(&1, config))
+    dirs
+    |> Enum.flat_map(&docs_from_dir(&1, config))
     |> sort_modules(config)
   end
 
@@ -30,9 +30,10 @@ defmodule ExDoc.Retriever do
   Extract documentation from all modules in the specified list of files
   """
   @spec docs_from_files([Path.t()], ExDoc.Config.t()) :: [ExDoc.ModuleNode.t()]
-  def docs_from_files(files, _config) when is_list(files) do
+  def docs_from_files(files, config) when is_list(files) do
     files
     |> Enum.map(&filename_to_module(&1))
+    |> docs_from_modules(config)
   end
 
   @doc """


### PR DESCRIPTION
`ExDoc.Retriever.docs_from_files/2` had its functionality removed by accident. 

This PR re-adds the deleted line and adds some tests to ensure `docs_from_files/2` behavior is kept. 