### PR TITLE
Fix issues introduced by "Use more horizontal space on smaller screens"

### DIFF
--- a/assets/css/content/cheatsheet.css
+++ b/assets/css/content/cheatsheet.css
@@ -126,6 +126,13 @@
     white-space: break-spaces;
   }
 
+  @media screen and (max-width: 768px) {
+    .page-cheatmd pre code {
+      border-left-width: 1px !important;
+      border-right-width: 1px !important;
+    }
+  }
+
   /* Tables */
 
   .page-cheatmd .h2 table {

--- a/assets/css/content/code.css
+++ b/assets/css/content/code.css
@@ -87,8 +87,8 @@
   */
   .content-inner > pre,
   .content-inner section > pre {
-    margin-left: calc(-1 * var(--content-gutter) - 2px);
-    margin-right: calc(-1 * var(--content-gutter) - 2px);
+    margin-left: calc(-1 * var(--content-gutter));
+    margin-right: calc(-1 * var(--content-gutter));
   }
 
   .content-inner > pre code,
@@ -96,5 +96,7 @@
     padding-left: var(--content-gutter);
     padding-right: var(--content-gutter);
     border-radius: 0;
+    border-left-width: 0;
+    border-right-width: 0;
   }
 }


### PR DESCRIPTION
Reference: #1643 

It might be worth leaving this open until other people have been able to provide feedback, in which case this can just be a catch-all for related fixes.

Link to review live mobile styles: https://hexdocs.pm/elixir/master/Kernel.html

- [x] Fix slight horizontal scroll due to overflowing full-bleed code blocks.