### PR TITLE
Safety check before running File.rm_rf! in doc gen

### DIFF
--- a/lib/ex_doc/formatter/epub.ex
+++ b/lib/ex_doc/formatter/epub.ex
@@ -12,7 +12,12 @@ defmodule ExDoc.Formatter.EPUB do
   def run(project_nodes, config) when is_map(config) do
     parent = config.output
     config = normalize_config(config)
-    HTML.setup_output(config, &cleanup_output_dir/2, &create_output_dir/2, parent)
+
+    HTML.setup_output(
+      parent,
+      &cleanup_output_dir(&1, config),
+      &create_output_dir(&1, config)
+    )
 
     project_nodes = HTML.render_all(project_nodes, ".xhtml", config, highlight_tag: "samp")
 

--- a/lib/ex_doc/formatter/epub.ex
+++ b/lib/ex_doc/formatter/epub.ex
@@ -12,7 +12,7 @@ defmodule ExDoc.Formatter.EPUB do
   def run(project_nodes, config) when is_map(config) do
     parent = config.output
     config = normalize_config(config)
-    setup_output(config, parent)
+    HTML.setup_output(config, &cleanup_output_dir/2, &create_output_dir/2, parent)
 
     project_nodes = HTML.render_all(project_nodes, ".xhtml", config, highlight_tag: "samp")
 
@@ -44,30 +44,14 @@ defmodule ExDoc.Formatter.EPUB do
     Path.relative_to_cwd(epub)
   end
 
-  defp setup_output(config, parent) do
-    safety_path = Path.join(parent, ".ex_doc")
-
-    cond do
-      File.exists?(safety_path) ->
-        File.rm_rf!(config.output)
-        mkdir_output!(config.output, parent)
-
-      not File.exists?(parent) ->
-        mkdir_output!(config.output, parent)
-
-      true ->
-        raise """
-        ex_doc cannot output to #{config.output}:
-        Directory already exists and is not managed by ex_doc.
-
-        Try giving an unexisting directory as `--output`.
-        """
-    end
+  defp create_output_dir(root, config) do
+    File.mkdir_p!(Path.join(config.output, "OEBPS"))
+    File.touch!(Path.join(root, ".ex_doc"))
   end
 
-  defp mkdir_output!(path, parent) do
-    File.mkdir_p!(Path.join(path, "OEBPS"))
-    File.touch!(Path.join(parent, ".ex_doc"))
+  defp cleanup_output_dir(docs_root, config) do
+    File.rm_rf!(config.output)
+    create_output_dir(docs_root, config)
   end
 
   defp normalize_config(config) do

--- a/test/ex_doc/formatter/epub_test.exs
+++ b/test/ex_doc/formatter/epub_test.exs
@@ -103,6 +103,18 @@ defmodule ExDoc.Formatter.EPUBTest do
     assert File.regular?(tmp_dir <> "/epub/another_dir/#{doc_config(context)[:project]}.epub")
   end
 
+  test "fails if trying to write to existing directory", context do
+    assert_raise RuntimeError, ~r/Directory already exists and is not managed by ex_doc/, fn ->
+      config = doc_config(context)
+
+      new_output = config[:output] <> "/new-dir"
+      File.mkdir_p!(new_output)
+
+      new_config = Keyword.put(config, :output, new_output)
+      generate_docs(new_config)
+    end
+  end
+
   test "generates an EPUB file with a standardized structure", %{tmp_dir: tmp_dir} = context do
     generate_docs_and_unzip(context, doc_config(context))
 

--- a/test/ex_doc/formatter/html/erlang_test.exs
+++ b/test/ex_doc/formatter/html/erlang_test.exs
@@ -5,6 +5,12 @@ defmodule ExDoc.Formatter.HTML.ErlangTest do
   @moduletag :otp_eep48
   @moduletag :tmp_dir
 
+  setup %{tmp_dir: tmp_dir} do
+    output = tmp_dir <> "/doc"
+    File.mkdir!(output)
+    File.touch!("#{output}/.ex_doc")
+  end
+
   test "smoke test", c do
     erlc(c, :foo, ~S"""
     %% @doc

--- a/test/ex_doc/formatter/html/search_items_test.exs
+++ b/test/ex_doc/formatter/html/search_items_test.exs
@@ -4,6 +4,12 @@ defmodule ExDoc.Formatter.HTML.SearchItemsTest do
 
   @moduletag :tmp_dir
 
+  setup %{tmp_dir: tmp_dir} do
+    output = tmp_dir <> "/doc"
+    File.mkdir!(output)
+    File.touch!("#{output}/.ex_doc")
+  end
+
   test "Elixir module", c do
     modules =
       elixirc(c, ~S'''

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -6,6 +6,12 @@ defmodule ExDoc.Formatter.HTMLTest do
 
   @moduletag :tmp_dir
 
+  setup %{tmp_dir: tmp_dir} do
+    output = tmp_dir <> "/html"
+    File.mkdir_p!(output)
+    File.touch!(output <> "/.ex_doc")
+  end
+
   defp read_wildcard!(path) do
     [file] = Path.wildcard(path)
     File.read!(file)
@@ -144,6 +150,18 @@ defmodule ExDoc.Formatter.HTMLTest do
     assert content_module =~ re[:module][:x_ua]
     refute content_module =~ re[:index][:title]
     refute content_module =~ re[:index][:refresh]
+  end
+
+  test "fails if trying to write to existing directory", context do
+    assert_raise RuntimeError, ~r/Directory already exists and is not managed by ex_doc/, fn ->
+      config = doc_config(context)
+
+      new_output = config[:output] <> "/new-dir"
+      File.mkdir_p!(new_output)
+
+      new_config = Keyword.put(config, :output, new_output)
+      generate_docs(new_config)
+    end
   end
 
   test "allows to set the authors of the document", %{tmp_dir: tmp_dir} = context do

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -152,16 +152,31 @@ defmodule ExDoc.Formatter.HTMLTest do
     refute content_module =~ re[:index][:refresh]
   end
 
-  test "fails if trying to write to existing directory", context do
-    assert_raise RuntimeError, ~r/Directory already exists and is not managed by ex_doc/, fn ->
-      config = doc_config(context)
+  test "succeeds if trying to write into an empty existing directory", context do
+    config = doc_config(context)
 
-      new_output = config[:output] <> "/new-dir"
-      File.mkdir_p!(new_output)
+    new_output = config[:output] <> "/new-dir"
+    File.mkdir_p!(new_output)
 
-      new_config = Keyword.put(config, :output, new_output)
-      generate_docs(new_config)
-    end
+    new_config = Keyword.put(config, :output, new_output)
+
+    refute ExUnit.CaptureIO.capture_io(:stderr, fn ->
+             generate_docs(new_config)
+           end) =~ "ExDoc is outputting to an existing directory"
+  end
+
+  test "warns if trying to write into existing directory with files", context do
+    config = doc_config(context)
+    new_output = config[:output] <> "/new-dir"
+
+    File.mkdir_p!(new_output)
+    File.touch!(Path.join(new_output, "dummy-file"))
+
+    new_config = Keyword.put(config, :output, new_output)
+
+    assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
+             generate_docs(new_config)
+           end) =~ "ExDoc is outputting to an existing directory"
   end
 
   test "allows to set the authors of the document", %{tmp_dir: tmp_dir} = context do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -22,6 +22,10 @@ defmodule TestHelper do
   def elixirc(context, filename \\ "nofile", code) do
     dir = context.tmp_dir
 
+    output_dir = context.tmp_dir <> "/html"
+    File.mkdir_p!(output_dir)
+    File.write!(output_dir <> "/.ex_doc", "")
+
     src_path = Path.join([dir, filename])
     src_path |> Path.dirname() |> File.mkdir_p!()
     File.write!(src_path, code)


### PR DESCRIPTION
This pull requests adds a safety check before running `Fille.rm_rf!` when creating docs.

Now it will only allow users to select as output either:
- Unexisting directories (which will be created by ex_doc)
- Directories already managed by ex_doc (have the `.ex_doc` file)

One I think inevitable outcome of this is that this is a breaking change, users with existing `docs` folders that try to run it in a new version will receive the error message.

Maybe we can add a line in the error saying `Run "rm -rf docs" if you are seeing this after upgrading ex_doc`

Closes #1555