### PR TITLE
Reinstate heavier font-weight for sidebar list items for non-Apple

### DIFF
--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -360,6 +360,10 @@
   color: var(--sidebarAccentMain);
 }
 
+.non-apple-os .sidebar #full-list ul li {
+  font-weight: 400; /* Non-Apple OSes render small light type too thinly */
+}
+
 .sidebar #full-list ul li.current-hash {
   color: var(--sidebarActiveItem);
 }


### PR DESCRIPTION
8e86d630 (Layout on apple-os and sidebar, 2023-03-29) resulted in subitem list items in the sidebar having 300 weight on non-Apple, I believe unintentionally. This reinstates their 400 weight for non-Apple. (Although this means top-level and second-level items are the same weight for non-Apple, I believe it was agreed the more readable font weight took priority.)

To avoid this second declaration of font-weight 400 for non-Apple, we could instead use !important for the first declaration, but this may result in specificity issues if the design were to include different weights in future.

Screenshots below are from Chrome, Ubuntu.

### Before

![_m_projects_ex_doc_repo_doc_readme html (4)](https://user-images.githubusercontent.com/192853/236047592-438eac63-a68c-4bd8-83b2-e7aaa9ed86ad.png)

### After

![_m_projects_ex_doc_repo_doc_readme html (5)](https://user-images.githubusercontent.com/192853/236047614-042eb886-8273-4454-82a3-88940ba92eb0.png)
