### PR TITLE
Prevent h3 horizontal rule causing horizontal page overflow/scrollbar

### DIFF
--- a/assets/css/content/cheatsheet.css
+++ b/assets/css/content/cheatsheet.css
@@ -40,6 +40,7 @@
     margin: 0 0 1em;
     color: var(--main);
     font-weight: 400;
+    overflow: hidden;
   }
 
   .page-cheatmd h3.section-heading .hover-link {
@@ -55,18 +56,14 @@
 
   .page-cheatmd h3::after {
     content: "";
-    margin-left: var(--horizontal-space);
+    margin-left: calc(var(--horizontal-space) / 2);
     vertical-align: baseline;
     display: inline-block;
     width: 100%;
     height: 1px;
     margin-right: -100%;
     margin-bottom: 5px;
-    background: linear-gradient(
-      to right,
-      rgba(116, 95, 181, .2),
-      transparent 80%
-    );
+    background-color: var(--codeBorder);
   }
 
   /* h4 */

--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -145,7 +145,6 @@ body.search-focused .sidebar-search .search-close-button {
   max-width: var(--content-width);
   margin: 0 auto;
   padding: 3px var(--content-gutter);
-  overflow-x: hidden;
 }
 
 .content-inner:focus {


### PR DESCRIPTION
Further to https://github.com/elixir-lang/ex_doc/pull/1650, this addresses the cause of the unwanted horizontal scrollbar on cheatsheet pages.

The offending element was the horizontal rule added to `h3`, which in some situations extended outside the containing column, and sometimes into/behind the next column.

Because a means of limiting the width of the rule (which is `::after` content) and achieving a consistent gradient between different headings isn't apparent to me, I've replaced the gradient with a solid colour and hidden the overflow of the `h3`. I've removed the `overflow-x: hidden` of the `.content-inner` `div` from the last PR on this, as that is no longer necessary.

Before:

![Screen Shot 2023-01-20 at 13 21 41](https://user-images.githubusercontent.com/192853/213695585-052d1bbe-0b13-4689-9fea-e2ca8c520c4f.png)

After:

![Screen Shot 2023-01-20 at 13 24 35](https://user-images.githubusercontent.com/192853/213695610-bde11cb2-2644-4ed4-aec7-6f9d6387d7ed.png)
