### PR TITLE
Initial pass at improving print.css

### DIFF
--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -22,4 +22,12 @@
   #toast {
     display: none;
   }
+
+  a.view-source {
+    display: none;
+  }
+
+  button.display-settings {
+    display: none;
+  }
 }

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -11,6 +11,8 @@
   .content {
     padding-left: 0;
     overflow: visible;
+    left: 0px;
+    width: 100%;
   }
 
   .summary-row {

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -55,4 +55,8 @@
     :is(h3, h4):is(.warning, .error, .info, .neutral, .tip)::before {
     color: var(--textHeaders);
   }
+
+  .content-inner pre code.makeup {
+    border-color: var(--gray300);
+  }
 }

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -34,4 +34,8 @@
   .content-inner .bottom-actions {
     display: none;
   }
+
+  .footer {
+    display: none;
+  }
 }

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -18,4 +18,8 @@
   .summary-row {
     page-break-inside: avoid;
   }
+
+  #toast {
+    display: none;
+  }
 }

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -50,12 +50,6 @@
     border-bottom: 2px solid var(--gray300);
   }
 
-  .content-inner
-    blockquote
-    :is(h3, h4):is(.warning, .error, .info, .neutral, .tip)::before {
-    color: var(--textHeaders);
-  }
-
   .content-inner pre code.makeup {
     border-color: var(--gray300);
     white-space: break-spaces;

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -59,4 +59,8 @@
   .content-inner pre code.makeup {
     border-color: var(--gray300);
   }
+
+  .content-inner code.inline {
+    border-color: var(--gray300);
+  }
 }

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -30,4 +30,8 @@
   button.display-settings {
     display: none;
   }
+
+  .content-inner .bottom-actions {
+    display: none;
+  }
 }

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -55,6 +55,10 @@
     white-space: break-spaces;
   }
 
+  .content-inner blockquote code.inline {
+    border-color: var(--gray300);
+  }
+
   .content-inner code.inline {
     border-color: var(--gray300);
   }

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -38,4 +38,21 @@
   .footer {
     display: none;
   }
+
+  .content-inner blockquote:is(.warning, .error, .info, .neutral, .tip) {
+    border: 2px solid var(--gray300);
+  }
+
+  .content-inner
+    blockquote
+    :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
+    color: var(--textHeaders);
+    border-bottom: 2px solid var(--gray300);
+  }
+
+  .content-inner
+    blockquote
+    :is(h3, h4):is(.warning, .error, .info, .neutral, .tip)::before {
+    color: var(--textHeaders);
+  }
 }

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -58,6 +58,7 @@
 
   .content-inner pre code.makeup {
     border-color: var(--gray300);
+    white-space: break-spaces;
   }
 
   .content-inner code.inline {


### PR DESCRIPTION
Hello!
I know there is quite a bit of work to be done for Cheatsheets to be viably printed but there is some low hanging fruit as far as printability goes for ExDoc as a whole.

There's a bit of dupl

I'm split on a few things as we can set CSS to force page breaks and cause codeblocks to shift to resist being split across multiple pages etc, but very interested in knowing what direction you'd like to head with `print.css`!

# Left Spacing + Show Source + Settings
Currently there's a large `300px` gap on the left side. We can remove this spacing as well as the Show Source and Settings buttons.
## Before
![image](https://user-images.githubusercontent.com/454563/202603185-d796deb4-084a-414c-a8e2-3d08a537cff6.png)
## After
![image](https://user-images.githubusercontent.com/454563/202603255-1f385a71-9462-4ba9-a6a7-bfc5e2e686f4.png)

# Admonition Blocks + Code Borders
The background colors for admonition blocks disappear so we can make them visible again by bringing in borders.
The code blocks and inline code borders were a very low contrast which lets them disappear but also makes distinguishing them difficult, the contrast has been increased for visibility.

## Before
![image](https://user-images.githubusercontent.com/454563/202603510-dd5a16dd-90bb-478e-904f-46930d162710.png)
## After
![image](https://user-images.githubusercontent.com/454563/202609966-ca24cf70-28a3-414a-8c8a-18c2f9e6358f.png)

# Tooltip Removed
The bottom of every page displayed a toast, in my case displaying Browser changed theme to "light". This has been hidden.
## Before
![image](https://user-images.githubusercontent.com/454563/202603883-e8100877-ecd5-4a4f-b37d-b8b019ff72d8.png)
## After
![image](https://user-images.githubusercontent.com/454563/202603924-31116f73-46c5-4ef3-97c8-4c7eba76ac5d.png)

# Code Wrap
Not all code blocks force wrapping. This is fine when viewed on a computer but it's fairly hard to scroll to the right once printed.
All code blocks now wrap.
## Before
![image](https://user-images.githubusercontent.com/454563/202604118-5613f01c-be4a-492c-87c7-fc0ef3ff39b9.png)
## After
![image](https://user-images.githubusercontent.com/454563/202604149-0f0e2230-b042-4364-bb4d-4ebf48230ffd.png)

# Remove footer information
The footer contains information related to ExDoc versioning etc, but it doesn't contain information like the version of the package that the docs were printed for. Given their limited use in printed form, I've removed them but would be interested in them containing some information which might allow a user to see that their printed documentation is outdated.

## Before
![image](https://user-images.githubusercontent.com/454563/202604428-c953877f-8720-4b6d-95b5-da6072a0c766.png)
## After
![image](https://user-images.githubusercontent.com/454563/202604527-d1db9439-fe97-4931-8c11-e543584235a0.png)

