### PR TITLE
Add media type for .license files for epub

### DIFF
--- a/lib/ex_doc/formatter/epub/templates/media-types.txt
+++ b/lib/ex_doc/formatter/epub/templates/media-types.txt
@@ -16,3 +16,4 @@ mp3,audio/mpeg
 mp4,video/mp4
 css,text/css
 js,text/javascript
+license,text/plain


### PR DESCRIPTION
This fixes an error when creating epub docs when an assets directory
contains `.license` files. These files are used to specify license and
copyright information to binary files like JPEGs and PNGs. See the
the [REUSE Specification](https://reuse.software) for an example that
documents the use of these files.
