### PR TITLE
Fix generation of `.livemd` paths to handle omitted '.html'

### DIFF
--- a/assets/js/content.js
+++ b/assets/js/content.js
@@ -59,7 +59,7 @@ function fixSpacebar () {
  */
 function setLivebookBadgeUrl () {
   const path = window.location.pathname
-  const notebookPath = path.replace(/\.html$/, '.livemd')
+  const notebookPath = path.replace(/(\.html)?$/, '.livemd')
   const notebookUrl = new URL(notebookPath, window.location.href).toString()
 
   settingsStore.getAndSubscribe(settings => {


### PR DESCRIPTION
Some HTTP servers redirect and omit the `.html` extension when you go to an html page, hosting a generated doc on one of these makes the “Run in Livebook” button break because it doesn’t add the `.livemd` extension to the link. This PR fixes it making the `.html` optional in the replacement.
