### PR TITLE
Prevent content-inner overflow (unwanted horizontal scrolling)

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -145,6 +145,7 @@ body.search-focused .sidebar-search .search-close-button {
   max-width: var(--content-width);
   margin: 0 auto;
   padding: 3px var(--content-gutter);
+  overflow: hidden;
 }
 
 .content-inner:focus {

--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -145,7 +145,7 @@ body.search-focused .sidebar-search .search-close-button {
   max-width: var(--content-width);
   margin: 0 auto;
   padding: 3px var(--content-gutter);
-  overflow: hidden;
+  overflow-x: hidden;
 }
 
 .content-inner:focus {


### PR DESCRIPTION
The issue was showing up on the cheatsheet example page.