### PR TITLE
Distinct deprecated autocomplete suggestions

### DIFF
--- a/assets/css/autocomplete.css
+++ b/assets/css/autocomplete.css
@@ -29,6 +29,11 @@
   text-decoration: none;
 }
 
+.autocomplete-suggestion-title-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+}
+
 .autocomplete-suggestion:hover,
 .autocomplete-suggestion.selected {
   background-color: var(--gray600);
@@ -55,5 +60,5 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  width: 100%;
+  max-width: 100%;
 }

--- a/assets/js/autocomplete/suggestions.js
+++ b/assets/js/autocomplete/suggestions.js
@@ -10,6 +10,7 @@ import { escapeRegexModifiers, escapeHtmlEntities, isBlank } from '../helpers'
  * @property {String|null} description An additional information (to be displayed below the title).
  * @property {Number} matchQuality How well the suggestion matches the given query string.
  * @property {String} category The group of suggestions that the suggestion belongs to.
+ * @property {bool} deprecated Wether this node is marked as deprecated in the codebase
  */
 
 const SUGGESTION_CATEGORY = {
@@ -103,6 +104,7 @@ function nodeSuggestion (node, query, category) {
     label: null,
     description: null,
     matchQuality: matchQuality(node.title, query),
+    deprecated: node.deprecated,
     category
   }
 }
@@ -120,6 +122,7 @@ function childNodeSuggestion (childNode, parentId, query, category, label) {
     label,
     description: parentId,
     matchQuality: matchQuality(childNode.id, query),
+    deprecated: childNode.deprecated,
     category
   }
 }
@@ -162,6 +165,7 @@ function moduleChildNodeSuggestion (childNode, parentId, query, category, label)
     label,
     description: parentId,
     matchQuality: matchQuality(modFun, query),
+    deprecated: childNode.deprecated,
     category
   }
 }

--- a/assets/js/handlebars/templates/autocomplete-suggestions.handlebars
+++ b/assets/js/handlebars/templates/autocomplete-suggestions.handlebars
@@ -7,7 +7,12 @@
     <a href="{{link}}" class="autocomplete-suggestion" data-index="{{@index}}" tabindex="-1">
       <div class="autocomplete-suggestion-title-wrapper">
         <div class="title">
-          <span translate="no">{{{title}}}</span>
+          {{# if deprecated }}
+            <s><span translate="no">{{{title}}}</span></s>
+          {{ else }}
+            <span translate="no">{{{title}}}</span>
+          {{/if}}
+
           {{#if label}}
             <span class="label">({{label}})</span>
           {{/if}}

--- a/assets/js/handlebars/templates/autocomplete-suggestions.handlebars
+++ b/assets/js/handlebars/templates/autocomplete-suggestions.handlebars
@@ -5,10 +5,16 @@
   </a>
   {{#each suggestions}}
     <a href="{{link}}" class="autocomplete-suggestion" data-index="{{@index}}" tabindex="-1">
-      <div class="title">
-        <span translate="no">{{{title}}}</span>
-        {{#if label}}
-          <span class="label">({{label}})</span>
+      <div class="autocomplete-suggestion-title-wrapper">
+        <div class="title">
+          <span translate="no">{{{title}}}</span>
+          {{#if label}}
+            <span class="label">({{label}})</span>
+          {{/if}}
+        </div>
+
+        {{#if deprecated}}
+          <span class="label">(deprecated)</span>
         {{/if}}
       </div>
 

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -124,10 +124,14 @@ defmodule ExDoc.Formatter.HTML.Templates do
 
         sections = module_sections(module)
 
+        deprecated? = not is_nil(module.deprecated)
+
         pairs =
           for key <- [:id, :title, :nested_title, :nested_context],
               value = Map.get(module, key),
               do: {key, value}
+
+        pairs = [{:deprecated, deprecated?} | pairs]
 
         Map.new([group: to_string(module.group)] ++ extra ++ pairs ++ sections)
       end
@@ -145,7 +149,9 @@ defmodule ExDoc.Formatter.HTML.Templates do
             "#{node.name}/#{node.arity}"
           end
 
-        %{id: id, title: node.signature, anchor: URI.encode(node.id)}
+        deprecated? = not is_nil(node.deprecated)
+
+        %{id: id, title: node.signature, anchor: URI.encode(node.id), deprecated: deprecated?}
       end
 
     %{key: HTML.text_to_id(group), name: group, nodes: nodes}

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -270,6 +270,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
                %{
                  "id" => "CompiledWithDocs",
                  "title" => "CompiledWithDocs",
+                 "deprecated" => false,
                  "nodeGroups" => [
                    %{
                      "key" => "functions",
@@ -288,6 +289,29 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
                },
                %{"id" => "CompiledWithDocs.Nested"}
              ] = create_sidebar_items(%{modules: nodes}, [])["modules"]
+    end
+
+    test "outputs deprecated: true if node is deprecated", context do
+      names = [CompiledWithDocs]
+      nodes = ExDoc.Retriever.docs_from_modules(names, doc_config(context))
+
+      path = ["modules", Access.at!(0), "nodeGroups", Access.at!(0), "nodes"]
+      sidebar_functions = get_in(create_sidebar_items(%{modules: nodes}, []), path)
+
+      assert Enum.any?(
+               sidebar_functions,
+               &match?(%{"anchor" => "example/2", "deprecated" => true}, &1)
+             )
+    end
+
+    test "outputs deprecated: true if module is deprecated", context do
+      names = [Warnings]
+      nodes = ExDoc.Retriever.docs_from_modules(names, doc_config(context))
+
+      assert Enum.any?(
+               create_sidebar_items(%{modules: nodes}, [])["modules"],
+               &match?(%{"title" => "Warnings", "deprecated" => true}, &1)
+             )
     end
 
     test "outputs nodes grouped based on metadata", context do


### PR DESCRIPTION
This patch shows a `(deprecated)` tag when autocompleting deprecated nodes.

Preview:
![deprecated_on_search_suggestions](https://github.com/elixir-lang/ex_doc/assets/59743220/6d4b0783-d024-4331-8281-a8faab241430)


Closes #1268 