### PR TITLE
Add watch mode to asset build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,15 +291,15 @@ For more details and configuration options see the [Mermaid usage docs](https://
 
 The easiest way to test changes to ExDoc is to locally rebuild the app and its own documentation:
 
-  1. Run `mix setup` to install all dependencies
-  2. Run `mix build` to generate docs. This is a custom alias that will build assets, recompile ExDoc, and output fresh docs into the `doc/` directory
-  3. If you want to contribute a pull request, please do not add to your commits the files generated in the `formatters/` directory
-  4. Run `mix lint` to check if the Elixir and JavaScript files are properly formatted.
-     You can run `mix fix` to let the JavaScript linter and Elixir formatter fix the code automatically before submitting your pull request
-
-If working on the assets, please see the README in the `assets/` directory.
+  1. Run `mix setup` to install all dependencies.
+  2. Run `mix build` to generate the docs. This is a custom alias that will build assets, recompile ExDoc, and output fresh docs into the `doc/` directory.
+  3. If working on the assets, you may wish to run the assets build script in watch mode: `npm run --prefix assets build:watch`.
+  4. Run `mix lint` to check if the Elixir and JavaScript files are properly formatted. You can run `mix fix` to let the JavaScript linter and Elixir formatter fix the code automatically before submitting your pull request.
+  5. Please do not add the files generated in the `formatters/` directory to your commits. These will be handled as necessary by the repository maintainers.
 
 The build process is currently tested in Node 16 LTS.
+
+See the README in the `assets/` directory for more information on working on the assets.
 
 ## License
 

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,9 +1,9 @@
 # Assets
 
-In this directory live all assets for `ExDoc`. The built, ready-to-use
+All asset sources for `ExDoc` live in this directory. The built, ready-to-use
 versions are found in `formatters/{html,epub}/dist`.
 
-To work on these assets you first need to install [Node.js] and [npm]. (npm
+To work on these assets you need to have [Node.js] and [npm] installed. (npm
 is usually installed along with Node.js.) The build process is currently tested
 in Node 16 LTS.
 
@@ -25,10 +25,25 @@ The following scripts are available from the root folder of the project.
 $ npm run --prefix assets build
 ```
 
-This will build a complete production bundle, including JavaScript and CSS.
-If you run `mix build` at the `ExDoc` root after changing your assets, it will
-automatically recompile the assets, invoke `mix compile --force`, and generate
-fresh docs with your changes.
+Build a complete production bundle, including JavaScript and CSS.
+
+(Note that this is not required to be manually run when generating docs: if you
+run `mix build` at the `ExDoc` root after changing your assets, the
+assets will be recompiled, `mix compile --force` will be invoked, and fresh
+docs with your changes will be generated.)
+
+### `build:watch`
+
+```bash
+$ npm run --prefix assets build:watch
+```
+
+Run the `build` command with watch mode set, providing for automatic assets
+rebuilds on every asset file change.
+
+Additionally, in watch mode, the docs are built after every asset rebuild,
+meaning the only action required to check results after changing asset sources
+is to refresh/reload the browser or ePub reader.
 
 ### `lint`
 
@@ -53,6 +68,7 @@ $ npm run --prefix assets test
 ```
 
 Run all the available JavaScript tests using [Karma].
+
 
 [esbuild]: https://esbuild.github.io
 [Node.js]: https://nodejs.org/

--- a/assets/build/build.js
+++ b/assets/build/build.js
@@ -1,25 +1,25 @@
 const path = require('node:path')
+const process = require('node:process')
+const child_process = require('node:child_process')
 const esbuild = require('esbuild')
 const util = require('./utilities')
+
+const watchMode = Boolean(process.env.npm_config_watch)
 
 
 /**
  * Configuration variables
  */
 
-// Build options
+// Basic build configuration and values
 const commonOptions = {
   entryNames: '[name]-[hash]',
   bundle: true,
   minify: true,
-  logLevel: 'info',
+  logLevel: watchMode ? 'warning' : 'info',
 }
-const epubOptions = {
-  outdir: path.resolve('../formatters/epub/dist'),
-}
-const htmlOptions = {
-  outdir: path.resolve('../formatters/html/dist'),
-}
+const epubOutDir = path.resolve('../formatters/epub/dist')
+const htmlOutDir = path.resolve('../formatters/html/dist')
 
 // Handlebars template paths
 const templates = {
@@ -29,52 +29,67 @@ const templates = {
 }
 templates.compiledPath = path.join(templates.compiledDir, templates.filename)
 
-// Directories to create/clean
-const cleanDirs = {
-  pre: [
-    epubOptions.outdir,
-    htmlOptions.outdir,
-    templates.compiledDir,
-  ],
-  postHtml: [
-    templates.compiledDir,
-  ],
+
+/**
+ * Build: Plugins
+ */
+
+// Empty outdir directories before both normal and watch-mode builds
+const epubOnStartPlugin = {
+  name: 'epubOnStart',
+  setup(build) { build.onStart(() => util.ensureEmptyDirsExistSync([epubOutDir])) },
+}
+const htmlOnStartPlugin = {
+  name: 'htmlOnStart',
+  setup(build) { build.onStart(() => util.ensureEmptyDirsExistSync([htmlOutDir])) },
 }
 
 
 /**
- * Clean: pre-build
+ * Build
  */
 
-util.ensureEmptyDirsExistSync(cleanDirs.pre)
-
-
-/**
- * Build: ePub
- */
-
-const epubBuild = esbuild.build({
+// ePub: esbuild options
+const epubBuildOptions = {
   ...commonOptions,
-  ...epubOptions,
+  outdir: epubOutDir,
+  plugins: [epubOnStartPlugin],
   entryPoints: [
     'js/entry/epub.js',
     'css/entry/epub-elixir.css',
     'css/entry/epub-erlang.css',
   ],
-}).catch(() => process.exit(1))
+}
 
+// ePub: esbuild (conditionally configuring watch mode and rebuilding of docs)
+if (!watchMode) {
+  esbuild.build(epubBuildOptions).catch(() => process.exit(1))
+} else {
+  esbuild.build({
+    ...epubBuildOptions,
+    watch: {
+      onRebuild(error, result) {
+        if (error) {
+          console.error('[watch] epub build failed:', error)
+        } else {
+          console.log('[watch] epub assets rebuilt')
+          if (result.errors.length > 0) console.log('[watch] epub build errors:', result.errors)
+          if (result.warnings.length > 0) console.log('[watch] epub build warnings:', result.warnings)
+          generateDocs("epub")
+        }
+      },
+    },
+  }).then(() => generateDocs("epub")).catch(() => process.exit(1))
+}
 
-/**
- * Build: HTML
- */
-
-// Precompile Handlebars templates
+// HTML: Precompile Handlebars templates
 util.runShellCmdSync(`npx handlebars ${templates.sourceDir} --output ${templates.compiledPath}`)
 
-// esbuild
-const htmlBuild = esbuild.build({
+// HTML: esbuild options
+const htmlBuildOptions = {
   ...commonOptions,
-  ...htmlOptions,
+  outdir: htmlOutDir,
+  plugins: [htmlOnStartPlugin],
   entryPoints: [
     templates.compiledPath,
     'js/entry/html.js',
@@ -86,22 +101,60 @@ const htmlBuild = esbuild.build({
     // TODO: Remove when @fontsource/* removes legacy .woff
     '.woff': 'file',
   },
-}).catch(() => process.exit(1))
+}
 
+// HTML: esbuild (conditionally configuring watch mode and rebuilding of docs)
+if (!watchMode) {
+  esbuild.build(htmlBuildOptions).catch(() => process.exit(1))
+} else {
+  esbuild.build({
+    ...htmlBuildOptions,
+    watch: {
+      onRebuild(error, result) {
+        if (error) {
+          console.error('[watch] html build failed:', error)
+        } else {
+          console.log('[watch] html assets rebuilt')
+          if (result.errors.length > 0) console.log('[watch] html build errors:', result.errors)
+          if (result.warnings.length > 0) console.log('[watch] html build warnings:', result.warnings)
+          buildTemplatesRuntime()
+          generateDocs("html")
+        }
+      },
+    },
+  }).then(() => {
+    buildTemplatesRuntime()
+    generateDocs("html")
+  }).catch(() => process.exit(1))
+}
+
+/**
+ * Functions
+ */
+
+// HTML: Handlebars runtime
 // The Handlebars runtime from the local module dist directory is used to ensure
 // the version matches that which was used to compile the templates.
 // 'bundle' must be false in order for 'Handlebar' to be available at runtime.
-esbuild.build({
-  ...commonOptions,
-  ...htmlOptions,
-  entryPoints: ['node_modules/handlebars/dist/handlebars.runtime.js'],
-  bundle: false,
-}).catch(() => process.exit(1))
+function buildTemplatesRuntime() {
+  esbuild.build({
+    ...commonOptions,
+    outdir: htmlOutDir,
+    entryPoints: ['node_modules/handlebars/dist/handlebars.runtime.js'],
+    bundle: false,
+  }).catch(() => process.exit(1))
+}
+// Build of the templates runtime is not required here when in watch mode, as
+// the ebuild watch mode config already provides for such.
+if (!watchMode) {
+  buildTemplatesRuntime()
+}
 
-
-/**
- * Clean: post-build
- */
-Promise.all([epubBuild, htmlBuild]).then(() => {
-  util.ensureEmptyDirsExistSync(cleanDirs.postHtml)
-})
+// Docs generation (used in watch mode only)
+function generateDocs(formatter) {
+  console.log(`Building ${formatter} docs`)
+  process.chdir('../')
+  child_process.execSync('mix compile --force')
+  child_process.execSync(`mix docs --formatter ${formatter}`)
+  process.chdir('./assets/')
+}

--- a/assets/build/build.js
+++ b/assets/build/build.js
@@ -105,7 +105,7 @@ const htmlBuildOptions = {
 
 // HTML: esbuild (conditionally configuring watch mode and rebuilding of docs)
 if (!watchMode) {
-  esbuild.build(htmlBuildOptions).catch(() => process.exit(1))
+  esbuild.build(htmlBuildOptions).then(() => buildTemplatesRuntime()).catch(() => process.exit(1))
 } else {
   esbuild.build({
     ...htmlBuildOptions,
@@ -143,11 +143,6 @@ function buildTemplatesRuntime() {
     entryPoints: ['node_modules/handlebars/dist/handlebars.runtime.js'],
     bundle: false,
   }).catch(() => process.exit(1))
-}
-// Build of the templates runtime is not required here when in watch mode, as
-// the ebuild watch mode config already provides for such.
-if (!watchMode) {
-  buildTemplatesRuntime()
 }
 
 // Docs generation (used in watch mode only)

--- a/assets/package.json
+++ b/assets/package.json
@@ -12,6 +12,7 @@
     "lint": "npx eslint './js/**/*.js'",
     "lint:fix": "npx eslint --fix './js/**/*.js'",
     "test": "npx karma start ./karma.conf.js --single-run",
+    "build:watch": "npm run build --watch",
     "build": "node build/build.js"
   },
   "repository": {


### PR DESCRIPTION
To help with working on the assets.

When in watch mode, docs are rebuilt after each assets rebuild. I've used [mix commands](https://github.com/elixir-lang/ex_doc/pull/1632/files#diff-bcfc80f32c23faeb609b83289a81441e9c957c11adf7e9ddaef23e7647cf2d69R152-R153), triggered with `child_process.execSync()`. I now wonder if we can detect whether Mix or Rebar is in use and alter the commands as necessary to support both?

HTML and ePub rebuilds are done independently of each other, depending on which assets are changed.

A browser/ePub reader refresh/reload is currently still required, but at least we no longer have to run the `mix build` command for every iteration. Perhaps a mean of auto-refreshing the browser could be added later.