### PR TITLE
Ignore vegalite codeblocks in search

### DIFF
--- a/lib/ex_doc/formatter/html/search_data.ex
+++ b/lib/ex_doc/formatter/html/search_data.ex
@@ -126,6 +126,7 @@ defmodule ExDoc.Formatter.HTML.SearchData do
         section =
           section
           |> HTML.strip_tags(" ")
+          |> drop_ignorable_codeblocks()
           |> String.trim()
 
         {clean_markdown(header), section}
@@ -145,5 +146,12 @@ defmodule ExDoc.Formatter.HTML.SearchData do
     |> HTML.strip_tags(" ")
     |> String.replace(~r/\s+/, " ")
     |> String.trim()
+  end
+
+  @ignored_codeblocks ~w[vega-lite]
+
+  defp drop_ignorable_codeblocks(section) do
+    block_names = Enum.join(@ignored_codeblocks, "|")
+    String.replace(section, ~r/^```(?:#{block_names})\n(?:[\s\S]*?)```$/m, "")
   end
 end

--- a/test/ex_doc/formatter/html/search_data_test.exs
+++ b/test/ex_doc/formatter/html/search_data_test.exs
@@ -211,6 +211,37 @@ defmodule ExDoc.Formatter.HTML.SearchDataTest do
     assert item2["doc"] == "Section _1_ content."
   end
 
+  test "drops vega-lite blocks", c do
+    readme_path = "#{c.tmp_dir}/README.md"
+
+    File.write!(readme_path, """
+    # Foo
+
+    _Foo_ content.
+
+    ## Section 1 Header
+
+    ```vega-lite
+      graph
+    ```
+
+    Section _1_ content.
+    """)
+
+    config = %ExDoc.Config{output: "#{c.tmp_dir}/doc", extras: [readme_path]}
+    [item1, item2] = search_data([], config)["items"]
+
+    assert item1["ref"] == "readme.html"
+    assert item1["type"] == "extras"
+    assert item1["title"] == "Foo"
+    assert item1["doc"] == "# Foo\n\n_Foo_ content."
+
+    assert item2["ref"] == "readme.html#section-1-header"
+    assert item2["type"] == "extras"
+    assert item2["title"] == "Section 1 Header - Foo"
+    assert item2["doc"] == "Section _1_ content."
+  end
+
   defp search_data(modules, config) do
     modules = ExDoc.Retriever.docs_from_modules(modules, config)
 


### PR DESCRIPTION
Scholar can now persist its index after removing the vega-lite codeblocks
![image](https://github.com/elixir-lang/ex_doc/assets/4422419/03a301e6-cde4-45b2-9e0a-d6eb1f6b5763)

Partially fixes #1732 

Before trimming a section, we add a step to match vegalite codeblocks and remove them.