### PR TITLE
Propagate :since metadata from modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ ExDoc supports metadata keys in your documentation.
 
 In Elixir, you can add metadata to modules and functions.
 
-For a module, use `@moduledoc`:
+For a module, use `@moduledoc`, which is equivalent to adding the annotation to everything inside the module (functions, macros, callbacks, types):
 
 ```elixir
 @moduledoc since: "1.10.0"

--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -37,6 +37,10 @@
   font-weight: normal;
 }
 
+.content-inner h1 .note {
+  font-family: var(--monoFontFamily);
+}
+
 .content-inner h2 {
   font-size: 1.6em;
   margin: 1em 0 .5em;

--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -37,10 +37,6 @@
   font-weight: normal;
 }
 
-.content-inner h1 .note {
-  font-family: var(--monoFontFamily);
-}
-
 .content-inner h2 {
   font-size: 1.6em;
   margin: 1em 0 .5em;
@@ -95,10 +91,6 @@
   margin-right: 5px;
   font-size: 14px;
   font-weight: normal;
-}
-
-.content-inner h1 .note {
-  float: right;
 }
 
 .content-inner blockquote {

--- a/lib/ex_doc/nodes.ex
+++ b/lib/ex_doc/nodes.ex
@@ -22,7 +22,7 @@ defmodule ExDoc.ModuleNode do
             language: nil,
             annotations: []
 
-  @typep annotation :: atom() | String.t()
+  @typep annotation :: atom()
 
   @type t :: %__MODULE__{
           id: String.t(),

--- a/lib/ex_doc/nodes.ex
+++ b/lib/ex_doc/nodes.ex
@@ -22,7 +22,7 @@ defmodule ExDoc.ModuleNode do
             language: nil,
             annotations: []
 
-  @typep annotation :: atom()
+  @typep annotation :: atom() | String.t()
 
   @type t :: %__MODULE__{
           id: String.t(),

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -140,7 +140,7 @@ defmodule ExDoc.Retriever do
       source_path: source_path,
       source_url: source_link(source, module_data.line),
       language: module_data.language,
-      annotations: List.wrap(metadata[:tags])
+      annotations: List.wrap(metadata[:tags]) ++ annotations_from_metadata(metadata)
     }
   end
 
@@ -345,16 +345,11 @@ defmodule ExDoc.Retriever do
   defp signature(list) when is_list(list), do: Enum.join(list, " ")
 
   defp annotations_from_metadata(metadata) do
-    annotations = []
-
-    annotations =
-      if since = metadata[:since] do
-        ["since #{since}" | annotations]
-      else
-        annotations
-      end
-
-    annotations
+    if since = metadata[:since] do
+      ["since #{since}"]
+    else
+      []
+    end
   end
 
   defp anno_line(line) when is_integer(line), do: abs(line)

--- a/test/ex_doc/retriever/elixir_test.exs
+++ b/test/ex_doc/retriever/elixir_test.exs
@@ -11,6 +11,7 @@ defmodule ExDoc.Retriever.ElixirTest do
       defmodule Mod do
         @moduledoc "Mod docs."
         @moduledoc tags: :public
+        @moduledoc since: "0.15.0"
 
         @doc "function/0 docs."
         @spec function() :: atom()
@@ -37,7 +38,7 @@ defmodule ExDoc.Retriever.ElixirTest do
                type: :module,
                typespecs: [],
                docs: [empty_doc_and_specs, function, macro],
-               annotations: [:public]
+               annotations: [:public, "since 0.15.0"]
              } = mod
 
       assert DocAST.to_string(mod.doc) == "<p>Mod docs.</p>"
@@ -47,7 +48,7 @@ defmodule ExDoc.Retriever.ElixirTest do
                annotations: [],
                defaults: [],
                deprecated: nil,
-               doc_line: 5,
+               doc_line: 6,
                group: :Functions,
                id: "function/0",
                name: :function,


### PR DESCRIPTION
`:since` was showing for functions, types, and callbacks, but not for modules.