### PR TITLE
Remove superfluous import of common custom properties from Erlang CSS

### DIFF
--- a/assets/css/custom-props/_erlang.css
+++ b/assets/css/custom-props/_erlang.css
@@ -1,5 +1,3 @@
-@import 'common.css';
-
 :root {
   --main:               hsl(0, 100%, 64%);
   --main-darkened-10:   hsl(0, 100%, 54%);


### PR DESCRIPTION
`common.css` is imported from `_html.css` and `_epub.css`.