### PR TITLE
Fix settings icon position

### DIFF
--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -66,7 +66,6 @@
   transition: color .3s ease-in-out;
   background-color: transparent;
   cursor: pointer;
-  padding: 0 0 0 6px;
 }
 .content-inner button.icon-action {
   margin-top: 12px;


### PR DESCRIPTION
Settings icon (on `readme.html`) was a little bit up.

Before:
![image](https://user-images.githubusercontent.com/76881129/226109664-eb93c21b-b217-44fe-9397-debeac19657b.png)
After:
![image](https://user-images.githubusercontent.com/76881129/226109671-8be12eb9-010d-45b4-8d40-0dab1d671fdb.png)