### PR TITLE
Fix precedence of switches vs config

### DIFF
--- a/lib/ex_doc/cli.ex
+++ b/lib/ex_doc/cli.ex
@@ -92,9 +92,8 @@ defmodule ExDoc.CLI do
   defp merge_config(opts) do
     case Keyword.fetch(opts, :config) do
       {:ok, config} ->
-        opts
-        |> Keyword.delete(:config)
-        |> Keyword.merge(read_config(config))
+        opts_without_config = Keyword.delete(opts, :config)
+        Keyword.merge(read_config(config), opts_without_config)
 
       _ ->
         opts

--- a/test/ex_doc/cli_test.exs
+++ b/test/ex_doc/cli_test.exs
@@ -140,6 +140,34 @@ defmodule ExDoc.CLITest do
       File.rm!("test.exs")
     end
 
+    test "switches take precedence over config" do
+      File.write!("test.exs", ~s([logo: "config_logo.png", formatters: ["html"]]))
+
+      {[{project, version, opts}], _io} =
+        run([
+          "ExDoc",
+          "--logo",
+          "opts_logo.png",
+          "1.2.3",
+          @ebin,
+          "-c",
+          "test.exs"
+        ])
+
+      assert project == "ExDoc"
+      assert version == "1.2.3"
+
+      assert Enum.sort(opts) == [
+               apps: [:ex_doc],
+               formatter: "html",
+               formatters: ["html"],
+               logo: "opts_logo.png",
+               source_beam: @ebin
+             ]
+    after
+      File.rm!("test.exs")
+    end
+
     test "missing" do
       assert_raise File.Error, fn ->
         run(["ExDoc", "1.2.3", @ebin, "-c", "test.exs"])


### PR DESCRIPTION
Currently config takes precedence over switches. This was discussed in build and packaging working group and it was concluded this is unexpected behaviour. This PR rectifies that. 