### PR TITLE
Improve consistency of type rendering weight across OSes

### DIFF
--- a/assets/css/_html.css
+++ b/assets/css/_html.css
@@ -1,4 +1,5 @@
 @import '@fontsource/lato/300.css';
+@import '@fontsource/lato/400.css';
 @import '@fontsource/lato/700.css';
 @import '@fontsource/merriweather/300.css';
 @import '@fontsource/merriweather/300-italic.css';
@@ -39,4 +40,10 @@
 body:not(.dark) .content-inner img[src*="#gh-dark-mode-only"],
 body.dark .content-inner img[src*="#gh-light-mode-only"] {
   display: none;
+}
+
+/* Improves consistency of type rendering across OSes; results in thinner type in Mac OS */
+body {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }

--- a/assets/css/_html.css
+++ b/assets/css/_html.css
@@ -41,9 +41,3 @@ body:not(.dark) .content-inner img[src*="#gh-dark-mode-only"],
 body.dark .content-inner img[src*="#gh-light-mode-only"] {
   display: none;
 }
-
-/* Improves consistency of type rendering across OSes; results in thinner type in Mac OS */
-body {
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}

--- a/assets/css/settings.css
+++ b/assets/css/settings.css
@@ -43,6 +43,7 @@
 
 #settings-modal-content .switch-button-container > div > p {
   font-size: 14px;
+  font-weight: 300;
   line-height: 1.4;
   margin: 0;
   padding-bottom: 6px;

--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -124,7 +124,6 @@
 
 .sidebar .sidebar-listNav :is(li, li a) {
   text-transform: uppercase;
-  font-weight: 300;
   font-size: 14px;
   color: var(--sidebarMuted);
 }
@@ -353,7 +352,6 @@
 }
 
 .sidebar #full-list ul li {
-  font-weight: 300;
   line-height: 16px;
   padding: 0 8px;
   margin-right: 0;

--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -80,6 +80,9 @@
   line-height: 20px;
   color: var(--sidebarMuted);
 }
+.non-apple-os .sidebar .sidebar-projectVersion {
+  font-weight: 400; /* Non-Apple OSes render small light type too thinly */
+}
 
 .sidebar .sidebar-projectVersionsDropdown {
   cursor: pointer;
@@ -124,8 +127,12 @@
 
 .sidebar .sidebar-listNav :is(li, li a) {
   text-transform: uppercase;
+  font-weight: 300;
   font-size: 14px;
   color: var(--sidebarMuted);
+}
+.non-apple-os .sidebar .sidebar-listNav :is(li, li a) {
+  font-weight: 400; /* Non-Apple OSes render small light type too thinly */
 }
 
 .sidebar .sidebar-listNav li {
@@ -352,10 +359,14 @@
 }
 
 .sidebar #full-list ul li {
+  font-weight: 300;
   line-height: 16px;
   padding: 0 8px;
   margin-right: 0;
   color: var(--sidebarAccentMain);
+}
+.non-apple-os .sidebar #full-list ul li {
+  font-weight: 400; /* Non-Apple OSes render small light type too thinly */
 }
 
 .sidebar #full-list ul li.current-hash {

--- a/assets/js/entry/html.js
+++ b/assets/js/entry/html.js
@@ -16,6 +16,7 @@ import { initialize as initTooltips } from '../tooltips/tooltips'
 import { initialize as initHintsPage } from '../tooltips/hint-page'
 import { initialize as initCopyButton } from '../copy-button'
 import { initialize as initSettings } from '../settings'
+import { initialize as initOs } from '../os'
 
 onDocumentReady(() => {
   initTheme()
@@ -33,4 +34,5 @@ onDocumentReady(() => {
   initSearchPage()
   initCopyButton()
   initSettings()
+  initOs()
 })

--- a/assets/js/os.js
+++ b/assets/js/os.js
@@ -1,0 +1,6 @@
+export function initialize () {
+  const appleDeviceExpr = /(Macintosh|iPhone|iPad|iPod)/
+
+  const osClass = appleDeviceExpr.test(window.navigator.userAgent) ? 'apple-os' : 'non-apple-os'
+  document.documentElement.classList.add(osClass)
+}


### PR DESCRIPTION
Fixes #1675

As the sidebar type is thinned in Mac OS via the alternative anti-aliasing, its weight can be increased from light to normal to avoid overly thin type in Linux and Windows.

The thin weight is preserved/used in places where differentiation from normal/bold is warranted.

Additionally, the normal/400 weight font was not being loaded, which resulted in type set to normal being rendered light. We're now loading light/300, normal/400 and bold/700 for the Lato sans serif font.

# Screenshots

All Firefox/Ubuntu, before followed by after. (@josevalim to make sure he's happy with Safari/WebKit in Mac OS.)

## Light: Sidebar

![Screen Shot 2023-03-09 at 15 25 32](https://user-images.githubusercontent.com/192853/224057233-586517bf-b7be-40cf-b7c8-83067db0073c.png)
![Screen Shot 2023-03-09 at 15 14 25](https://user-images.githubusercontent.com/192853/224057268-fc2d7726-11ac-48f6-9e27-05c1213e9392.png)

## Light: Settings

![Screen Shot 2023-03-09 at 15 26 02](https://user-images.githubusercontent.com/192853/224057429-6284cd83-8671-4626-9ba6-5a40be7268ca.png)
![Screen Shot 2023-03-09 at 15 14 48](https://user-images.githubusercontent.com/192853/224057442-302e6bf6-ddfb-406b-bc28-a2404efcee3b.png)

## Dark: Sidebar

(Same as light theme sidebar.)

![Screen Shot 2023-03-09 at 15 26 08](https://user-images.githubusercontent.com/192853/224057485-1ed09566-9ef6-4fea-9570-13087c2fc4c8.png)
![Screen Shot 2023-03-09 at 15 15 03](https://user-images.githubusercontent.com/192853/224057503-6cb58752-f934-4ea6-b992-10b6c4a48557.png)


## Dark: Settings

![Screen Shot 2023-03-09 at 15 26 11](https://user-images.githubusercontent.com/192853/224057559-b6129517-eeb5-4161-a24e-d4e598f5adaf.png)
![Screen Shot 2023-03-09 at 15 15 08](https://user-images.githubusercontent.com/192853/224057577-e97bd284-6bb4-4f98-b09d-d73a33b74812.png)
