### PR TITLE
Basic Cheatsheet print.css

### DIFF
--- a/assets/css/_html.css
+++ b/assets/css/_html.css
@@ -33,6 +33,7 @@
 @import 'toast.css';
 @import 'screen-reader.css';
 @import 'print.css';
+@import 'print-cheatsheet.css';
 @import 'makeup.css';
 
 

--- a/assets/css/content/cheatsheet.css
+++ b/assets/css/content/cheatsheet.css
@@ -1,283 +1,285 @@
-.page-cheatmd .content-inner {
-  max-width: 1200px;
-}
+@media screen {
+  .page-cheatmd .content-inner {
+    max-width: 1200px;
+  }
 
-/* h1 styling */
+  /* h1 styling */
 
-.page-cheatmd h1 {
-  margin-bottom: 1em;
-}
+  .page-cheatmd h1 {
+    margin-bottom: 1em;
+  }
 
-/* h2 styling */
+  /* h2 styling */
 
-.page-cheatmd h2 {
-  margin: 1em 0;
-  column-span: all;
-  padding-left: 3px;
-  color: var(--gray700);
-  font-weight: 500;
-}
+  .page-cheatmd h2 {
+    margin: 1em 0;
+    column-span: all;
+    padding-left: 3px;
+    color: var(--gray700);
+    font-weight: 500;
+  }
 
-.page-cheatmd.dark h2 {
-  color: var(--gray200);
-}
+  .page-cheatmd.dark h2 {
+    color: var(--gray200);
+  }
 
-/* h3 styling */
+  /* h3 styling */
 
-.page-cheatmd h3 {
-  white-space: nowrap;
-  overflow: hidden;
-  margin: 0 0 1em;
-  padding-left: 5px;
-  color: var(--main);
-  font-weight: 400;
-}
+  .page-cheatmd h3 {
+    white-space: nowrap;
+    overflow: hidden;
+    margin: 0 0 1em;
+    padding-left: 5px;
+    color: var(--main);
+    font-weight: 400;
+  }
 
-.page-cheatmd section.h3 {
-  min-width: 300px;
-  margin: 0 0 2em 0;
-  break-inside: avoid;
-  -webkit-column-break-inside: avoid;
-}
+  .page-cheatmd section.h3 {
+    min-width: 300px;
+    margin: 0 0 2em 0;
+    break-inside: avoid;
+    -webkit-column-break-inside: avoid;
+  }
 
-.page-cheatmd h3::after {
-  margin-left: 24px;
-  content: "";
-  vertical-align: middle;
-  display: inline-block;
-  width: 100%;
-  height: 1px;
-  background: linear-gradient(
-    to right,
-    rgba(116, 95, 181, 0.2),
-    transparent 80%
-  );
-}
+  .page-cheatmd h3::after {
+    margin-left: 24px;
+    content: "";
+    vertical-align: middle;
+    display: inline-block;
+    width: 100%;
+    height: 1px;
+    background: linear-gradient(
+      to right,
+      rgba(116, 95, 181, 0.2),
+      transparent 80%
+    );
+  }
 
-/* h4 styling */
+  /* h4 styling */
 
-.page-cheatmd h4 {
-  display: block;
-  margin: 0;
-  padding: 0.25em 1.5em;
-  font-weight: 400;
-  background: var(--gray100);
-  color: #567;
-  border: solid 1px 1px 0 1px var(--gray100);
-}
+  .page-cheatmd h4 {
+    display: block;
+    margin: 0;
+    padding: 0.25em 1.5em;
+    font-weight: 400;
+    background: var(--gray100);
+    color: #567;
+    border: solid 1px 1px 0 1px var(--gray100);
+  }
 
-.page-cheatmd.dark h4 {
-  background: #192f50;
-  color: var(--textBody);
-  border: 1px solid #192f50;
-  border-bottom: 0;
-}
+  .page-cheatmd.dark h4 {
+    background: #192f50;
+    color: var(--textBody);
+    border: 1px solid #192f50;
+    border-bottom: 0;
+  }
 
-/* Paragraphs */
+  /* Paragraphs */
 
-.page-cheatmd .h2 p {
-  margin: 0;
-  display: block;
-  background: var(--gray50);
-  padding: 1.5em;
-}
+  .page-cheatmd .h2 p {
+    margin: 0;
+    display: block;
+    background: var(--gray50);
+    padding: 1.5em;
+  }
 
-.page-cheatmd.dark .h2 p {
-  background: var(--gray700);
-}
+  .page-cheatmd.dark .h2 p {
+    background: var(--gray700);
+  }
 
-.page-cheatmd .h2 p > code {
-  color: #eb5757;
-  border-radius: 3px;
-  padding: 0.2em 0.4em;
-}
+  .page-cheatmd .h2 p > code {
+    color: #eb5757;
+    border-radius: 3px;
+    padding: 0.2em 0.4em;
+  }
 
-/* Code blocks */
+  /* Code blocks */
 
-.page-cheatmd pre code {
-  padding: 1em 1.5em;
-}
+  .page-cheatmd pre code {
+    padding: 1em 1.5em;
+  }
 
-.page-cheatmd pre code::-webkit-scrollbar {
-  width: 0.4rem;
-  height: 0.6rem;
-}
+  .page-cheatmd pre code::-webkit-scrollbar {
+    width: 0.4rem;
+    height: 0.6rem;
+  }
 
-.page-cheatmd .h2 pre {
-  margin: 0;
-}
+  .page-cheatmd .h2 pre {
+    margin: 0;
+  }
 
-.page-cheatmd pre.wrap {
-  white-space: break-spaces;
-}
+  .page-cheatmd pre.wrap {
+    white-space: break-spaces;
+  }
 
-/* Tables */
+  /* Tables */
 
-.page-cheatmd .h2 table {
-  display: table;
-  box-sizing: border-box;
-  width: 100%;
-  border-collapse: collapse;
-  margin: 0;
-}
+  .page-cheatmd .h2 table {
+    display: table;
+    box-sizing: border-box;
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0;
+  }
 
-.page-cheatmd .h2 table th {
-  padding: 0.75em 1.5em;
-  line-height: 2em;
-  margin-bottom: -1px;
-  vertical-align: middle;
-  border-bottom: 1px solid var(--codeBorder);
-}
+  .page-cheatmd .h2 table th {
+    padding: 0.75em 1.5em;
+    line-height: 2em;
+    margin-bottom: -1px;
+    vertical-align: middle;
+    border-bottom: 1px solid var(--codeBorder);
+  }
 
-.page-cheatmd .h2 table td {
-  padding: 0.75em 1.5em;
-  border: 0;
-  border-bottom: 1px solid var(--codeBorder);
-}
+  .page-cheatmd .h2 table td {
+    padding: 0.75em 1.5em;
+    border: 0;
+    border-bottom: 1px solid var(--codeBorder);
+  }
 
-.page-cheatmd .h2 table tr:first-child {
-  border-top: 1px solid var(--codeBorder);
-}
+  .page-cheatmd .h2 table tr:first-child {
+    border-top: 1px solid var(--codeBorder);
+  }
 
-.page-cheatmd .h2 table td code {
-  color: #eb5757;
-  border-radius: 3px;
-  padding: 0.2em 0.4em;
-}
+  .page-cheatmd .h2 table td code {
+    color: #eb5757;
+    border-radius: 3px;
+    padding: 0.2em 0.4em;
+  }
 
-.page-cheatmd .h2 thead {
-  background-color: var(--gray50);
-}
+  .page-cheatmd .h2 thead {
+    background-color: var(--gray50);
+  }
 
-.page-cheatmd.dark .h2 thead {
-  background-color: var(--gray700);
-}
+  .page-cheatmd.dark .h2 thead {
+    background-color: var(--gray700);
+  }
 
-.page-cheatmd .h2 tbody {
-  background-color: var(--codeBackground);
-}
+  .page-cheatmd .h2 tbody {
+    background-color: var(--codeBackground);
+  }
 
-/* Lists */
-.page-cheatmd .h2 ul,
-.page-cheatmd .h2 ol {
-  margin: 0;
-  padding: 0;
-}
+  /* Lists */
+  .page-cheatmd .h2 ul,
+  .page-cheatmd .h2 ol {
+    margin: 0;
+    padding: 0;
+  }
 
-.page-cheatmd .h2 li {
-  list-style-position: inside;
-  padding: 0.5em 1.5em;
-  line-height: 2em;
-  vertical-align: middle;
-  background-color: var(--codeBackground);
-  border-bottom: 1px solid var(--codeBorder);
-}
+  .page-cheatmd .h2 li {
+    list-style-position: inside;
+    padding: 0.5em 1.5em;
+    line-height: 2em;
+    vertical-align: middle;
+    background-color: var(--codeBackground);
+    border-bottom: 1px solid var(--codeBorder);
+  }
 
-.page-cheatmd .h2 ul + pre code,
-.page-cheatmd .h2 ol + pre code {
-  border-top: 0;
-}
+  .page-cheatmd .h2 ul + pre code,
+  .page-cheatmd .h2 ol + pre code {
+    border-top: 0;
+  }
 
-.page-cheatmd .h2 li > code {
-  color: #eb5757;
-  border-radius: 3px;
-  padding: 0.2em 0.4em;
-}
+  .page-cheatmd .h2 li > code {
+    color: #eb5757;
+    border-radius: 3px;
+    padding: 0.2em 0.4em;
+  }
 
-/* Columns */
+  /* Columns */
 
-.page-cheatmd section.width-50 {
-  display: block;
-  width: 50%;
-  margin: 0;
-}
+  .page-cheatmd section.width-50 {
+    display: block;
+    width: 50%;
+    margin: 0;
+  }
 
-.page-cheatmd section.width-50 > section > table {
-  width: 100%;
-}
+  .page-cheatmd section.width-50 > section > table {
+    width: 100%;
+  }
 
-.page-cheatmd section.col-2 {
-  column-count: 2;
-  column-gap: 40px;
-  height: auto;
-}
-
-.page-cheatmd section.col-2-left {
-  display: grid;
-  grid-template-columns: 33% 63.2%;
-  column-gap: 40px;
-}
-
-.page-cheatmd section.col-2-left > h2 {
-  display: block;
-  grid-column-end: span 2;
-}
-
-.page-cheatmd section.col-3 {
-  column-count: 3;
-  column-gap: 40px;
-  height: auto;
-}
-
-.page-cheatmd section.list-4 > ul {
-  display: flex;
-  flex-wrap: wrap;
-}
-
-.page-cheatmd section.list-4 > ul > li {
-  flex: 0 0 25%;
-}
-
-.page-cheatmd section.list-6 > ul {
-  display: flex;
-  flex-wrap: wrap;
-}
-
-.page-cheatmd section.list-6 > ul > li {
-  flex: 0 0 16.6667%;
-}
-
-/* Media query */
-
-@media (max-width: 1400px) {
-  .page-cheatmd section.col-3 {
+  .page-cheatmd section.col-2 {
     column-count: 2;
     column-gap: 40px;
+    height: auto;
   }
 
   .page-cheatmd section.col-2-left {
+    display: grid;
+    grid-template-columns: 33% 63.2%;
+    column-gap: 40px;
+  }
+
+  .page-cheatmd section.col-2-left > h2 {
     display: block;
-    column-count: 1;
-  }
-}
-
-@media (max-width: 1200px) {
-  .page-cheatmd section.col-3,
-  .page-cheatmd section.col-2 {
-    column-count: 1;
+    grid-column-end: span 2;
   }
 
-  .page-cheatmd section.list-6 > ul > li {
+  .page-cheatmd section.col-3 {
+    column-count: 3;
+    column-gap: 40px;
+    height: auto;
+  }
+
+  .page-cheatmd section.list-4 > ul {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .page-cheatmd section.list-4 > ul > li {
     flex: 0 0 25%;
   }
-}
 
-@media (max-width: 1000px) {
-  .page-cheatmd section.list-4 > ul > li {
-    flex: 0 0 33%;
+  .page-cheatmd section.list-6 > ul {
+    display: flex;
+    flex-wrap: wrap;
   }
 
   .page-cheatmd section.list-6 > ul > li {
-    flex: 0 0 33%;
-  }
-}
-
-@media (max-width: 600px) {
-  .page-cheatmd section.list-4 > ul > li {
-    flex: 0 0 50%;
+    flex: 0 0 16.6667%;
   }
 
-  .page-cheatmd section.list-6 > ul > li {
-    flex: 0 0 50%;
+  /* Media query */
+
+  @media (max-width: 1400px) {
+    .page-cheatmd section.col-3 {
+      column-count: 2;
+      column-gap: 40px;
+    }
+
+    .page-cheatmd section.col-2-left {
+      display: block;
+      column-count: 1;
+    }
+  }
+
+  @media (max-width: 1200px) {
+    .page-cheatmd section.col-3,
+    .page-cheatmd section.col-2 {
+      column-count: 1;
+    }
+
+    .page-cheatmd section.list-6 > ul > li {
+      flex: 0 0 25%;
+    }
+  }
+
+  @media (max-width: 1000px) {
+    .page-cheatmd section.list-4 > ul > li {
+      flex: 0 0 33%;
+    }
+
+    .page-cheatmd section.list-6 > ul > li {
+      flex: 0 0 33%;
+    }
+  }
+
+  @media (max-width: 600px) {
+    .page-cheatmd section.list-4 > ul > li {
+      flex: 0 0 50%;
+    }
+
+    .page-cheatmd section.list-6 > ul > li {
+      flex: 0 0 50%;
+    }
   }
 }

--- a/assets/css/print-cheatsheet.css
+++ b/assets/css/print-cheatsheet.css
@@ -115,7 +115,7 @@
 
   .page-cheatmd h4 {
     display: block;
-    margin: 0;
+    margin: -1px 0 -1px 0;
     padding: 0.5em;
     border: solid 1px var(--gray800);
   }
@@ -131,7 +131,7 @@
      when multiple p tags are next to each other */
   .page-cheatmd .content-inner section p {
     display: block;
-    margin: 0;
+    margin: -1px 0 -1px 0;
     font-size: 0.95em;
     padding: 0.5em;
     border: solid;

--- a/assets/css/print-cheatsheet.css
+++ b/assets/css/print-cheatsheet.css
@@ -194,6 +194,7 @@
 
   .page-cheatmd .h2 li {
     padding: 0.5em;
+    margin-bottom: -1px;
     line-height: 1.5em;
     vertical-align: middle;
     border-bottom: 1px solid var(--gray800);

--- a/assets/css/print-cheatsheet.css
+++ b/assets/css/print-cheatsheet.css
@@ -193,7 +193,7 @@
   }
 
   .page-cheatmd .h2 li {
-    padding: 0.5em;
+    padding: 0.5em 0.75em;
     margin-bottom: -1px;
     line-height: 1.5em;
     vertical-align: middle;

--- a/assets/css/print-cheatsheet.css
+++ b/assets/css/print-cheatsheet.css
@@ -215,6 +215,10 @@
     border-bottom: 1px solid var(--gray200);
   }
 
+  .page-cheatmd .h2 li:last-of-type {
+    border-bottom: 0;
+  }
+
   /* Remove copy button from Code Blocks */
 
   pre:hover button.copy-button {

--- a/assets/css/print-cheatsheet.css
+++ b/assets/css/print-cheatsheet.css
@@ -205,4 +205,9 @@
   pre:hover button.copy-button {
     display: none;
   }
+
+  /* Remove hover tooltip from inline code references */
+  .page-cheatmd div#tooltip {
+    display: none;
+  }
 }

--- a/assets/css/print-cheatsheet.css
+++ b/assets/css/print-cheatsheet.css
@@ -1,0 +1,212 @@
+@media print {
+  /* Set page size to landscape for printing */
+  @page {
+    size: landscape;
+  }
+
+  /* Basic layout and columns */
+  .page-cheatmd .content-inner {
+    max-width: 100%;
+    width: 100%;
+    padding: 0;
+  }
+
+  .page-cheatmd section.col-2 {
+    column-count: 2;
+    column-gap: 20px;
+    height: auto;
+  }
+
+  .page-cheatmd section.col-2-left {
+    display: grid;
+    grid-template-columns: 33% 63.2%;
+    column-gap: 20px;
+  }
+
+  .page-cheatmd section.col-2-left > h2 {
+    display: block;
+    grid-column-end: span 2;
+  }
+
+  .page-cheatmd section.col-3 {
+    column-count: 3;
+    column-gap: 10px;
+    height: auto;
+  }
+
+  .page-cheatmd section.list-4 > ul > li {
+    flex: 0 0 25%;
+  }
+
+  .page-cheatmd section.list-6 > ul > li {
+    flex: 0 0 16.6667%;
+  }
+
+  .page-cheatmd section.list-4 > ul {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .page-cheatmd section.list-6 > ul {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .page-cheatmd section.width-50 {
+    display: block;
+    width: 50%;
+    margin: 0;
+  }
+
+  .page-cheatmd section.width-50 > section > table {
+    width: 100%;
+  }
+
+  /* h1 styling */
+
+  .page-cheatmd h1 {
+    margin-top: 0em;
+    margin-bottom: 1em;
+  }
+
+  /* h2 styling */
+
+  .page-cheatmd h2 {
+    margin: 1.5em 0 0.25em;
+    column-span: all;
+    padding-left: 8px;
+    border-left: solid 6px var(--gray500);
+  }
+
+  .page-cheatmd section.h2 {
+    page-break-inside: avoid;
+  }
+
+  /* h3 styling */
+
+  .page-cheatmd h3 {
+    white-space: nowrap;
+    overflow: hidden;
+    margin: 0 0 0.25em;
+    padding-left: 5px;
+  }
+
+  .page-cheatmd h3.section-heading {
+    overflow: hidden;
+  }
+
+  .page-cheatmd section.h3 {
+    min-width: 300px;
+    margin: 0 0 0.5em 0;
+    break-inside: avoid;
+    page-break-inside: avoid;
+    -webkit-column-break-inside: avoid;
+  }
+
+  /* Line to the side of the h3 */
+  .page-cheatmd h3.section-heading:after {
+    content: "";
+    display: inline-block;
+    height: 0.75em;
+    vertical-align: bottom;
+    width: 100%;
+    margin-right: -100%;
+    margin-left: 10px;
+    border-top: 2px solid var(--gray200);
+  }
+
+  /* h4 styling */
+
+  .page-cheatmd h4 {
+    display: block;
+    margin: 0;
+    padding: 0.25em;
+    /* font-weight: 600; */
+    border: solid 1px var(--gray800);
+  }
+
+  /* p styling */
+
+  .page-cheatmd .h2 p {
+    padding: 0.5em;
+  }
+
+  /* Ensure solo p tags have borders around them, but merge the border
+     when multiple p tags are next to each other */
+  .page-cheatmd .content-inner section p {
+    display: block;
+    margin: 0;
+    padding: 0.5em;
+    border: solid;
+    border-color: var(--gray800);
+    border-width: 1px 1px 0px 1px;
+  }
+
+  .page-cheatmd .content-inner section p + p {
+    border-width: 0px 1px 0px 1px;
+  }
+
+  .page-cheatmd .content-inner section p:last-of-type {
+    border-width: 0px 1px 1px 1px;
+  }
+
+  .page-cheatmd .content-inner section p:only-of-type {
+    border-width: 1px;
+  }
+
+  /* Tables */
+
+  .page-cheatmd table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0;
+    font-variant-numeric: tabular-nums;
+    page-break-inside: avoid;
+  }
+
+  .page-cheatmd th,
+  .page-cheatmd td {
+    vertical-align: top;
+    border: 1px solid var(--gray800);
+    padding: 0.25em 0.5em;
+  }
+
+  .page-cheatmd th {
+    font-weight: bold;
+    text-align: left;
+    color: var(--gray800);
+  }
+
+  /* Code Blocks */
+
+  .page-cheatmd pre {
+    margin: 0;
+  }
+
+  /* Lists */
+
+  .page-cheatmd ul,
+  .page-cheatmd ol {
+    border: 1px solid var(--gray800);
+    margin: 0;
+    padding: 0;
+    list-style-position: inside;
+  }
+
+  .page-cheatmd .h2 li {
+    padding: 0.25em 0.5em;
+    line-height: 1.5em;
+    vertical-align: middle;
+    border-bottom: 1px solid var(--gray800);
+  }
+
+  .page-cheatmd .h2 li:last-of-type {
+    border-bottom: 0px;
+  }
+
+  /* Remove copy button from Code Blocks */
+
+  pre:hover button.copy-button {
+    display: none;
+  }
+}

--- a/assets/css/print-cheatsheet.css
+++ b/assets/css/print-cheatsheet.css
@@ -120,8 +120,7 @@
   .page-cheatmd h4 {
     display: block;
     margin: 0;
-    padding: 0.25em;
-    /* font-weight: 600; */
+    padding: 0.5em;
     border: solid 1px var(--gray800);
   }
 
@@ -168,7 +167,7 @@
   .page-cheatmd td {
     vertical-align: top;
     border: 1px solid var(--gray800);
-    padding: 0.25em 0.5em;
+    padding: 0.5em;
   }
 
   .page-cheatmd th {
@@ -194,14 +193,10 @@
   }
 
   .page-cheatmd .h2 li {
-    padding: 0.25em 0.5em;
+    padding: 0.5em;
     line-height: 1.5em;
     vertical-align: middle;
     border-bottom: 1px solid var(--gray800);
-  }
-
-  .page-cheatmd .h2 li:last-of-type {
-    border-bottom: 0px;
   }
 
   /* Remove copy button from Code Blocks */

--- a/assets/css/print-cheatsheet.css
+++ b/assets/css/print-cheatsheet.css
@@ -71,7 +71,7 @@
     margin: 1em 0 0.25em;
     column-span: all;
     padding-left: 8px;
-    border-left: solid 6px var(--gray500);
+    border-left: solid 6px var(--gray100);
   }
 
   .page-cheatmd section.h2 {
@@ -165,16 +165,28 @@
 
   .page-cheatmd th,
   .page-cheatmd td {
+    text-align: left;
     vertical-align: top;
-    border: 1px solid var(--gray300);
     padding: 0.5em;
     font-size: 0.95em;
   }
 
+  .page-cheatmd thead {
+    border: 1px solid var(--gray300);
+  }
+
+  .page-cheatmd .content-inner thead tr {
+    border-bottom: none;
+  }
+
   .page-cheatmd th {
     font-weight: bold;
+  }
+
+  .page-cheatmd td {
+    border-bottom: 1px solid var(--gray200);
+    font-weight: bold;
     text-align: left;
-    color: var(--gray300);
   }
 
   /* Code Blocks */
@@ -187,7 +199,6 @@
 
   .page-cheatmd ul,
   .page-cheatmd ol {
-    border: 1px solid var(--gray300);
     margin: 0;
     padding: 0;
     list-style-position: inside;
@@ -195,10 +206,8 @@
 
   .page-cheatmd .h2 li {
     padding: 0.5em 0.75em;
-    margin-bottom: -1px;
-    line-height: 1.5em;
     vertical-align: middle;
-    border-bottom: 1px solid var(--gray300);
+    border-bottom: 1px solid var(--gray200);
   }
 
   /* Remove copy button from Code Blocks */

--- a/assets/css/print-cheatsheet.css
+++ b/assets/css/print-cheatsheet.css
@@ -117,7 +117,7 @@
     display: block;
     margin: -1px 0 -1px 0;
     padding: 0.5em;
-    border: solid 1px var(--gray800);
+    border: solid 1px var(--gray300);
   }
 
   /* p styling */
@@ -135,7 +135,7 @@
     font-size: 0.95em;
     padding: 0.5em;
     border: solid;
-    border-color: var(--gray800);
+    border-color: var(--gray300);
     border-width: 1px 1px 0px 1px;
   }
 
@@ -164,7 +164,7 @@
   .page-cheatmd th,
   .page-cheatmd td {
     vertical-align: top;
-    border: 1px solid var(--gray800);
+    border: 1px solid var(--gray300);
     padding: 0.5em;
     font-size: 0.95em;
   }
@@ -172,7 +172,7 @@
   .page-cheatmd th {
     font-weight: bold;
     text-align: left;
-    color: var(--gray800);
+    color: var(--gray300);
   }
 
   /* Code Blocks */
@@ -185,7 +185,7 @@
 
   .page-cheatmd ul,
   .page-cheatmd ol {
-    border: 1px solid var(--gray800);
+    border: 1px solid var(--gray300);
     margin: 0;
     padding: 0;
     list-style-position: inside;
@@ -196,7 +196,7 @@
     margin-bottom: -1px;
     line-height: 1.5em;
     vertical-align: middle;
-    border-bottom: 1px solid var(--gray800);
+    border-bottom: 1px solid var(--gray300);
   }
 
   /* Remove copy button from Code Blocks */

--- a/assets/css/print-cheatsheet.css
+++ b/assets/css/print-cheatsheet.css
@@ -108,7 +108,7 @@
     width: 100%;
     margin-right: -100%;
     margin-left: 10px;
-    border-top: 2px solid var(--gray100);
+    border-top: 2px solid var(--gray50);
   }
 
   /* h4 styling */

--- a/assets/css/print-cheatsheet.css
+++ b/assets/css/print-cheatsheet.css
@@ -175,6 +175,12 @@
     border: 1px solid var(--gray300);
   }
 
+  .page-cheatmd .content-inner tbody tr {
+    border-width: 0px 1px 1px 1px;
+    border-style: solid;
+    border-color: var(--gray200);
+  }
+
   .page-cheatmd .content-inner thead tr {
     border-bottom: none;
   }
@@ -184,7 +190,6 @@
   }
 
   .page-cheatmd td {
-    border-bottom: 1px solid var(--gray200);
     font-weight: bold;
     text-align: left;
   }

--- a/assets/css/print-cheatsheet.css
+++ b/assets/css/print-cheatsheet.css
@@ -1,9 +1,4 @@
 @media print {
-  /* Set page size to landscape for printing */
-  @page {
-    size: landscape;
-  }
-
   /* Basic layout and columns */
   .page-cheatmd .content-inner {
     max-width: 100%;

--- a/assets/css/print-cheatsheet.css
+++ b/assets/css/print-cheatsheet.css
@@ -124,6 +124,7 @@
 
   .page-cheatmd .content-inner p {
     font-size: 0.95em;
+    line-height: 1.5em;
     padding: 0.5em;
   }
 
@@ -133,6 +134,7 @@
     display: block;
     margin: -1px 0 -1px 0;
     font-size: 0.95em;
+    line-height: 1.5em;
     padding: 0.5em;
     border: solid;
     border-color: var(--gray300);

--- a/assets/css/print-cheatsheet.css
+++ b/assets/css/print-cheatsheet.css
@@ -9,6 +9,7 @@
     max-width: 100%;
     width: 100%;
     padding: 0;
+    font-size: 0.85em;
   }
 
   .page-cheatmd section.col-2 {
@@ -66,13 +67,13 @@
 
   .page-cheatmd h1 {
     margin-top: 0em;
-    margin-bottom: 1em;
+    margin-bottom: 0.5em;
   }
 
   /* h2 styling */
 
   .page-cheatmd h2 {
-    margin: 1.5em 0 0.25em;
+    margin: 1em 0 0.25em;
     column-span: all;
     padding-left: 8px;
     border-left: solid 6px var(--gray500);
@@ -126,7 +127,8 @@
 
   /* p styling */
 
-  .page-cheatmd .h2 p {
+  .page-cheatmd .content-inner p {
+    font-size: 0.95em;
     padding: 0.5em;
   }
 
@@ -135,6 +137,7 @@
   .page-cheatmd .content-inner section p {
     display: block;
     margin: 0;
+    font-size: 0.95em;
     padding: 0.5em;
     border: solid;
     border-color: var(--gray800);
@@ -168,6 +171,7 @@
     vertical-align: top;
     border: 1px solid var(--gray800);
     padding: 0.5em;
+    font-size: 0.95em;
   }
 
   .page-cheatmd th {

--- a/assets/css/print-cheatsheet.css
+++ b/assets/css/print-cheatsheet.css
@@ -93,7 +93,7 @@
 
   .page-cheatmd section.h3 {
     min-width: 300px;
-    margin: 0 0 0.5em 0;
+    margin: 0 0 0.75em 0;
     break-inside: avoid;
     page-break-inside: avoid;
     -webkit-column-break-inside: avoid;
@@ -108,7 +108,7 @@
     width: 100%;
     margin-right: -100%;
     margin-left: 10px;
-    border-top: 2px solid var(--gray200);
+    border-top: 2px solid var(--gray100);
   }
 
   /* h4 styling */

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -1,3 +1,5 @@
+/* Standard print styles */
+
 @media print {
   .main {
     display: block;
@@ -61,5 +63,142 @@
 
   .content-inner code.inline {
     border-color: var(--gray300);
+  }
+}
+
+/* Cheatsheet Print Styles */
+
+@media print {
+  .page-cheatmd .content-inner {
+    max-width: 1000px;
+  }
+
+  /* Columns */
+
+  .page-cheatmd section.list-4 > ul > li {
+    flex: 0 0 50%;
+  }
+
+  .page-cheatmd section.list-6 > ul > li {
+    flex: 0 0 33%;
+  }
+
+  .page-cheatmd section.list-4 > ul {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .page-cheatmd section.list-6 > ul {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  /* Headers */
+
+  .page-cheatmd h3.section-heading {
+    overflow: hidden;
+  }
+
+  /* There is a -2.7em margin for the other style sheet, but its incorrect here */
+  .page-cheatmd .content-inner .section-heading a.hover-link {
+    margin-left: -2.45em;
+  }
+
+  /* Line to the side of the h3 */
+  .page-cheatmd h3.section-heading:after {
+    content: "";
+    display: inline-block;
+    height: 0.75em;
+    vertical-align: bottom;
+    width: 100%;
+    margin-right: -100%;
+    margin-left: 10px;
+    border-top: 2px solid var(--gray200);
+  }
+
+  .page-cheatmd h4 {
+    display: block;
+    margin: 0;
+    padding: 0.25em 1.5em;
+    font-weight: 400;
+    border: solid 1px var(--gray800);
+  }
+
+  /* Ensure solo p tags have borders around them, but merge the border
+     when multiple p tags are next to each other */
+  .page-cheatmd .content-inner section p {
+    display: block;
+    margin: 0;
+    padding: 0.25em 1.5em;
+    border: solid;
+    border-color: var(--gray800);
+    border-width: 1px 1px 0px 1px;
+  }
+
+  .page-cheatmd .content-inner section p + p {
+    border-width: 0px 1px 0px 1px;
+  }
+
+  .page-cheatmd .content-inner section p:last-of-type {
+    border-width: 0px 1px 1px 1px;
+  }
+
+  .page-cheatmd .content-inner section p:only-of-type {
+    border-width: 1px;
+  }
+
+  /* Tables */
+
+  .page-cheatmd table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .page-cheatmd th,
+  .page-cheatmd td {
+    vertical-align: top;
+    border: 1px solid var(--gray800);
+    line-height: 15px;
+    padding: 15px;
+  }
+
+  .page-cheatmd th {
+    font-weight: bold;
+    text-align: left;
+    color: var(--gray800);
+  }
+
+  /* Code blocks */
+
+  .page-cheatmd pre {
+    margin: 0;
+  }
+
+  .page-cheatmd content-inner pre code.makeup {
+    border-color: var(--gray300);
+    white-space: break-spaces;
+  }
+
+  /* Lists */
+
+  .page-cheatmd ul,
+  .page-cheatmd ol {
+    border: 1px solid var(--gray800);
+    margin: 0;
+    padding: 0;
+    list-style-position: inside;
+  }
+
+  .page-cheatmd .h2 li {
+    padding: 0.5em 1.5em;
+    line-height: 2em;
+    vertical-align: middle;
+    border-bottom: 1px solid var(--gray800);
+  }
+
+  .page-cheatmd .h2 li:last-of-type {
+    border-bottom: 0px;
   }
 }

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -1,5 +1,3 @@
-/* Standard print styles */
-
 @media print {
   .main {
     display: block;
@@ -56,6 +54,8 @@
   .content-inner pre code.makeup {
     border-color: var(--gray300);
     white-space: break-spaces;
+    page-break-inside: avoid;
+    break-inside: avoid;
   }
 
   .content-inner blockquote code.inline {
@@ -64,142 +64,5 @@
 
   .content-inner code.inline {
     border-color: var(--gray300);
-  }
-}
-
-/* Cheatsheet Print Styles */
-
-@media print {
-  .page-cheatmd .content-inner {
-    max-width: 1000px;
-  }
-
-  /* Columns */
-
-  .page-cheatmd section.list-4 > ul > li {
-    flex: 0 0 50%;
-  }
-
-  .page-cheatmd section.list-6 > ul > li {
-    flex: 0 0 33%;
-  }
-
-  .page-cheatmd section.list-4 > ul {
-    display: flex;
-    flex-wrap: wrap;
-  }
-
-  .page-cheatmd section.list-6 > ul {
-    display: flex;
-    flex-wrap: wrap;
-  }
-
-  /* Headers */
-
-  .page-cheatmd h3.section-heading {
-    overflow: hidden;
-  }
-
-  /* There is a -2.7em margin for the other style sheet, but its incorrect here */
-  .page-cheatmd .content-inner .section-heading a.hover-link {
-    margin-left: -2.45em;
-  }
-
-  /* Line to the side of the h3 */
-  .page-cheatmd h3.section-heading:after {
-    content: "";
-    display: inline-block;
-    height: 0.75em;
-    vertical-align: bottom;
-    width: 100%;
-    margin-right: -100%;
-    margin-left: 10px;
-    border-top: 2px solid var(--gray200);
-  }
-
-  .page-cheatmd h4 {
-    display: block;
-    margin: 0;
-    padding: 0.25em 1.5em;
-    font-weight: 400;
-    border: solid 1px var(--gray800);
-  }
-
-  /* Ensure solo p tags have borders around them, but merge the border
-     when multiple p tags are next to each other */
-  .page-cheatmd .content-inner section p {
-    display: block;
-    margin: 0;
-    padding: 1.5em;
-    border: solid;
-    border-color: var(--gray800);
-    border-width: 1px 1px 0px 1px;
-  }
-
-  .page-cheatmd .content-inner section p + p {
-    border-width: 0px 1px 0px 1px;
-  }
-
-  .page-cheatmd .content-inner section p:last-of-type {
-    border-width: 0px 1px 1px 1px;
-  }
-
-  .page-cheatmd .content-inner section p:only-of-type {
-    border-width: 1px;
-  }
-
-  /* Tables */
-
-  .page-cheatmd table {
-    width: 100%;
-    border-collapse: collapse;
-    margin: 0;
-    font-variant-numeric: tabular-nums;
-  }
-
-  .page-cheatmd th,
-  .page-cheatmd td {
-    vertical-align: top;
-    border: 1px solid var(--gray800);
-    line-height: 15px;
-    padding: 15px;
-  }
-
-  .page-cheatmd th {
-    font-weight: bold;
-    text-align: left;
-    color: var(--gray800);
-  }
-
-  /* Code blocks */
-
-  .page-cheatmd pre {
-    margin: 0;
-  }
-
-  .page-cheatmd content-inner pre code.makeup {
-    border-color: var(--gray300);
-    white-space: break-spaces;
-  }
-
-  /* Lists */
-
-  .page-cheatmd ul,
-  .page-cheatmd ol {
-    border: 1px solid var(--gray800);
-    margin: 0;
-    padding: 0;
-    list-style-position: inside;
-  }
-
-  .page-cheatmd .h2 li {
-    padding: 0.5em 1.5em;
-    line-height: 2em;
-    vertical-align: middle;
-    border-bottom: 1px solid var(--gray800);
-  }
-
-  .page-cheatmd .h2 li:last-of-type {
-    border-bottom: 0px;
   }
 }

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -37,7 +37,8 @@
     display: none;
   }
 
-  .footer {
+  /* Hide On Hex.pm text but keep Built Using ExDoc */
+  .footer p:first-of-type {
     display: none;
   }
 

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -130,7 +130,7 @@
   .page-cheatmd .content-inner section p {
     display: block;
     margin: 0;
-    padding: 0.25em 1.5em;
+    padding: 1.5em;
     border: solid;
     border-color: var(--gray800);
     border-width: 1px 1px 0px 1px;

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -23,6 +23,10 @@
     display: none;
   }
 
+  .content-inner .section-heading a.hover-link {
+    display: none;
+  }
+
   a.view-source {
     display: none;
   }

--- a/lib/ex_doc/formatter/html/templates/head_template.eex
+++ b/lib/ex_doc/formatter/html/templates/head_template.eex
@@ -11,6 +11,9 @@
     <% end %>
     <title><%= page.title %> — <%= config.project %> v<%= config.version %></title>
     <link rel="stylesheet" href="<%= asset_rev config.output, "dist/html-#{config.proglang}*.css" %>" />
+    <%= if page.type == :cheatmd do %>
+      <style>@media print { @page { size: landscape; } }</style>
+    <% end %>
     <%= if config.canonical do %>
       <link rel="canonical" href="<%= config.canonical %>" />
     <% end %>


### PR DESCRIPTION
Hey hey! This attempts to make the printed version appear more like a low-ink version of the one column 1000px screen version of the Cheatsheet.

By wrapping all of the existing cheatsheet css in `@media screen` and adding a `@media print` section for the cheatsheet we have fewer styles to overwrite for printability. It halves the amount the columns displayed: `.list-4` displays 2, `.list-6` displays 3, etc. I've also brought back the Built using ExDoc portion of the footer string.

Styling for print could make further departures from the screen version for clarity but this is a large difference in usability from the existing print styles.

Two PDFs of the [ExDoc Cheatsheet](https://hexdocs.pm/ex_doc/cheatsheet.html) for comparison:

[Cheatsheet User Guide - Old.pdf](https://github.com/elixir-lang/ex_doc/files/10040549/Cheatsheet.User.Guide.ExDoc.v0.29.0.-.Old.Print.pdf)

[Cheatsheet User Guide - New.pdf](https://github.com/elixir-lang/ex_doc/files/10040598/Cheatsheet.User.Guide.ExDoc.v0.29.0.-.New.Print.pdf)


## ExDoc Cheatsheet Screen Version
![image](https://user-images.githubusercontent.com/454563/202688050-4f9a509b-6206-4200-a754-6faae669e6f7.png)

## Original Print
![image](https://user-images.githubusercontent.com/454563/202687952-c43678b4-b050-4c92-9f79-34e4d6733e0e.png)

## New Print
![image](https://user-images.githubusercontent.com/454563/202688771-3dec3fe5-e2fb-4fa2-8955-7858f6ed5939.png)
![image](https://user-images.githubusercontent.com/454563/202689425-b3b2bb07-3f51-468a-a561-9cf1d70367f7.png)





