### PR TITLE
Warn on invalid references in links

### DIFF
--- a/lib/ex_doc/language/elixir.ex
+++ b/lib/ex_doc/language/elixir.ex
@@ -550,8 +550,13 @@ defmodule ExDoc.Language.Elixir do
     timeout: 0
   ]
 
-  defp url(string = "mix help " <> name, mode, config), do: mix_task(name, string, mode, config)
-  defp url(string = "mix " <> name, mode, config), do: mix_task(name, string, mode, config)
+  defp url(string = "mix help " <> name, mode, config) do
+    name |> mix_task(string, mode, config) |> maybe_remove_link(mode)
+  end
+
+  defp url(string = "mix " <> name, mode, config) do
+    name |> mix_task(string, mode, config) |> maybe_remove_link(mode)
+  end
 
   defp url(string, mode, config) do
     case Regex.run(~r{^(.+)/(\d+)$}, string) do
@@ -721,11 +726,9 @@ defmodule ExDoc.Language.Elixir do
         mix_task: true,
         original_text: string
       })
-
-      :remove_link
-    else
-      url
     end
+
+    url
   end
 
   defp safe_format_string!(string) do

--- a/lib/ex_doc/language/elixir.ex
+++ b/lib/ex_doc/language/elixir.ex
@@ -447,7 +447,7 @@ defmodule ExDoc.Language.Elixir do
           [[_, custom_link]] ->
             custom_link
             |> url(:custom_link, config)
-            |> remove_and_warn_if_invalid(href, config)
+            |> remove_and_warn_if_invalid(custom_link, config)
 
           [] ->
             build_extra_link(href, config)
@@ -458,9 +458,9 @@ defmodule ExDoc.Language.Elixir do
     end
   end
 
-  defp remove_and_warn_if_invalid(nil, href, config) do
+  defp remove_and_warn_if_invalid(nil, reference, config) do
     warn(
-      ~s[documentation references "#{href}" but it is invalid],
+      ~s[documentation references "#{reference}" but it is invalid],
       {config.file, config.line},
       config.id
     )

--- a/lib/ex_doc/language/elixir.ex
+++ b/lib/ex_doc/language/elixir.ex
@@ -444,12 +444,26 @@ defmodule ExDoc.Language.Elixir do
     case Keyword.fetch(attrs, :href) do
       {:ok, href} ->
         case Regex.scan(@ref_regex, href) do
-          [[_, custom_link]] -> url(custom_link, :custom_link, config)
-          [] -> build_extra_link(href, config)
+          [[_, custom_link]] ->
+            custom_link
+            |> url(:custom_link, config)
+            |> maybe_remove_invalid_ref(href)
+
+          [] ->
+            build_extra_link(href, config)
         end
 
       _ ->
         nil
+    end
+  end
+
+  defp maybe_remove_invalid_ref(result, href) do
+    if is_nil(result) and String.match?(href, ~r/`.*`/) do
+      IO.warn("found invalid reference: #{href}")
+      :remove_link
+    else
+      result
     end
   end
 

--- a/test/ex_doc/language/elixir_test.exs
+++ b/test/ex_doc/language/elixir_test.exs
@@ -462,19 +462,19 @@ defmodule ExDoc.Language.ElixirTest do
 
     assert warn(fn ->
              assert autolink_doc(~m"[text](`fakefunction`)") == ~m"text"
-           end) =~ ~s[but it is invalid]
+           end) =~ ~s[documentation references "fakefunction" but it is invalid]
 
     assert warn(fn ->
              assert autolink_doc(~m"[text](`some.function`)") == ~m"text"
-           end) =~ ~s[but it is invalid]
+           end) =~ ~s[documentation references "some.function" but it is invalid]
 
     assert warn(fn ->
              assert autolink_doc(~m"[text](`Enum.map()`)") == ~m"text"
-           end) =~ ~s[but it is invalid]
+           end) =~ ~s[documentation references "Enum.map()" but it is invalid]
 
     assert warn(fn ->
              assert autolink_doc(~m"[text](`t:supervisor.child_spec/0`)") == ~m"text"
-           end) =~ ~s[but it is invalid]
+           end) =~ ~s[documentation references "t:supervisor.child_spec/0" but it is invalid]
 
     assert warn(fn ->
              autolink_spec(quote(do: t() :: String.bad()))

--- a/test/ex_doc/language/elixir_test.exs
+++ b/test/ex_doc/language/elixir_test.exs
@@ -32,24 +32,6 @@ defmodule ExDoc.Language.ElixirTest do
       assert autolink_doc(~m"`PATH`") == ~m"`PATH`"
     end
 
-    test "removes link and warns on invalid references" do
-      assert warn(fn ->
-               assert autolink_doc(~m"[text](`fakefunction`)") == ~m"text"
-             end) =~ ~s[but it is invalid]
-
-      assert warn(fn ->
-               assert autolink_doc(~m"[text](`some.function`)") == ~m"text"
-             end) =~ ~s[but it is invalid]
-
-      assert warn(fn ->
-               assert autolink_doc(~m"[text](`Enum.map()`)") == ~m"text"
-             end) =~ ~s[but it is invalid]
-
-      assert warn(fn ->
-               assert autolink_doc(~m"[text](`t:supervisor.child_spec/0`)") == ~m"text"
-             end) =~ ~s[but it is invalid]
-    end
-
     test "erlang module" do
       assert_unchanged(~m"`:array`")
     end
@@ -477,6 +459,22 @@ defmodule ExDoc.Language.ElixirTest do
     warn(~m"`c:GenServer.handle_call/9`")
 
     warn(~m"`t:Calendar.date/9`")
+
+    assert warn(fn ->
+             assert autolink_doc(~m"[text](`fakefunction`)") == ~m"text"
+           end) =~ ~s[but it is invalid]
+
+    assert warn(fn ->
+             assert autolink_doc(~m"[text](`some.function`)") == ~m"text"
+           end) =~ ~s[but it is invalid]
+
+    assert warn(fn ->
+             assert autolink_doc(~m"[text](`Enum.map()`)") == ~m"text"
+           end) =~ ~s[but it is invalid]
+
+    assert warn(fn ->
+             assert autolink_doc(~m"[text](`t:supervisor.child_spec/0`)") == ~m"text"
+           end) =~ ~s[but it is invalid]
 
     assert warn(fn ->
              autolink_spec(quote(do: t() :: String.bad()))


### PR DESCRIPTION
This pull request adds a check to warn and remove a link if it is a reference (has backticks) and could not be parsed as a reference.

That means links such as  ``[supervisor docs](`t:supervisor.child_spec/0`)`` will now warn on build and not emit a broken link rather than failing silently.j

Closes #1572 