### PR TITLE
Support Erlang Extras

### DIFF
--- a/lib/ex_doc/language/erlang.ex
+++ b/lib/ex_doc/language/erlang.ex
@@ -217,6 +217,41 @@ defmodule ExDoc.Language.Erlang do
     binary
   end
 
+  defp walk_doc({:code, attrs, [code], meta} = ast, config) do
+    {text, url} =
+      case parse_autolink(code) do
+        {:module, module} = ref ->
+          text = Atom.to_string(module)
+          # Modules are parsed very permissively, so undefined/private
+          # modules do not emit warnings
+          url = do_url(ref, code, config, false)
+          {text, url}
+
+        {:local, kind, name, arity} ->
+          {"#{name}/#{arity}", local_url(kind, name, arity, config)}
+
+        {:remote, kind, module, name, arity} ->
+          text =
+            if kind == :type and arity == 0 do
+              "#{module}:#{name}()"
+            else
+              "#{module}:#{name}/#{arity}"
+            end
+
+          url = remote_url(kind, module, name, arity, config)
+          {text, url}
+
+        :error ->
+          {code, nil}
+      end
+
+    if url do
+      {:a, [href: url], {:code, attrs, [text], meta}, %{}}
+    else
+      ast
+    end
+  end
+
   defp walk_doc({:a, attrs, inner, _meta} = ast, config) do
     case attrs[:rel] do
       "https://erlang.org/doc/link/seeerl" ->
@@ -308,7 +343,7 @@ defmodule ExDoc.Language.Erlang do
 
   defp url(:module, string, config) do
     ref = {:module, String.to_atom(string)}
-    do_url(ref, string, config)
+    do_url(ref, string, config, true)
   end
 
   defp url(kind, string, config) do
@@ -327,31 +362,46 @@ defmodule ExDoc.Language.Erlang do
     name = String.to_atom(name)
     arity = String.to_integer(arity)
 
-    original_text =
-      if kind == :type and arity == 0 do
-        "#{name}()"
-      else
-        "#{name}/#{arity}"
-      end
-
     if module == "" do
-      ref = {kind, config.current_module, name, arity}
-      visibility = Refs.get_visibility(ref)
-
-      if visibility == :public do
-        final_url({kind, name, arity}, config)
-      else
-        Autolink.maybe_warn(ref, config, visibility, %{original_text: original_text})
-        nil
-      end
+      local_url(kind, name, arity, config)
     else
-      ref = {kind, String.to_atom(module), name, arity}
-      original_text = "#{module}:#{original_text}"
-      do_url(ref, original_text, config)
+      remote_url(kind, String.to_atom(module), name, arity, config)
     end
   end
 
-  defp do_url(ref, original_text, config) do
+  defp remote_url(kind, module, name, arity, config) do
+    ref = {kind, module, name, arity}
+
+    text =
+      if kind == :type and arity == 0 do
+        "#{module}:#{name}()"
+      else
+        "#{module}:#{name}/#{arity}"
+      end
+
+    do_url(ref, text, config, true)
+  end
+
+  defp local_url(kind, name, arity, config) do
+    ref = {kind, config.current_module, name, arity}
+    visibility = Refs.get_visibility(ref)
+
+    if visibility == :public do
+      final_url({kind, name, arity}, config)
+    else
+      original_text =
+        if kind == :type and arity == 0 do
+          "#{name}()"
+        else
+          "#{name}/#{arity}"
+        end
+
+      Autolink.maybe_warn(ref, config, visibility, %{original_text: original_text})
+      nil
+    end
+  end
+
+  defp do_url(ref, original_text, config, emit_warning) do
     visibility = Refs.get_visibility(ref)
 
     # TODO: type with content = %{} in otp xml is marked as :hidden, it should be :public
@@ -359,7 +409,10 @@ defmodule ExDoc.Language.Erlang do
     if visibility == :public or (visibility == :hidden and elem(ref, 0) == :type) do
       final_url(ref, config)
     else
-      Autolink.maybe_warn(ref, config, visibility, %{original_text: original_text})
+      if emit_warning do
+        Autolink.maybe_warn(ref, config, visibility, %{original_text: original_text})
+      end
+
       nil
     end
   end
@@ -403,6 +456,86 @@ defmodule ExDoc.Language.Erlang do
 
   defp fragment(:ex_doc, :type, name, arity) do
     "#t:#{name}/#{arity}"
+  end
+
+  defp kind("c:" <> rest), do: {:callback, rest}
+  defp kind("t:" <> rest), do: {:type, rest}
+  defp kind(rest), do: {:function, rest}
+
+  defp parse_autolink(string) do
+    case Regex.run(~r{^(.+)(/\d+|\(\))$}, string) do
+      [_, left, right] ->
+        with {:ok, arity} <- parse_arity(right) do
+          {kind, rest} = kind(left)
+
+          case parse_module_function(rest) do
+            {:local, name} ->
+              {:local, kind, name, arity}
+
+            {:remote, module, name} ->
+              {:remote, kind, module, name, arity}
+
+            :error ->
+              :error
+          end
+        end
+
+      nil ->
+        parse_module(string)
+
+      _ ->
+        :error
+    end
+  end
+
+  # 0-arity types may take the form `t:module:type()`.
+  defp parse_arity("()") do
+    {:ok, 0}
+  end
+
+  defp parse_arity("/" <> arity_string) do
+    case Integer.parse(arity_string) do
+      {arity, ""} -> {:ok, arity}
+      _ -> :error
+    end
+  end
+
+  defp parse_module_function(string) do
+    case String.split(string, ":") do
+      [module_string, function_string] ->
+        with {:module, module} <- parse_module(module_string),
+             {:function, function} <- parse_function(function_string) do
+          {:remote, module, function}
+        end
+
+      [function_string] ->
+        with {:function, function} <- parse_function(function_string) do
+          {:local, function}
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  defp parse_function(string) do
+    case Code.string_to_quoted("& #{string}/0") do
+      {:ok, {:&, _, [{:/, _, [{function, _, _}, 0]}]}} when is_atom(function) ->
+        {:function, function}
+
+      _ ->
+        :error
+    end
+  end
+
+  defp parse_module(string) do
+    case Code.string_to_quoted(":#{string}", warn_on_unnecessary_quotes: false) do
+      {:ok, module} when is_atom(module) ->
+        {:module, module}
+
+      _ ->
+        :error
+    end
   end
 
   # Traverses quoted and formatted string of the typespec AST, replacing refs with links.

--- a/test/ex_doc/formatter/epub_test.exs
+++ b/test/ex_doc/formatter/epub_test.exs
@@ -83,8 +83,14 @@ defmodule ExDoc.Formatter.EPUBTest do
   end
 
   test "generates an EPUB file with erlang as proglang", %{tmp_dir: tmp_dir} = context do
-    generate_docs(Keyword.put(doc_config(context), :proglang, :erlang))
-    assert File.regular?(tmp_dir <> "/epub/#{doc_config(context)[:project]}.epub")
+    config =
+      context
+      |> doc_config()
+      |> Keyword.put(:proglang, :erlang)
+      |> Keyword.update!(:skip_undefined_reference_warnings_on, &["test/fixtures/README.md" | &1])
+
+    generate_docs(config)
+    assert File.regular?(tmp_dir <> "/epub/#{config[:project]}.epub")
   end
 
   test "generates an EPUB file in specified output directory", %{tmp_dir: tmp_dir} = context do


### PR DESCRIPTION
This change supports generating extras with Erlang syntax. Inline-code blocks are parsed as Elixir but written as Erlang, so `:telemetry.execute/3` is correctly autolinked and re-written as `telemetry:execute/3`.

Connects https://github.com/elixir-lang/ex_doc/issues/1333