### PR TITLE
Fix sidebar button background gradient color

### DIFF
--- a/assets/css/custom-props/theme-light.css
+++ b/assets/css/custom-props/theme-light.css
@@ -60,9 +60,9 @@
   --success:                     var(--green);
 
   --sidebarButtonBackground:     linear-gradient(180deg,
-                                                 var(--gray900) 20%,
-                                                 var(--gray900-opacity-50) 70%,
-                                                 var(--gray900-opacity-0) 100%);
+                                                 var(--white) 20%,
+                                                 var(--white-opacity-50) 70%,
+                                                 var(--white-opacity-0) 100%);
   --sidebarAccentMain:           var(--gray50);
   --sidebarBackground:           var(--gray800);
   --sidebarGradient:             linear-gradient(var(--sidebarBackground),


### PR DESCRIPTION
The light theme's gradient that shows at small viewport widths was using the dark theme's colors.

### Before

![_m_projects_ex_doc_repo_doc_readme html (6)](https://user-images.githubusercontent.com/192853/236049328-c9242395-3792-4d51-8e50-3b8638a318b1.png)

### After

![_m_projects_ex_doc_repo_doc_readme html (7)](https://user-images.githubusercontent.com/192853/236049333-2f239304-3d0f-4ae8-bc51-e15c97afa18d.png)
