### PR TITLE
Fix visited link color in admonition blocks

### DIFF
--- a/assets/css/content/admonition.css
+++ b/assets/css/content/admonition.css
@@ -4,7 +4,7 @@
   border-left: 0;
 }
 
-.content-inner blockquote:is(.warning, .error, .info, .neutral, .tip) a {
+.content-inner blockquote:is(.warning, .error, .info, .neutral, .tip) :is(a, a:visited) {
   color: var(--black);
 }
 


### PR DESCRIPTION
Visited link styles were not being overridden by blockquotes, which caused visited links to appear with very low contrast.

Before:

![block-link-visited-before](https://user-images.githubusercontent.com/503938/220939369-e0d54c55-be31-4365-81b0-8026eb0a2c80.png)

After:

![block-link-visited-after](https://user-images.githubusercontent.com/503938/220939402-526c27b5-7bca-4ea0-ada2-0fd35636bdb1.png)
