### PR TITLE
Add tooltip to functions on sidebar

### DIFF
--- a/assets/js/handlebars/templates/sidebar-items.handlebars
+++ b/assets/js/handlebars/templates/sidebar-items.handlebars
@@ -56,7 +56,7 @@
             <ul class="{{group.key}}-list deflist">
               {{#each group.nodes}}
                 <li>
-                  <a href="{{node.id}}.html#{{anchor}}" translate="no">{{id}}</a>
+                  <a href="{{node.id}}.html#{{anchor}}" title="{{title}}" translate="no">{{id}}</a>
                 </li>
               {{/each}}
             </ul>

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -146,7 +146,7 @@ defmodule ExDoc.Formatter.HTML.Templates do
             "#{node.name}/#{node.arity}"
           end
 
-        %{id: id, anchor: URI.encode(node.id)}
+        %{id: id, title: node.signature, anchor: URI.encode(node.id)}
       end
 
     %{key: HTML.text_to_id(group), name: group, nodes: nodes}

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -270,8 +270,9 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       assert content =~ ~r("modules":\[\{.*"id":"CompiledWithDocs",.*"title":"CompiledWithDocs")ms
       assert content =~ ~r("id":"CompiledWithDocs".*"key":"functions".*"example/2")ms
       assert content =~ ~r("id":"CompiledWithDocs".*"key":"functions".*"example_without_docs/0")ms
-      assert content =~ ~r("id":"CompiledWithDocs.Nested")ms
-      assert content =~ ~r(\{"anchor":"__struct__/0","id":"%CompiledWithDocs\{\}"\})ms
+      assert content =~ ~s("id":"CompiledWithDocs.Nested")
+      assert content =~ ~s("anchor":"__struct__/0","id":"%CompiledWithDocs{}")
+      assert content =~ ~s("anchor":"is_zero/1","id":"is_zero/1","title":"is_zero\(number\))
     end
 
     test "outputs nodes grouped based on metadata", context do


### PR DESCRIPTION
This commit adds a tooltip to the sidebar with the function signature. This improves UX when listing functions with same name but different arities. It also works for types, guards, and callbacks.

<img width="296" alt="Screen Shot 2022-10-26 at 19 05 20" src="https://user-images.githubusercontent.com/5093045/198150169-a4549ce5-4df5-406f-8dbb-28e3e3edab91.png">

Closes #1614