### PR TITLE
Remove sidebar gradient

### DIFF
--- a/assets/css/custom-props/theme-dark.css
+++ b/assets/css/custom-props/theme-dark.css
@@ -75,8 +75,6 @@ body.dark {
                                                  var(--gray900-opacity-0) 100%);
   --sidebarAccentMain:           var(--gray50);
   --sidebarBackground:           var(--gray800);
-  --sidebarGradient:             linear-gradient(var(--sidebarBackground),
-                                                 var(gray800-opacity-0));
   --sidebarHeader:               var(--gray700);
   --sidebarMuted:                var(--gray300);
   --sidebarHover:                var(--white);

--- a/assets/css/custom-props/theme-light.css
+++ b/assets/css/custom-props/theme-light.css
@@ -75,8 +75,6 @@
                                                  var(--white-opacity-0) 100%);
   --sidebarAccentMain:           var(--gray50);
   --sidebarBackground:           var(--gray800);
-  --sidebarGradient:             linear-gradient(var(--sidebarBackground),
-                                                 var(gray800-opacity-0));
   --sidebarHeader:               var(--gray700);
   --sidebarMuted:                var(--gray300);
   --sidebarHover:                var(--white);

--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -13,16 +13,6 @@
   font-weight: 400; /* Non-Apple OSes render small light type too thinly */
 }
 
-.sidebar .gradient {
-  background: var(--sidebarGradient);
-  height: 20px;
-  margin-top: -20px;
-  pointer-events: none;
-  position: relative;
-  top: 20px;
-  z-index: 100;
-}
-
 .sidebar ul {
   list-style: none;
 }

--- a/lib/ex_doc/formatter/html/templates/sidebar_template.eex
+++ b/lib/ex_doc/formatter/html/templates/sidebar_template.eex
@@ -51,7 +51,6 @@
     </ul>
   </div>
 
-  <div class="gradient"></div>
   <ul id="full-list"></ul>
 </section>
 


### PR DESCRIPTION
When I checked out the project to work on something else, I noticed an invalid CSS variable, `var(gray800-opacity-0)` (missing leading `--` in front of the name).

After digging around, I realized that, if fixed, the sidebar gradient would be a gradient from gray800 to gray800-opacity-0, and it would be rendered inside of the sidebar that already has a solid background color of gray800. That means the gradient would not be visible at all. Its positioning styles also mean that the gradient element never took up any space.

I decided it makes no sense to fix this gradient element that would be invisible anyway and doesn't affect the flow of other elements, and instead I'm deleting it.