### PR TITLE
Fix escaping `#{}` in search_items.json

### DIFF
--- a/lib/ex_doc/utils.ex
+++ b/lib/ex_doc/utils.ex
@@ -122,7 +122,9 @@ defmodule ExDoc.Utils do
   end
 
   def to_json(binary) when is_binary(binary) do
-    inspect(binary, printable_limit: :infinity)
+    binary
+    |> inspect(printable_limit: :infinity)
+    |> String.replace("\\#\{", "#\{")
   end
 
   def to_json(integer) when is_integer(integer) do

--- a/test/ex_doc/formatter/html/search_items_test.exs
+++ b/test/ex_doc/formatter/html/search_items_test.exs
@@ -81,6 +81,22 @@ defmodule ExDoc.Formatter.HTML.SearchItemsTest do
     assert item["doc"] == ""
   end
 
+  test "escaping", c do
+    modules =
+      elixirc(c, ~S'''
+      defmodule SearchFoo do
+        @moduledoc ~S"""
+        #{}
+        """
+      end
+      ''')
+
+    config = %ExDoc.Config{output: "#{c.tmp_dir}/doc"}
+    [item] = search_items(modules, config)
+
+    assert item["doc"] == ~S"#{}"
+  end
+
   @tag :otp_eep48
   test "Erlang module", c do
     [module] =


### PR DESCRIPTION
Inspect implementation for String is such that:

    iex> ~S"#{}"
    "\#{}"

However `\#` is invalid JSON escape code.
