### PR TITLE
Firefox H2 print rendering fix

### DIFF
--- a/assets/css/print-cheatsheet.css
+++ b/assets/css/print-cheatsheet.css
@@ -185,7 +185,6 @@
   }
 
   .page-cheatmd td {
-    font-weight: bold;
     text-align: left;
   }
 

--- a/assets/css/print-cheatsheet.css
+++ b/assets/css/print-cheatsheet.css
@@ -67,11 +67,18 @@
 
   /* h2 styling */
 
-  .page-cheatmd h2 {
+  .page-cheatmd h2.section-heading {
     margin: 1em 0 0.25em;
     column-span: all;
-    padding-left: 8px;
+  }
+
+  /* for some reason Firefox extends the h2 border-left to the following h3 when printing,
+     moving the border-left to the :before pseudo-element fixes this */
+
+  .page-cheatmd h2.section-heading:before {
     border-left: solid 6px var(--gray100);
+    margin-right: 8px;
+    content: " ";
   }
 
   .page-cheatmd section.h2 {

--- a/assets/css/print-cheatsheet.css
+++ b/assets/css/print-cheatsheet.css
@@ -192,7 +192,7 @@
   /* Code Blocks */
 
   .page-cheatmd pre {
-    margin: 0;
+    margin: -1px 0px -1px 0px;
   }
 
   /* Lists */

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -27,11 +27,11 @@
     display: none;
   }
 
-  a.view-source {
+  .content-inner button.icon-action {
     display: none;
   }
 
-  button.display-settings {
+  .content-inner a.icon-action {
     display: none;
   }
 


### PR DESCRIPTION
Hey hey!

Couldn't let this ship tomorrow without at least giving Firefox a look!
The markup looks fine so I can't quite give a good answer to why Firefox print renderer brings the H2's border down into the H3 in that one instance, but by using a `:before` pseudo element to add the border we remove the issue.

While I was there, I cleaned up the removal of the Print/Settings/View Source icons as two of them still rendered on print.

Additionally, I collapsed the borders on the code elements so there wouldn't be a double thick line when two code elements followed each other.

[Firefox Fixes.pdf](https://github.com/elixir-lang/ex_doc/files/10052605/firefox.fix.pdf)

### Firefox Print Rendering Oddity
When Firefox renders a PDF it handles `font-weight: 700` oddly and effectively just doubles the text and shifts it slightly?
Looks fine when you print from Firefox, but when you zoom in, bold text in the saved PDF looks quite weird.

I've removed the `font-weight: bold` from the `td` which fixes this and looks to be more correct, but thought I should document this rendering oddity.

![image](https://user-images.githubusercontent.com/454563/202937724-31fd7b5b-52fa-4747-a6fe-eb25687f0b35.png)