### PR TITLE
Use full-width for tabs and use variable for border-radius

### DIFF
--- a/assets/css/custom-props/common.css
+++ b/assets/css/custom-props/common.css
@@ -2,6 +2,7 @@
   /* Layout & Whitespace */
   --content-width: 949px;
   --content-gutter: 60px;
+  --border-radius: 4px;
 
   /* Font Families */
   --serifFontFamily: 'Merriweather', 'Book Antiqua', Georgia, 'Century Schoolbook', serif;

--- a/assets/css/keyboard-shortcuts.css
+++ b/assets/css/keyboard-shortcuts.css
@@ -22,7 +22,7 @@
 #keyboard-shortcuts-content kbd > kbd {
   background-color: var(--settingsInputBorder);
   color: var(--contrast);
-  border-radius: 3px;
+  border-radius: var(--border-radius);
   font-family: inherit;
   font-weight: bold;
   display: inline-block;

--- a/assets/css/modal.css
+++ b/assets/css/modal.css
@@ -27,7 +27,7 @@
   margin: 75px auto 0 auto;
   max-width: 500px;
   background-color: var(--modalBackground);
-  border-radius: 3px;
+  border-radius: var(--border-radius);
   box-shadow: 2px 2px 8px rgba(0, 0, 0, .2);
   padding: 25px 35px 35px;
 }

--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -39,7 +39,7 @@
 
 .sidebar .sidebar-header {
   margin: 12px;
-  border-radius: 4px;
+  border-radius: var(--border-radius);
   background-color: var(--gray700);
   width: 276px;
 }
@@ -120,6 +120,7 @@
   padding: 0;
   padding-top: 12px;
   margin: 0;
+  display: flex;
 }
 
 .sidebar .sidebar-listNav :is(li, li a) {
@@ -130,9 +131,18 @@
 }
 
 .sidebar .sidebar-listNav li {
-  display: inline-block;
+  text-align: center;
+  width: 100%;
   border-bottom: 3px solid transparent;
   line-height: 27px;
+}
+
+.sidebar .sidebar-listNav li:first-child {
+  border-bottom-left-radius: var(--border-radius);
+}
+
+.sidebar .sidebar-listNav li:last-child {
+  border-bottom-right-radius: var(--border-radius);
 }
 
 .sidebar .sidebar-listNav li:is(:hover, .selected) {
@@ -201,7 +211,7 @@
 .sidebar .sidebar-search .search-input {
   background-color: var(--gray700);
   border: none;
-  border-radius: 4px;
+  border-radius: var(--border-radius);
   color: var(--gray50);
   margin-left: 12px;
   padding: 8px 6px 8px 38px;


### PR DESCRIPTION
I updated the tabs in the sidebar to use all available space.

### 2 Tabs
Before:
<img width="300" alt="Screenshot 2023-01-13 at 14 31 13" src="https://user-images.githubusercontent.com/792046/212332414-8b2f967b-1672-459f-888e-9d46a3c790f6.png">
After:
<img width="303" alt="Screenshot 2023-01-13 at 14 33 02" src="https://user-images.githubusercontent.com/792046/212332411-46efdf00-d012-47d5-88f8-a8326d23454e.png">

### 3 Tabs
Before
<img width="302" alt="Screenshot 2023-01-13 at 14 30 54" src="https://user-images.githubusercontent.com/792046/212332416-2bcf5078-e4b5-4d61-9ef2-ebd8e3b977cd.png">
After:
<img width="304" alt="Screenshot 2023-01-13 at 14 39 00" src="https://user-images.githubusercontent.com/792046/212333111-a408b9ce-9c9a-4fe0-8f6b-5ffecbb641de.png">

I also introduced a variable for the `border-radius` to make it's value consistent throughout all files. Since there were some with 3px and some with 4px I am not quite sure which is the "correct" one. I did set it to 4px for now.