### PR TITLE
Adjust extract_sections/2 to account for undocumented erlang functions

### DIFF
--- a/lib/ex_doc/formatter/html/search_data.ex
+++ b/lib/ex_doc/formatter/html/search_data.ex
@@ -141,6 +141,8 @@ defmodule ExDoc.Formatter.HTML.SearchData do
     |> String.trim()
   end
 
+  defp clean_html(nil), do: ""
+
   defp clean_html(doc) do
     doc
     |> HTML.strip_tags(" ")

--- a/lib/ex_doc/formatter/html/search_data.ex
+++ b/lib/ex_doc/formatter/html/search_data.ex
@@ -108,6 +108,10 @@ defmodule ExDoc.Formatter.HTML.SearchData do
     extract_sections_from_markdown(doc)
   end
 
+  defp extract_sections("application/erlang+html", %{rendered_doc: nil}) do
+    {nil, []}
+  end
+
   defp extract_sections("application/erlang+html", %{rendered_doc: doc}) do
     {clean_html(doc), []}
   end
@@ -140,8 +144,6 @@ defmodule ExDoc.Formatter.HTML.SearchData do
     |> HTML.strip_tags(" ")
     |> String.trim()
   end
-
-  defp clean_html(nil), do: ""
 
   defp clean_html(doc) do
     doc

--- a/test/ex_doc/formatter/html/erlang_test.exs
+++ b/test/ex_doc/formatter/html/erlang_test.exs
@@ -16,13 +16,16 @@ defmodule ExDoc.Formatter.HTML.ErlangTest do
     %% @doc
     %% foo module.
     -module(foo).
-    -export([foo/1]).
+    -export([foo/1, bar/0]).
     -export_type([t/0]).
 
     %% @doc
     %% f/0 function.
     -spec foo(atom()) -> atom().
     foo(X) -> X.
+
+    -spec bar() -> baz.
+    bar() -> baz.
 
     -type t() :: atom().
     %% t/0 type.


### PR DESCRIPTION
Recent changes around cleaning html and striping tags introduced a regression when it comes to generating ex doc for erlang modules.

Specifically, undocumented functions (exported or not) end up as a `nil` node in the ast. The nil node gets passed from 
 [SearchData.node_child/2](https://github.com/elixir-lang/ex_doc/blob/main/lib/ex_doc/formatter/html/search_data.ex#L75) to [SearchData.extract_sections/2](https://github.com/elixir-lang/ex_doc/blob/main/lib/ex_doc/formatter/html/search_data.ex#L75), then to [SearchData.clean_html/1](https://github.com/elixir-lang/ex_doc/blob/main/lib/ex_doc/formatter/html/search_data.ex#L144). Said `ni`l node will cause a crash since `HTML.strip_tags/2` in has a binary guard clause. 
 
Since `strip_tags/2` has a guard clause the best place to catch this seemed to be in `clean_html/1` to itself, however it may be more appropriate to normalize variant further up. In that sense, it makes more sense to catch this at `extract_sections/2` since there would at least be a bit more context, but still it may be worth catching this even further up. 

None the less, a fix with a test is offered in this PR 😄 

Possibly worth noting a work around for this in Erlang source code is to explicitly state that a functions documentation is private (i.e., `%% @private`). 