### PR TITLE
Add optional function annotations

### DIFF
--- a/lib/ex_doc/config.ex
+++ b/lib/ex_doc/config.ex
@@ -6,8 +6,10 @@ defmodule ExDoc.Config do
   def filter_modules(_module, _metadata), do: true
   def before_closing_head_tag(_), do: ""
   def before_closing_body_tag(_), do: ""
+  def annotations_for_docs(_), do: []
 
-  defstruct api_reference: true,
+  defstruct annotations_for_docs: &__MODULE__.annotations_for_docs/1,
+            api_reference: true,
             apps: [],
             assets: nil,
             authors: nil,
@@ -44,6 +46,7 @@ defmodule ExDoc.Config do
             version: nil
 
   @type t :: %__MODULE__{
+          annotations_for_docs: (term() -> list()),
           api_reference: boolean(),
           apps: [atom()],
           assets: nil | String.t(),

--- a/lib/ex_doc/config.ex
+++ b/lib/ex_doc/config.ex
@@ -46,7 +46,7 @@ defmodule ExDoc.Config do
             version: nil
 
   @type t :: %__MODULE__{
-          annotations_for_docs: (term() -> list()),
+          annotations_for_docs: (map() -> list()),
           api_reference: boolean(),
           apps: [atom()],
           assets: nil | String.t(),


### PR DESCRIPTION
This PR adds the possibility to specify additional function annotations that will be rendered by ExDoc. This is at the function level what https://github.com/elixir-lang/ex_doc/pull/1430 does for modules.

My use case is that a bunch of functions are generated at compile time and I want to mark them as such using ```@doc tags: [:generated]```

This would be the result:
<img width="879" alt="Screenshot 2022-11-17 at 14 08 56" src="https://user-images.githubusercontent.com/54566/202454925-d8d05bac-0b4f-4bfa-8961-4abe30dc4fd8.png">

