### PR TITLE
Enable Earmark footnotes by default

### DIFF
--- a/lib/ex_doc/markdown/earmark.ex
+++ b/lib/ex_doc/markdown/earmark.ex
@@ -21,6 +21,8 @@ defmodule ExDoc.Markdown.Earmark do
     * `:breaks` - (boolean) only applicable if `gfm` is enabled. Makes all line
       breaks significant (so every line in the input is a new line in the output).
 
+    * `:footnotes` - (boolean) enables footnotes. Defaults to `true`.
+
   """
   @impl true
   def to_ast(text, opts) do
@@ -29,7 +31,8 @@ defmodule ExDoc.Markdown.Earmark do
       line: 1,
       file: "nofile",
       breaks: false,
-      pure_links: true
+      pure_links: true,
+      footnotes: true
     ]
 
     options = Keyword.merge(options, opts)


### PR DESCRIPTION
GFM has footnotes ([link](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#footnotes)), which currently aren't supported by default with ExDoc. Since GFM is already enabled by default, I think it would make sense to enable footnotes by default as well.

See also: [documentation on footnotes in Earmark repository](https://github.com/robertdober/earmark_parser#footnotes).