### PR TITLE
Rename `searchNodes` to `searchData`

### DIFF
--- a/assets/js/search-page.js
+++ b/assets/js/search-page.js
@@ -1,4 +1,4 @@
-/* globals searchNodes */
+/* globals searchData */
 
 import lunr from 'lunr'
 import { qs, escapeHtmlEntities, isBlank, getQueryParamByName, getProjectNameAndVersion } from './helpers'
@@ -98,7 +98,7 @@ function createIndex () {
     this.pipeline.remove(lunr.trimmer)
     this.use(elixirTrimmer)
 
-    searchNodes.forEach(searchNode => {
+    searchData.items.forEach(searchNode => {
       this.add(searchNode)
     })
   })
@@ -175,7 +175,7 @@ function searchResultsToDecoratedSearchNodes (results) {
 }
 
 function getSearchNodeByRef (ref) {
-  return searchNodes.find(searchNode => searchNode.ref === ref) || null
+  return searchData.items.find(searchNode => searchNode.ref === ref) || null
 }
 
 function getExcerpts (searchNode, metadata) {

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -1,7 +1,7 @@
 defmodule ExDoc.Formatter.HTML do
   @moduledoc false
 
-  alias __MODULE__.{Assets, Templates, SearchItems}
+  alias __MODULE__.{Assets, Templates, SearchData}
   alias ExDoc.{Markdown, GroupMatcher, Utils}
 
   @main "api-reference"
@@ -23,7 +23,7 @@ defmodule ExDoc.Formatter.HTML do
 
     # Generate search early on without api reference in extras
     static_files = generate_assets(config, @assets_dir, default_assets(config))
-    search_items = generate_search_items(project_nodes, extras, config)
+    search_data = generate_search_data(project_nodes, extras, config)
 
     nodes_map = %{
       modules: filter_list(:module, project_nodes),
@@ -38,7 +38,7 @@ defmodule ExDoc.Formatter.HTML do
       end
 
     all_files =
-      search_items ++
+      search_data ++
         static_files ++
         generate_sidebar_items(nodes_map, extras, config) ++
         generate_extras(nodes_map, extras, config) ++
@@ -226,16 +226,16 @@ defmodule ExDoc.Formatter.HTML do
 
   defp generate_sidebar_items(nodes_map, extras, config) do
     content = Templates.create_sidebar_items(nodes_map, extras)
-    sidebar_items = "dist/sidebar_items-#{digest(content)}.js"
-    File.write!(Path.join(config.output, sidebar_items), content)
-    [sidebar_items]
+    path = "dist/sidebar_items-#{digest(content)}.js"
+    File.write!(Path.join(config.output, path), content)
+    [path]
   end
 
-  defp generate_search_items(linked, extras, config) do
-    content = SearchItems.create(linked, extras)
-    search_items = "dist/search_items-#{digest(content)}.js"
-    File.write!(Path.join(config.output, search_items), content)
-    [search_items]
+  defp generate_search_data(linked, extras, config) do
+    content = SearchData.create(linked, extras)
+    path = "dist/search_data-#{digest(content)}.js"
+    File.write!(Path.join(config.output, path), content)
+    [path]
   end
 
   defp digest(content) do

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -232,7 +232,7 @@ defmodule ExDoc.Formatter.HTML do
   end
 
   defp generate_search_data(linked, extras, config) do
-    content = SearchData.create(linked, extras)
+    content = SearchData.create(linked, extras, config.proglang)
     path = "dist/search_data-#{digest(content)}.js"
     File.write!(Path.join(config.output, path), content)
     [path]

--- a/lib/ex_doc/formatter/html/search_data.ex
+++ b/lib/ex_doc/formatter/html/search_data.ex
@@ -1,4 +1,4 @@
-defmodule ExDoc.Formatter.HTML.SearchItems do
+defmodule ExDoc.Formatter.HTML.SearchData do
   @moduledoc false
 
   # TODO: It should not depend on the parent module
@@ -6,7 +6,7 @@ defmodule ExDoc.Formatter.HTML.SearchItems do
 
   def create(nodes, extras) do
     items = Enum.flat_map(nodes, &module/1) ++ Enum.flat_map(extras, &extra/1)
-    ["searchNodes=" | ExDoc.Utils.to_json(items)]
+    ["searchData=" | ExDoc.Utils.to_json(%{items: items})]
   end
 
   defp extra(map) do

--- a/lib/ex_doc/formatter/html/search_data.ex
+++ b/lib/ex_doc/formatter/html/search_data.ex
@@ -4,9 +4,21 @@ defmodule ExDoc.Formatter.HTML.SearchData do
   # TODO: It should not depend on the parent module
   alias ExDoc.Formatter.HTML
 
-  def create(nodes, extras) do
+  def create(nodes, extras, proglang) do
+    content_type =
+      case proglang do
+        :elixir -> "text/markdown"
+        :erlang -> "text/plain"
+      end
+
     items = Enum.flat_map(nodes, &module/1) ++ Enum.flat_map(extras, &extra/1)
-    ["searchData=" | ExDoc.Utils.to_json(%{items: items})]
+
+    data = %{
+      items: items,
+      content_type: content_type
+    }
+
+    ["searchData=" | ExDoc.Utils.to_json(data)]
   end
 
   defp extra(map) do

--- a/lib/ex_doc/formatter/html/templates/search_template.eex
+++ b/lib/ex_doc/formatter/html/templates/search_template.eex
@@ -9,5 +9,5 @@
 
   <div class="loading"><div></div><div></div><div></div><div></div></div>
 </div>
-<script src="<%= asset_rev config.output, "dist/search_items*.js" %>"></script>
+<script src="<%= asset_rev config.output, "dist/search_data*.js" %>"></script>
 <%= footer_template(config, nil) %>

--- a/test/ex_doc/formatter/html/search_data_test.exs
+++ b/test/ex_doc/formatter/html/search_data_test.exs
@@ -25,7 +25,9 @@ defmodule ExDoc.Formatter.HTML.SearchDataTest do
       ''')
 
     config = %ExDoc.Config{output: "#{c.tmp_dir}/doc"}
-    [item1, item2] = search_data(modules, config)
+    data = search_data(modules, config)
+    assert data["content_type"] == "text/markdown"
+    [item1, item2] = data["items"]
 
     assert item1["ref"] == "SearchFoo.html"
     assert item1["type"] == "module"
@@ -53,7 +55,7 @@ defmodule ExDoc.Formatter.HTML.SearchDataTest do
       ''')
 
     config = %ExDoc.Config{output: "#{c.tmp_dir}/doc"}
-    [item1, item2] = search_data(modules, config)
+    [item1, item2] = search_data(modules, config)["items"]
 
     assert item1["ref"] == "Mix.Tasks.SearchItemTest.html"
     assert item1["type"] == "task"
@@ -74,7 +76,7 @@ defmodule ExDoc.Formatter.HTML.SearchDataTest do
       ''')
 
     config = %ExDoc.Config{output: "#{c.tmp_dir}/doc"}
-    [item] = search_data(modules, config)
+    [item] = search_data(modules, config)["items"]
     assert item["ref"] == "SearchFoo.html"
     assert item["type"] == "module"
     assert item["title"] == "SearchFoo"
@@ -92,7 +94,7 @@ defmodule ExDoc.Formatter.HTML.SearchDataTest do
       ''')
 
     config = %ExDoc.Config{output: "#{c.tmp_dir}/doc"}
-    [item] = search_data(modules, config)
+    [item] = search_data(modules, config)["items"]
 
     assert item["doc"] == ~S"#{}"
   end
@@ -106,8 +108,10 @@ defmodule ExDoc.Formatter.HTML.SearchDataTest do
       -module(search_foo).
       """)
 
-    config = %ExDoc.Config{output: "#{c.tmp_dir}/doc"}
-    [item] = search_data([module], config)
+    config = %ExDoc.Config{output: "#{c.tmp_dir}/doc", proglang: :erlang}
+    data = search_data([module], config)
+    assert data["content_type"] == "text/plain"
+    [item] = data["items"]
     assert item["ref"] == "search_foo.html"
     assert item["type"] == "module"
     assert item["title"] == "search_foo"
@@ -126,7 +130,7 @@ defmodule ExDoc.Formatter.HTML.SearchDataTest do
       ''')
 
     config = %ExDoc.Config{output: "#{c.tmp_dir}/doc"}
-    [%{"type" => "module"}, item] = search_data(modules, config)
+    [%{"type" => "module"}, item] = search_data(modules, config)["items"]
     assert item["ref"] == "SearchFoo.html#foo/0"
     assert item["type"] == "function"
     assert item["title"] == "SearchFoo.foo/0"
@@ -149,7 +153,7 @@ defmodule ExDoc.Formatter.HTML.SearchDataTest do
       ''')
 
     config = %ExDoc.Config{output: "#{c.tmp_dir}/doc"}
-    [%{"type" => "behaviour"}, item1, item2] = search_data(modules, config)
+    [%{"type" => "behaviour"}, item1, item2] = search_data(modules, config)["items"]
     assert item1["ref"] == "SearchFoo.html#c:handle_foo/0"
     assert item1["type"] == "callback"
     assert item1["title"] == "SearchFoo.handle_foo/0"
@@ -173,7 +177,7 @@ defmodule ExDoc.Formatter.HTML.SearchDataTest do
       ''')
 
     config = %ExDoc.Config{output: "#{c.tmp_dir}/doc"}
-    [%{"type" => "module"}, item] = search_data(modules, config)
+    [%{"type" => "module"}, item] = search_data(modules, config)["items"]
     assert item["ref"] == "SearchFoo.html#t:foo/0"
     assert item["type"] == "type"
     assert item["title"] == "SearchFoo.foo/0"
@@ -194,7 +198,7 @@ defmodule ExDoc.Formatter.HTML.SearchDataTest do
     """)
 
     config = %ExDoc.Config{output: "#{c.tmp_dir}/doc", extras: [readme_path]}
-    [item1, item2] = search_data([], config)
+    [item1, item2] = search_data([], config)["items"]
 
     assert item1["ref"] == "readme.html"
     assert item1["type"] == "extras"
@@ -213,7 +217,6 @@ defmodule ExDoc.Formatter.HTML.SearchDataTest do
     ExDoc.Formatter.HTML.run(modules, config)
     [path] = Path.wildcard(Path.join([config.output, "dist", "search_data-*.js"]))
     "searchData=" <> json = File.read!(path)
-    %{"items" => items} = Jason.decode!(json)
-    items
+    Jason.decode!(json)
   end
 end

--- a/test/ex_doc/formatter/html/search_data_test.exs
+++ b/test/ex_doc/formatter/html/search_data_test.exs
@@ -1,4 +1,4 @@
-defmodule ExDoc.Formatter.HTML.SearchItemsTest do
+defmodule ExDoc.Formatter.HTML.SearchDataTest do
   use ExUnit.Case, async: true
   import TestHelper
 
@@ -25,7 +25,7 @@ defmodule ExDoc.Formatter.HTML.SearchItemsTest do
       ''')
 
     config = %ExDoc.Config{output: "#{c.tmp_dir}/doc"}
-    [item1, item2] = search_items(modules, config)
+    [item1, item2] = search_data(modules, config)
 
     assert item1["ref"] == "SearchFoo.html"
     assert item1["type"] == "module"
@@ -53,7 +53,7 @@ defmodule ExDoc.Formatter.HTML.SearchItemsTest do
       ''')
 
     config = %ExDoc.Config{output: "#{c.tmp_dir}/doc"}
-    [item1, item2] = search_items(modules, config)
+    [item1, item2] = search_data(modules, config)
 
     assert item1["ref"] == "Mix.Tasks.SearchItemTest.html"
     assert item1["type"] == "task"
@@ -74,7 +74,7 @@ defmodule ExDoc.Formatter.HTML.SearchItemsTest do
       ''')
 
     config = %ExDoc.Config{output: "#{c.tmp_dir}/doc"}
-    [item] = search_items(modules, config)
+    [item] = search_data(modules, config)
     assert item["ref"] == "SearchFoo.html"
     assert item["type"] == "module"
     assert item["title"] == "SearchFoo"
@@ -92,7 +92,7 @@ defmodule ExDoc.Formatter.HTML.SearchItemsTest do
       ''')
 
     config = %ExDoc.Config{output: "#{c.tmp_dir}/doc"}
-    [item] = search_items(modules, config)
+    [item] = search_data(modules, config)
 
     assert item["doc"] == ~S"#{}"
   end
@@ -107,7 +107,7 @@ defmodule ExDoc.Formatter.HTML.SearchItemsTest do
       """)
 
     config = %ExDoc.Config{output: "#{c.tmp_dir}/doc"}
-    [item] = search_items([module], config)
+    [item] = search_data([module], config)
     assert item["ref"] == "search_foo.html"
     assert item["type"] == "module"
     assert item["title"] == "search_foo"
@@ -126,7 +126,7 @@ defmodule ExDoc.Formatter.HTML.SearchItemsTest do
       ''')
 
     config = %ExDoc.Config{output: "#{c.tmp_dir}/doc"}
-    [%{"type" => "module"}, item] = search_items(modules, config)
+    [%{"type" => "module"}, item] = search_data(modules, config)
     assert item["ref"] == "SearchFoo.html#foo/0"
     assert item["type"] == "function"
     assert item["title"] == "SearchFoo.foo/0"
@@ -149,7 +149,7 @@ defmodule ExDoc.Formatter.HTML.SearchItemsTest do
       ''')
 
     config = %ExDoc.Config{output: "#{c.tmp_dir}/doc"}
-    [%{"type" => "behaviour"}, item1, item2] = search_items(modules, config)
+    [%{"type" => "behaviour"}, item1, item2] = search_data(modules, config)
     assert item1["ref"] == "SearchFoo.html#c:handle_foo/0"
     assert item1["type"] == "callback"
     assert item1["title"] == "SearchFoo.handle_foo/0"
@@ -173,7 +173,7 @@ defmodule ExDoc.Formatter.HTML.SearchItemsTest do
       ''')
 
     config = %ExDoc.Config{output: "#{c.tmp_dir}/doc"}
-    [%{"type" => "module"}, item] = search_items(modules, config)
+    [%{"type" => "module"}, item] = search_data(modules, config)
     assert item["ref"] == "SearchFoo.html#t:foo/0"
     assert item["type"] == "type"
     assert item["title"] == "SearchFoo.foo/0"
@@ -194,7 +194,7 @@ defmodule ExDoc.Formatter.HTML.SearchItemsTest do
     """)
 
     config = %ExDoc.Config{output: "#{c.tmp_dir}/doc", extras: [readme_path]}
-    [item1, item2] = search_items([], config)
+    [item1, item2] = search_data([], config)
 
     assert item1["ref"] == "readme.html"
     assert item1["type"] == "extras"
@@ -207,12 +207,13 @@ defmodule ExDoc.Formatter.HTML.SearchItemsTest do
     assert item2["doc"] == "Section _1_ content."
   end
 
-  defp search_items(modules, config) do
+  defp search_data(modules, config) do
     modules = ExDoc.Retriever.docs_from_modules(modules, config)
 
     ExDoc.Formatter.HTML.run(modules, config)
-    [path] = Path.wildcard(Path.join([config.output, "dist", "search_items-*.js"]))
-    "searchNodes=" <> json = File.read!(path)
-    Jason.decode!(json)
+    [path] = Path.wildcard(Path.join([config.output, "dist", "search_data-*.js"]))
+    "searchData=" <> json = File.read!(path)
+    %{"items" => items} = Jason.decode!(json)
+    items
   end
 end

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -39,7 +39,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
   setup %{tmp_dir: tmp_dir} do
     File.cp_r!("formatters/html", tmp_dir <> "/html_templates")
     File.touch!(tmp_dir <> "/html_templates/dist/sidebar_items-123456.js")
-    File.touch!(tmp_dir <> "/html_templates/dist/search_items-123456.js")
+    File.touch!(tmp_dir <> "/html_templates/dist/search_data-123456.js")
     :ok
   end
 


### PR DESCRIPTION
- Rename `searchNodes` to `searchData`
- Add content-type based on proglang