### PR TITLE
Change format for tooltip header

### DIFF
--- a/assets/css/content/functions.css
+++ b/assets/css/content/functions.css
@@ -17,7 +17,7 @@
 .content-inner .detail-header {
   margin: 2.0em 0 1.0em;
   padding: .5em 1em;
-  background-color: var(--textDetailBackground);
+  background-color: var(--codeBackground);
   border-left: 3px solid var(--main);
   font-size: 1em;
   font-family: var(--monoFontFamily);
@@ -32,7 +32,6 @@
   display: inline-block;
   font-family: var(--monoFontFamily);
   font-size: 1rem;
-  font-weight: 700;
 }
 
 .content-inner .detail-header:hover a.detail-link {

--- a/assets/js/handlebars/templates/tooltip-body.handlebars
+++ b/assets/js/handlebars/templates/tooltip-body.handlebars
@@ -4,10 +4,10 @@
   </section>
 {{else}}
   <div class="detail-header">
-    <h1 class="signature">
+    <div class="signature">
       <span translate="no">{{this.hint.title}}</span>
       <div class="version-info" translate="no">{{this.hint.version}}</div>
-    </h1>
+    </div>
   </div>
   {{#if this.hint.description}}
     <section class="docstring">


### PR DESCRIPTION
Fixes #1639 

Result screen for light theme:
<img width="497" alt="image" src="https://user-images.githubusercontent.com/38437931/209975750-4283e2d0-2135-4cf5-8ddb-4bc2d76eaa61.png">

And for dark:
<img width="497" alt="image" src="https://user-images.githubusercontent.com/38437931/209975859-dd1b582e-4cfd-4d2e-8e84-285a0ad57396.png">
