### PR TITLE
Update Cheatsheet print styles

### DIFF
--- a/assets/css/content/cheatsheet.css
+++ b/assets/css/content/cheatsheet.css
@@ -1,297 +1,297 @@
-@media screen {
-  .page-cheatmd {
-    --horizontal-space: 1.5em;
-    --vertical-space: 1em;
-  }
+.page-cheatmd .content-inner {
+  --horizontal-space: 1.5em;
+  --vertical-space: 1em;
+}
 
-  @media (max-width: 600px) {
-    .page-cheatmd {
-      --horizontal-space: 1em;
-      --vertical-space: .75em;
-    }
-  }
-
+@media (max-width: 600px) {
   .page-cheatmd .content-inner {
-    max-width: 1200px;
+    --horizontal-space: 1em;
+    --vertical-space: .75em;
   }
+}
 
-  /* h1 */
+.page-cheatmd .content-inner {
+  max-width: 1200px;
+}
 
-  .page-cheatmd h1 {
-    margin-bottom: var(--vertical-space);
+/* h1 */
+
+.page-cheatmd .content-inner h1 {
+  margin-bottom: var(--vertical-space);
+}
+
+/* h2 */
+
+.page-cheatmd .content-inner h2 {
+  margin: var(--vertical-space) 0;
+  column-span: all;
+  color: var(--gray700);
+  font-weight: 500;
+}
+
+.page-cheatmd.dark .content-inner h2 {
+  color: var(--gray200);
+}
+
+/* h3 */
+
+.page-cheatmd .content-inner h3 {
+  margin: 0 0 1em;
+  color: var(--main);
+  font-weight: 400;
+  overflow: hidden;
+}
+
+.page-cheatmd .content-inner h3.section-heading .hover-link {
+  display: none;
+}
+
+.page-cheatmd .content-inner section.h3 {
+  min-width: 300px;
+  margin: 0 0 calc(var(--vertical-space) * 2) 0;
+  break-inside: avoid;
+}
+
+.page-cheatmd .content-inner h3::after {
+  content: "";
+  margin-left: calc(var(--horizontal-space) / 2);
+  vertical-align: baseline;
+  display: inline-block;
+  width: 100%;
+  height: 1px;
+  margin-right: -100%;
+  margin-bottom: 5px;
+  background-color: var(--codeBorder);
+}
+
+/* h4 */
+
+.page-cheatmd .content-inner h4 {
+  display: block;
+  margin: 0;
+  padding: .25em var(--horizontal-space);
+  font-weight: 400;
+  background: var(--gray100);
+  color: #567;
+  border: solid 1px 1px 0 1px var(--gray100);
+}
+
+.page-cheatmd.dark .content-inner h4 {
+  background: #192f50;
+  color: var(--textBody);
+  border: 1px solid #192f50;
+  border-bottom: 0;
+}
+
+/* Paragraphs */
+
+.page-cheatmd .content-inner .h2 p {
+  margin: 0;
+  display: block;
+  background: var(--gray50);
+  padding: var(--vertical-space) var(--horizontal-space);
+}
+
+.page-cheatmd.dark .content-inner .h2 p {
+  background: var(--gray700);
+}
+
+.page-cheatmd .content-inner .h2 p > code {
+  color: #eb5757;
+  border-radius: 3px;
+  padding: .2em .4em;
+}
+
+/* Code blocks */
+
+.page-cheatmd .content-inner pre code {
+  padding: var(--vertical-space) var(--horizontal-space);
+}
+
+.page-cheatmd .content-inner pre code::-webkit-scrollbar {
+  width: .4rem;
+  height: .6rem;
+}
+
+.page-cheatmd .content-inner .h2 pre {
+  margin: 0;
+}
+
+.page-cheatmd .content-inner .h2 pre + pre {
+  margin-top: -1px;
+}
+
+.page-cheatmd .content-inner pre.wrap {
+  white-space: break-spaces;
+}
+
+@media screen and (max-width: 768px) {
+  .page-cheatmd .content-inner pre code {
+    border-left-width: 1px !important;
+    border-right-width: 1px !important;
   }
+}
 
-  /* h2 */
+/* Tables */
 
-  .page-cheatmd h2 {
-    margin: var(--vertical-space) 0;
-    column-span: all;
-    color: var(--gray700);
-    font-weight: 500;
-  }
+.page-cheatmd .content-inner .h2 table {
+  display: table;
+  box-sizing: border-box;
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0;
+}
 
-  .page-cheatmd.dark h2 {
-    color: var(--gray200);
-  }
+.page-cheatmd .content-inner .h2 th {
+  padding: var(--vertical-space) var(--horizontal-space);
+  line-height: inherit;
+  margin-bottom: -1px;
+  vertical-align: middle;
+  border-bottom: 1px solid var(--codeBorder);
+}
 
-  /* h3 */
+.page-cheatmd .content-inner .h2 td {
+  padding: var(--vertical-space) var(--horizontal-space);
+  border: 0;
+  border-bottom: 1px solid var(--codeBorder);
+}
 
-  .page-cheatmd h3 {
-    margin: 0 0 1em;
-    color: var(--main);
-    font-weight: 400;
-    overflow: hidden;
-  }
+.page-cheatmd .content-inner .h2 tr:first-child {
+  border-top: 1px solid var(--codeBorder);
+}
 
-  .page-cheatmd h3.section-heading .hover-link {
-    display: none;
-  }
+.page-cheatmd .content-inner .h2 td code {
+  color: #eb5757;
+  border-radius: 3px;
+  padding: .2em .4em;
+}
 
-  .page-cheatmd section.h3 {
-    min-width: 300px;
-    margin: 0 0 calc(var(--vertical-space) * 2) 0;
-    break-inside: avoid;
-  }
+.page-cheatmd .content-inner .h2 thead {
+  background-color: var(--gray50);
+}
 
-  .page-cheatmd h3::after {
-    content: "";
-    margin-left: calc(var(--horizontal-space) / 2);
-    vertical-align: baseline;
-    display: inline-block;
-    width: 100%;
-    height: 1px;
-    margin-right: -100%;
-    margin-bottom: 5px;
-    background-color: var(--codeBorder);
-  }
+.page-cheatmd.dark .content-inner .h2 thead {
+  background-color: var(--gray700);
+}
 
-  /* h4 */
+.page-cheatmd .content-inner .h2 tbody {
+  background-color: var(--codeBackground);
+}
 
-  .page-cheatmd h4 {
-    display: block;
-    margin: 0;
-    padding: .25em var(--horizontal-space);
-    font-weight: 400;
-    background: var(--gray100);
-    color: #567;
-    border: solid 1px 1px 0 1px var(--gray100);
-  }
+/* Lists */
 
-  .page-cheatmd.dark h4 {
-    background: #192f50;
-    color: var(--textBody);
-    border: 1px solid #192f50;
-    border-bottom: 0;
-  }
+.page-cheatmd .content-inner .h2 :is(ul, ol) {
+  margin: 0;
+  padding: 0;
+}
 
-  /* Paragraphs */
+.page-cheatmd .content-inner .h2 li {
+  list-style-position: inside;
+  padding: .5em var(--horizontal-space);
+  line-height: 2em;
+  vertical-align: middle;
+  background-color: var(--codeBackground);
+  border-bottom: 1px solid var(--codeBorder);
+}
 
-  .page-cheatmd .h2 p {
-    margin: 0;
-    display: block;
-    background: var(--gray50);
-    padding: var(--vertical-space) var(--horizontal-space);
-  }
+.page-cheatmd .content-inner .h2 :is(ul, ol) + pre code {
+  border-top: 0;
+}
 
-  .page-cheatmd.dark .h2 p {
-    background: var(--gray700);
-  }
+.page-cheatmd .content-inner .h2 li > code {
+  color: #eb5757;
+  border-radius: 3px;
+  padding: .2em .4em;
+}
 
-  .page-cheatmd .h2 p > code {
-    color: #eb5757;
-    border-radius: 3px;
-    padding: .2em .4em;
-  }
+/* Columns */
 
-  /* Code blocks */
+.page-cheatmd .content-inner section.width-50 {
+  display: block;
+  width: 50%;
+  margin: 0;
+}
 
-  .page-cheatmd pre code {
-    padding: var(--vertical-space) var(--horizontal-space);
-  }
+.page-cheatmd .content-inner section.width-50 > section > table {
+  width: 100%;
+}
 
-  .page-cheatmd pre code::-webkit-scrollbar {
-    width: .4rem;
-    height: .6rem;
-  }
+.page-cheatmd .content-inner section:is(.col-2, .col-2-left, .col-3) {
+  column-gap: 40px;
+}
 
-  .page-cheatmd .h2 pre {
-    margin: 0;
-  }
+.page-cheatmd .content-inner section.col-2 {
+  column-count: 2;
+  height: auto;
+}
 
-  .page-cheatmd pre.wrap {
-    white-space: break-spaces;
-  }
+.page-cheatmd .content-inner section.col-2-left {
+  display: grid;
+  grid-template-columns: calc(100% / 3) auto;
+}
 
-  @media screen and (max-width: 768px) {
-    .page-cheatmd pre code {
-      border-left-width: 1px !important;
-      border-right-width: 1px !important;
-    }
-  }
+.page-cheatmd .content-inner section.col-2-left > h2 {
+  grid-column-end: span 2;
+}
 
-  /* Tables */
+.page-cheatmd .content-inner section.col-3 {
+  column-count: 3;
+  height: auto;
+}
 
-  .page-cheatmd .h2 table {
-    display: table;
-    box-sizing: border-box;
-    width: 100%;
-    border-collapse: collapse;
-    margin: 0;
-  }
+.page-cheatmd .content-inner section.list-4 > ul {
+  display: flex;
+  flex-wrap: wrap;
+}
 
-  .page-cheatmd .h2 table th {
-    padding: var(--vertical-space) var(--horizontal-space);
-    line-height: inherit;
-    margin-bottom: -1px;
-    vertical-align: middle;
-    border-bottom: 1px solid var(--codeBorder);
-  }
+.page-cheatmd .content-inner section.list-4 > ul > li {
+  flex: 0 0 calc(100% / 4);
+}
 
-  .page-cheatmd .h2 table td {
-    padding: var(--vertical-space) var(--horizontal-space);
-    border: 0;
-    border-bottom: 1px solid var(--codeBorder);
-  }
+.page-cheatmd .content-inner section.list-6 > ul {
+  display: flex;
+  flex-wrap: wrap;
+}
 
-  .page-cheatmd .h2 table tr:first-child {
-    border-top: 1px solid var(--codeBorder);
-  }
+.page-cheatmd .content-inner section.list-6 > ul > li {
+  flex: 0 0 calc(100% / 6);
+}
 
-  .page-cheatmd .h2 table td code {
-    color: #eb5757;
-    border-radius: 3px;
-    padding: .2em .4em;
-  }
+/* Layout adjustments for smaller viewports. Limited to screen as sufficient width is assumed when printing. */
 
-  .page-cheatmd .h2 thead {
-    background-color: var(--gray50);
-  }
-
-  .page-cheatmd.dark .h2 thead {
-    background-color: var(--gray700);
-  }
-
-  .page-cheatmd .h2 tbody {
-    background-color: var(--codeBackground);
-  }
-
-  /* Lists */
-
-  .page-cheatmd .h2 ul,
-  .page-cheatmd .h2 ol {
-    margin: 0;
-    padding: 0;
-  }
-
-  .page-cheatmd .h2 li {
-    list-style-position: inside;
-    padding: .5em var(--horizontal-space);
-    line-height: 2em;
-    vertical-align: middle;
-    background-color: var(--codeBackground);
-    border-bottom: 1px solid var(--codeBorder);
-  }
-
-  .page-cheatmd .h2 ul + pre code,
-  .page-cheatmd .h2 ol + pre code {
-    border-top: 0;
-  }
-
-  .page-cheatmd .h2 li > code {
-    color: #eb5757;
-    border-radius: 3px;
-    padding: .2em .4em;
-  }
-
-  /* Columns */
-
-  .page-cheatmd section.width-50 {
-    display: block;
-    width: 50%;
-    margin: 0;
-  }
-
-  .page-cheatmd section.width-50 > section > table {
-    width: 100%;
-  }
-
-  .page-cheatmd section:is(.col-2, .col-2-left, .col-3) {
-    column-gap: 40px;
-  }
-
-  .page-cheatmd section.col-2 {
+@media screen and (max-width: 1400px) {
+  .page-cheatmd .content-inner section.col-3 {
     column-count: 2;
-    height: auto;
   }
 
-  .page-cheatmd section.col-2-left {
-    display: grid;
-    grid-template-columns: calc(100% / 3) auto;
+  .page-cheatmd .content-inner section.col-2-left {
+    display: block;
+    column-count: 1;
+  }
+}
+
+@media screen and (max-width: 1200px) {
+  .page-cheatmd .content-inner section:is(.col-2, .col-3) {
+    column-count: 1;
   }
 
-  .page-cheatmd section.col-2-left > h2 {
-    grid-column-end: span 2;
-  }
-
-  .page-cheatmd section.col-3 {
-    column-count: 3;
-    height: auto;
-  }
-
-  .page-cheatmd section.list-4 > ul {
-    display: flex;
-    flex-wrap: wrap;
-  }
-
-  .page-cheatmd section.list-4 > ul > li {
+  .page-cheatmd .content-inner section.list-6 > ul > li {
     flex: 0 0 calc(100% / 4);
   }
+}
 
-  .page-cheatmd section.list-6 > ul {
-    display: flex;
-    flex-wrap: wrap;
+@media screen and (max-width: 1000px) {
+  .page-cheatmd .content-inner section:is(.list-4, .list-6) > ul > li {
+    flex: 0 0 calc(100% / 3);
+  }
+}
+
+@media screen and (max-width: 600px) {
+  .page-cheatmd .content-inner section:is(.list-4, .list-6) > ul > li {
+    flex: 0 0 calc(100% / 2);
   }
 
-  .page-cheatmd section.list-6 > ul > li {
-    flex: 0 0 calc(100% / 6);
-  }
-
-  /* Media query */
-
-  @media (max-width: 1400px) {
-    .page-cheatmd section.col-3 {
-      column-count: 2;
-    }
-
-    .page-cheatmd section.col-2-left {
-      display: block;
-      column-count: 1;
-    }
-  }
-
-  @media (max-width: 1200px) {
-    .page-cheatmd section:is(.col-2, .col-3) {
-      column-count: 1;
-    }
-
-    .page-cheatmd section.list-6 > ul > li {
-      flex: 0 0 calc(100% / 4);
-    }
-  }
-
-  @media (max-width: 1000px) {
-    .page-cheatmd section:is(.list-4, .list-6) > ul > li {
-      flex: 0 0 calc(100% / 3);
-    }
-  }
-
-  @media (max-width: 600px) {
-    .page-cheatmd section:is(.list-4, .list-6) > ul > li {
-      flex: 0 0 calc(100% / 2);
-    }
-
-    .page-cheatmd section.width-50 {
-      width: 100%;
-    }
+  .page-cheatmd .content-inner section.width-50 {
+    width: 100%;
   }
 }

--- a/assets/css/print-cheatsheet.css
+++ b/assets/css/print-cheatsheet.css
@@ -1,228 +1,141 @@
 @media print {
+
+  /* Remove background colors and set border colors */
+  .page-cheatmd .content-inner * {
+    background-color: transparent !important;
+    border-color: var(--gray300) !important;
+  }
+
   /* Basic layout and columns */
+
   .page-cheatmd .content-inner {
     max-width: 100%;
     width: 100%;
     padding: 0;
-    font-size: .85em;
+    font-size: .7em;
   }
 
-  .page-cheatmd section:is(.col-2, .col-2-left) {
-    column-gap: 20px;
+  .page-cheatmd .content-inner section:is(.col-2, .col-2-left, .col-3) {
+    column-gap: 30px;
   }
 
-  .page-cheatmd section.col-2 {
+  /* column-count and grid display required to be set again within @print media query to take effect when actually printing */
+  .page-cheatmd .content-inner section.col-2 {
     column-count: 2;
-    height: auto;
   }
-
-  .page-cheatmd section.col-2-left {
+  .page-cheatmd .content-inner section.col-2-left {
     display: grid;
-    grid-template-columns: calc(100% / 3) auto;
   }
-
-  .page-cheatmd section.col-2-left > h2 {
-    display: block;
-    grid-column-end: span 2;
-  }
-
-  .page-cheatmd section.col-3 {
+  .page-cheatmd .content-inner section.col-3 {
     column-count: 3;
-    column-gap: 10px;
-    height: auto;
-  }
-
-  .page-cheatmd section.list-4 > ul > li {
-    flex: 0 0 calc(100% / 4);
-  }
-
-  .page-cheatmd section.list-6 > ul > li {
-    flex: 0 0 calc(100% / 6);
-  }
-
-  .page-cheatmd section:is(.list-4, .list-6) > ul {
-    display: flex;
-    flex-wrap: wrap;
-  }
-
-  .page-cheatmd section.width-50 {
-    display: block;
-    width: 50%;
-    margin: 0;
-  }
-
-  .page-cheatmd section.width-50 > section > table {
-    width: 100%;
   }
 
   /* h1 */
 
-  .page-cheatmd h1 {
+  .page-cheatmd .content-inner h1 {
     margin-top: 0;
     margin-bottom: .5em;
   }
 
   /* h2 */
 
-  .page-cheatmd h2.section-heading {
-    margin: 1em 0 .25em;
+  .page-cheatmd .content-inner h2.section-heading {
+    font-weight: bold;
+    margin-top: 1em;
     column-span: all;
   }
 
-  /* For some reason Firefox extends the h2 border-left to the following h3 when printing;
-     moving the border-left to the :before pseudo-element fixes this */
-
-  .page-cheatmd h2.section-heading:before {
-    border-left: solid 6px var(--gray100);
-    margin-right: 8px;
-    content: " ";
-  }
-
-  .page-cheatmd section.h2 {
+  .page-cheatmd .content-inner section.h2 {
     break-inside: avoid;
   }
 
   /* h3 */
 
-  .page-cheatmd h3 {
-    white-space: nowrap;
-    overflow: hidden;
-    margin: 0 0 .25em;
-    padding-left: 5px;
+  .page-cheatmd .content-inner h3 {
+    font-weight: bold;
+    color: var(--main-darkened-10);
   }
 
-  .page-cheatmd h3.section-heading {
-    overflow: hidden;
+  .page-cheatmd .content-inner h3::after {
+    height: 2px;
+    background-color: var(--gray300);
   }
 
-  .page-cheatmd section.h3 {
+  .page-cheatmd .content-inner section.h3 {
     min-width: 300px;
-    margin: 0 0 .75em 0;
     break-inside: avoid;
   }
 
   /* h4 */
 
-  .page-cheatmd h4 {
-    display: block;
-    margin: -1px 0 -1px 0;
-    padding: .5em;
-    border: solid 1px var(--gray300);
+  .page-cheatmd .content-inner h4 {
+    padding: .5em 0;
+    border: none;
+    font-weight: bold;
+    color: black;
   }
 
-  /* p */
+  /* Paragraphs */
 
-  .page-cheatmd .content-inner p {
-    font-size: .95em;
+  .page-cheatmd .content-inner .h2 p {
+    padding-left: 0;
+    padding-right: 0;
+    border: none !important;
+  }
+
+  /* Code blocks */
+
+  .page-cheatmd .content-inner code {
     line-height: 1.5em;
-    padding: .5em;
-  }
-
-  /* Ensure solo p tags have borders around them, but merge the border
-     when multiple p tags are next to each other */
-  .page-cheatmd .content-inner section p {
-    display: block;
-    margin: -1px 0 -1px 0;
-    font-size: .95em;
-    line-height: 1.5em;
-    padding: .5em;
-    border: solid;
-    border-color: var(--gray300);
-    border-width: 1px 1px 0 1px;
-  }
-
-  .page-cheatmd .content-inner section p + p {
-    border-width: 0 1px 0 1px;
-  }
-
-  .page-cheatmd .content-inner section p:last-of-type {
-    border-width: 0 1px 1px 1px;
-  }
-
-  .page-cheatmd .content-inner section p:only-of-type {
-    border-width: 1px;
   }
 
   /* Tables */
 
-  .page-cheatmd table {
-    width: 100%;
-    border-collapse: collapse;
-    margin: 0;
+  .page-cheatmd .content-inner .h2 table {
     font-variant-numeric: tabular-nums;
     break-inside: avoid;
   }
 
-  .page-cheatmd th,
-  .page-cheatmd td {
-    text-align: left;
+  .page-cheatmd .content-inner .h2 :is(th, td) {
     vertical-align: top;
-    padding: .5em;
-    font-size: .95em;
+    padding-left: 0;
+    padding-right: 0;
   }
 
-  .page-cheatmd thead {
-    border: 1px solid var(--gray300);
+  .page-cheatmd .content-inner .h2 thead {
+    border-style: solid none;
+    border-width: 1px;
   }
 
-  .page-cheatmd .content-inner tbody tr {
-    border-width: 0 1px 1px 1px;
-    border-style: solid;
-    border-color: var(--gray200);
-  }
-
-  .page-cheatmd .content-inner thead tr {
+  .page-cheatmd .content-inner .h2 tr {
     border-bottom: none;
   }
 
-  .page-cheatmd th {
+  .page-cheatmd .content-inner .h2 th {
     font-weight: bold;
-  }
-
-  .page-cheatmd td {
-    text-align: left;
-  }
-
-  /* Code Blocks */
-
-  .page-cheatmd pre {
-    margin: -1px 0 -1px 0;
   }
 
   /* Lists */
 
-  .page-cheatmd ul,
-  .page-cheatmd ol {
-    margin: 0;
-    padding: 0;
-    list-style-position: inside;
-  }
-
-  .page-cheatmd .h2 li {
-    padding: .5em .75em;
+  .page-cheatmd .content-inner .h2 li {
+    padding-left: 0;
+    padding-right: 0;
     vertical-align: middle;
-    border-bottom: 1px solid var(--gray200);
-  }
-
-  .page-cheatmd .h2 li:last-of-type {
-    border-bottom: 0;
+    border-bottom: none;
   }
 
   /* Remove copy button from code blocks */
-  pre:hover button.copy-button {
+  .page-cheatmd .content-inner pre:hover button.copy-button {
     display: none;
   }
 
   /* Remove hover tooltip from inline code references */
-  .page-cheatmd div#tooltip {
+  .page-cheatmd .content-inner div#tooltip {
     display: none;
   }
 
-  .page-cheatmd footer p {
+  .page-cheatmd .content-inner footer p:not(.built-using) {
     display: none;
   }
 
-  .page-cheatmd footer p.built-using {
-    display: block;
-  }
 }


### PR DESCRIPTION
Main changes:

- all background color removed in order to avoid potential photocopying issues;
- more color from the main styles' text preserved in order to keep more character;
- H3 horizontal rules preserved, at 2px instead of 1px to differentiate from 1px tables and code boxes;
- paragraphs' and lists' borders removed, and tables' left/right borders removed, in order to lessen the "boxiness" (this allows for the H3 rules to make more visual sense).

The "screen" media query is removed from the main cheatsheet styles, allowing them to apply to the printed version in order to reduce repetition of setting font, color, etc.

Increases use of .content-inner selector namespace to be safe.

## Remaining to do

The horizontal rules next to H3 text are achieved via background, and so only appear when the 'print backgrounds' option is selected. We should see if we can convert to non-background content.

## Preview

### Before

![image](https://user-images.githubusercontent.com/192853/220871394-2f25c006-ace6-48e2-abb1-e85f2404fed1.png)

### After

![image](https://user-images.githubusercontent.com/192853/220872044-d533ac4b-17c4-43ee-b5df-ed4611ba86fd.png)
