### PR TITLE
Fix clickable area of sidebar tabs

### DIFF
--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -131,11 +131,17 @@
 
 .sidebar .sidebar-listNav li {
   display: inline-block;
-  border-bottom: 3px solid transparent;
-  line-height: 27px;
+  padding: 0;
 }
 
-.sidebar .sidebar-listNav li:is(:hover, .selected) {
+.sidebar .sidebar-listNav li a {
+  display: inline-block;
+  line-height: 27px;
+  border-bottom: 3px solid transparent;
+  padding: 0 10px;
+}
+
+.sidebar .sidebar-listNav li:is(:hover, .selected) a {
   border-color: var(--main);
 }
 


### PR DESCRIPTION
This annoyed me already too often, so I finally fixed it 😜 Basically it expands the `<a>` tag of the sidebar tabs instead of the `<li>` tag, so the clickable area is bigger and easier to hit.

## Before:
![before](https://user-images.githubusercontent.com/14321/212695285-959d7826-8a2b-45a5-9615-03ab021b7e05.gif)

## After:
![after](https://user-images.githubusercontent.com/14321/212695290-6c8a5c41-564e-4126-ab2f-00193e716d0a.gif)

