### PR TITLE
Erlang: Skip unexported types

### DIFF
--- a/lib/ex_doc/language.ex
+++ b/lib/ex_doc/language.ex
@@ -92,7 +92,7 @@ defmodule ExDoc.Language do
               }
 
   @doc """
-  Returns a map with type information.
+  Returns a map with type information or the atom `:skip`.
 
   The map has the following keys:
 
@@ -111,6 +111,7 @@ defmodule ExDoc.Language do
                 signature: [binary()],
                 spec: spec_ast()
               }
+              | :skip
 
   @doc """
   Autolinks docs.

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -308,18 +308,20 @@ defmodule ExDoc.Retriever do
   defp get_types(module_data, source) do
     {:docs_v1, _, _, _, _, _, docs} = module_data.docs
 
-    for {{:type, _, _}, _, _, content, _} = doc <- docs, content != :hidden do
-      get_type(doc, source, module_data)
+    for {{:type, _, _}, _, _, content, _} = type_entry <- docs,
+        content != :hidden,
+        type_data = module_data.language.type_data(type_entry, module_data),
+        type_data != :skip do
+      get_type(type_entry, type_data, source, module_data)
     end
   end
 
-  defp get_type(type_entry, source, module_data) do
+  defp get_type(type_entry, type_data, source, module_data) do
     {:docs_v1, _, _, content_type, _, _, _} = module_data.docs
     {{_, name, arity}, anno, _signature, doc, metadata} = type_entry
     doc_line = anno_line(anno)
     annotations = annotations_from_metadata(metadata)
 
-    type_data = module_data.language.type_data(type_entry, module_data)
     signature = signature(type_data.signature)
     annotations = if type_data.type == :opaque, do: ["opaque" | annotations], else: annotations
     doc_ast = doc_ast(content_type, doc, file: source.path)

--- a/test/ex_doc/retriever/erlang_test.exs
+++ b/test/ex_doc/retriever/erlang_test.exs
@@ -137,6 +137,9 @@ defmodule ExDoc.Retriever.ErlangTest do
 
       -opaque opaque1() :: atom().
       %% opaque1/0 docs.
+
+      -type private_type1() :: integer().
+      %% private_type1/0 docs.
       """)
 
       config = %ExDoc.Config{source_url_pattern: "%{path}:%{line}"}


### PR DESCRIPTION
EDoc includes the Doc chunks for unexported types, so they are not skipped by the comprehension filter `content != :hidden` in `ExDoc.Retriever`. So unexported types end up being documented by ExDoc but they are hidden in EDoc-generated docs.

This change checks which types are exported by inspecting the abstract code for `export_type` attributes (similar to how `Code.Typespec.fetch_types/1` works) and skips any unexported types.

Connects #1333