### PR TITLE
Improve sidebar search placeholder text hue

### DIFF
--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -217,6 +217,11 @@
   width: 276px;
 }
 
+.sidebar .sidebar-search .search-input::placeholder {
+  color: var(--sidebarAccentMain);
+  opacity: 0.3;
+}
+
 .sidebar .sidebar-search .search-input:is(:focus, :hover) {
   outline: none;
 }


### PR DESCRIPTION
We replace the default grey browser placeholder with a dimmed accent color from existing CSS variable

Small change but it is visually more pleasing 😄 

**Before**
<img width="411" alt="Screenshot 2023-05-04 at 1 41 17 PM" src="https://user-images.githubusercontent.com/464900/236286322-61ddf3e6-e91d-498b-9045-4b407fa04705.png">

**After**
<img width="461" alt="Screenshot 2023-05-04 at 1 42 05 PM" src="https://user-images.githubusercontent.com/464900/236286365-dadcd5b1-f7c1-4714-9fa3-707b943d0d91.png">
