### PR TITLE
Remove Coveralls leftovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # ExDoc
 
 [![Build Status](https://github.com/elixir-lang/ex_doc/workflows/CI/badge.svg)](https://github.com/elixir-lang/ex_doc/actions?query=workflow%3A%22CI%22)
-[![Coverage Status](https://coveralls.io/repos/github/elixir-lang/ex_doc/badge.svg?branch=master)](https://coveralls.io/github/elixir-lang/ex_doc?branch=master)
 
 ExDoc is a tool to generate documentation for your Elixir projects. To see an example, [you can access Elixir's official docs](https://hexdocs.pm/elixir/).
 

--- a/mix.exs
+++ b/mix.exs
@@ -15,9 +15,7 @@ defmodule ExDoc.Mixfile do
       escript: escript(),
       elixirc_paths: elixirc_paths(Mix.env()),
       source_url: @source_url,
-      test_coverage: [tool: ExCoveralls],
       test_elixirc_options: [docs: true, debug_info: true],
-      preferred_cli_env: [coveralls: :test],
       name: "ExDoc",
       description: "ExDoc is a documentation generation tool for Elixir",
       docs: docs()


### PR DESCRIPTION
Hey there! 

The [coveralls](https://hex.pm/packages/coveralls) library was removed from ex_doc by 649c21e, but it was kept as the default coverage tool - which caused `mix test --cover` to fail. 😿 

This PR does two things:
1. Removes Coveralls leftovers from `mix.exs` - so `mix test --cover` works again
2. Removes old coveralls.io badge from README - the coverage is pretty outdated since the last build is from 2019