### PR TITLE
Start edoc & xmerl when running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
               elixir: "1.11"
               otp: 21
           - pair:
-              elixir: "1.13"
-              otp: 24
+              elixir: "1.14"
+              otp: 25
             lint: lint
     steps:
       - uses: actions/checkout@v3

--- a/lib/ex_doc/language.ex
+++ b/lib/ex_doc/language.ex
@@ -64,7 +64,7 @@ defmodule ExDoc.Language do
               %{
                 line: non_neg_integer() | nil,
                 specs: [spec_ast()],
-                doc_fallback: (-> ExDoc.DocAST.t()) | nil,
+                doc_fallback: (() -> ExDoc.DocAST.t()) | nil,
                 extra_annotations: [String.t()]
               }
               | :skip

--- a/lib/ex_doc/language.ex
+++ b/lib/ex_doc/language.ex
@@ -64,7 +64,9 @@ defmodule ExDoc.Language do
               %{
                 line: non_neg_integer() | nil,
                 specs: [spec_ast()],
-                doc_fallback: (() -> ExDoc.DocAST.t()) | nil,
+                # TODO: change to following on Elixir 1.15. It trips mix formatter between 1.14 and 1.15
+                # doc_fallback: (-> ExDoc.DocAST.t()) | nil,
+                doc_fallback: (... -> ExDoc.DocAST.t()) | nil,
                 extra_annotations: [String.t()]
               }
               | :skip

--- a/mix.exs
+++ b/mix.exs
@@ -24,10 +24,13 @@ defmodule ExDoc.Mixfile do
 
   def application do
     [
-      extra_applications: [:eex, :crypto],
+      extra_applications: [:eex, :crypto] ++ extra_applications(Mix.env()),
       mod: {ExDoc.Application, []}
     ]
   end
+
+  defp extra_applications(:test), do: [:edoc, :xmerl]
+  defp extra_applications(_), do: []
 
   defp deps do
     [


### PR DESCRIPTION
On 1.15-dev I started seeing some test failures. It is because we detect
whether we're on recent enough OTP for docs chunks like this:

    # https://github.com/elixir-lang/ex_doc/blob/main/test/test_helper.exs#L1
    otp_eep48? = Code.ensure_loaded?(:edoc_doclet_chunks)

And it started returning false on 1.15-dev unless we add :edoc to extra
applications. We need xmerl too to use some of the edoc functions.
