### PR TITLE
Allow multiple extra files with the same name

### DIFF
--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -355,11 +355,7 @@ defmodule ExDoc.Formatter.HTML do
 
     extras
     |> Enum.map_reduce(1, fn extra, idx ->
-      if ids_count[extra.id] > 1 do 
-        {disambiguate_id(extra, idx), idx + 1}
-      else
-        {extra, idx}
-      end
+      if ids_count[extra.id] > 1, do: {disambiguate_id(extra, idx), idx + 1}, else: {extra, idx}
     end)
     |> elem(0)
     |> Enum.sort_by(fn extra -> GroupMatcher.group_index(groups, extra.group) end)

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -354,9 +354,14 @@ defmodule ExDoc.Formatter.HTML do
     ids_count = Enum.reduce(extras, %{}, &Map.update(&2, &1.id, 1, fn c -> c + 1 end))
 
     extras
-    |> Enum.with_index(fn extra, idx ->
-      if ids_count[extra.id] > 1, do: disambiguate_id(extra, idx + 1), else: extra
+    |> Enum.map_reduce(1, fn extra, idx ->
+      if ids_count[extra.id] > 1 do 
+        {disambiguate_id(extra, idx), idx + 1}
+      else
+        {extra, idx}
+      end
     end)
+    |> elem(0)
     |> Enum.sort_by(fn extra -> GroupMatcher.group_index(groups, extra.group) end)
   end
 

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -355,7 +355,7 @@ defmodule ExDoc.Formatter.HTML do
 
     extras
     |> Enum.with_index(fn extra, idx ->
-      if ids_count[extra.id] > 1, do: disambiguate_id(extra, idx), else: extra
+      if ids_count[extra.id] > 1, do: disambiguate_id(extra, idx + 1), else: extra
     end)
     |> Enum.sort_by(fn extra -> GroupMatcher.group_index(groups, extra.group) end)
   end

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -351,7 +351,7 @@ defmodule ExDoc.Formatter.HTML do
       )
       |> Enum.map(&elem(&1, 1))
 
-    ids_count = Enum.reduce(extras, %{}, &Map.update(&2, &1.id, 0, fn c -> c + 1 end))
+    ids_count = Enum.reduce(extras, %{}, &Map.update(&2, &1.id, 1, fn c -> c + 1 end))
 
     extras
     |> Enum.with_index(fn extra, idx ->

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -104,8 +104,8 @@ defmodule ExDoc.Formatter.HTMLTest do
 
     generate_docs(config)
 
-    foo_content = EasyHTML.parse!(File.read!("#{c.tmp_dir}/html/readme-0.html"))["#content"]
-    bar_content = EasyHTML.parse!(File.read!("#{c.tmp_dir}/html/readme-1.html"))["#content"]
+    foo_content = EasyHTML.parse!(File.read!("#{c.tmp_dir}/html/readme-1.html"))["#content"]
+    bar_content = EasyHTML.parse!(File.read!("#{c.tmp_dir}/html/readme-2.html"))["#content"]
 
     assert to_string(foo_content["h1 > span"]) == "README foo"
     assert to_string(bar_content["h1 > span"]) == "README bar"

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -83,6 +83,34 @@ defmodule ExDoc.Formatter.HTMLTest do
     end
   end
 
+  test "multiple extras with the same name", c do
+    File.mkdir_p!("#{c.tmp_dir}/foo")
+
+    File.write!("#{c.tmp_dir}/foo/README.md", """
+    # README foo
+    """)
+
+    File.mkdir_p!("#{c.tmp_dir}/bar")
+
+    File.write!("#{c.tmp_dir}/bar/README.md", """
+    # README bar
+    """)
+
+    config =
+      Keyword.replace!(doc_config(c), :extras, [
+        "#{c.tmp_dir}/foo/README.md",
+        "#{c.tmp_dir}/bar/README.md"
+      ])
+
+    generate_docs(config)
+
+    foo_content = EasyHTML.parse!(File.read!("#{c.tmp_dir}/html/readme-0.html"))["#content"]
+    bar_content = EasyHTML.parse!(File.read!("#{c.tmp_dir}/html/readme-1.html"))["#content"]
+
+    assert to_string(foo_content["h1 > span"]) == "README foo"
+    assert to_string(bar_content["h1 > span"]) == "README bar"
+  end
+
   test "warns when generating an index.html file with an invalid redirect",
        %{tmp_dir: tmp_dir} = context do
     output =


### PR DESCRIPTION
This pull request adds a check to disambiguate the id generated ids if any of them are duplicated.

This already solves the issue, but I still have the following questions:
- Can we try to generate the ids considering the full filepaths (maybe parent directory), so that we don't need to disambiguate them later?
  - I think this is possible, but probably there will be edge cases
- I couldn't find any great way to test it, does someone have an idea?
   - I've tried adding multiple extra README.md files to the fixture `foo` app and then capturing IO/mix output, no success
- Are there any safe heuristics we could follow in order to avoid having `readme-1`, `readme-2`, etc in the URLs? Maybe using the groups or file paths?

Closes #1550 