### PR TITLE
Revert hover link approach to fix markup of headings containing links

### DIFF
--- a/assets/css/content/admonition.css
+++ b/assets/css/content/admonition.css
@@ -108,6 +108,7 @@
 
 .content-inner blockquote :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) :is(a, a:visited) {
   color: inherit;
+  text-decoration-color: currentColor;
 }
 
 @media screen and (max-width: 768px) {

--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -132,8 +132,7 @@
 }
 
 .content-inner .section-heading a {
-  color:  var(--links);
-  text-decoration: none;
+  color: var(--links);
   display: inline-block;
 }
 
@@ -141,14 +140,21 @@
   color: var(--links);
 }
 
+.content-inner .section-heading a.hover-link {
+  text-decoration: none;
+}
+
 .content-inner .section-heading i {
-  font-size: 16px;
+  --icon-size: 16px;
+  --icon-spacing: 5px;
+  font-size: var(--icon-size);
   margin-top: .1em;
-  margin-left: -21px;
+  margin-left: calc(-1 * (var(--icon-size) + var(--icon-spacing)));
+  padding-right: var(--icon-spacing);
   opacity: 0;
 }
 
-.content-inner .section-heading a:is(:hover, :focus) i {
+.content-inner .section-heading:hover i {
   opacity: 1;
 }
 

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -302,10 +302,9 @@ defmodule ExDoc.Formatter.HTML.Templates do
 
     """
     <#{tag} id="#{prefix}#{id}" class="#{class_attribute}">
-      <a href="##{prefix}#{id}">
+      <a href="##{prefix}#{id}" class="hover-link">
         <i class="ri-link-m" aria-hidden="true"></i>
-        #{title}
-      </a>
+      </a>#{title}
     </#{tag}>
     """
   end

--- a/test/ex_doc/formatter/epub/templates_test.exs
+++ b/test/ex_doc/formatter/epub/templates_test.exs
@@ -60,10 +60,10 @@ defmodule ExDoc.Formatter.EPUB.TemplatesTest do
       assert content =~ ~r{<h1 id="content">\s*CompiledWithDocs\s*}
 
       assert content =~
-               ~r{<h2 id="module-example-unicode-escaping" class="section-heading">.*<a href="#module-example-unicode-escaping">.*<i class="ri-link-m" aria-hidden="true"></i>.*Example.*</a>.*</h2>}ms
+               ~r{<h2 id="module-example-unicode-escaping" class="section-heading">.*<a href="#module-example-unicode-escaping" class="hover-link">.*<i class="ri-link-m" aria-hidden="true"></i>.*</a>.*Example.*</h2>}ms
 
       assert content =~
-               ~r{<h3 id="module-example-h3-heading" class="section-heading">.*<a href="#module-example-h3-heading">.*<i class="ri-link-m" aria-hidden="true"></i>.*Example H3 heading.*</a>.*</h3>}ms
+               ~r{<h3 id="module-example-h3-heading" class="section-heading">.*<a href="#module-example-h3-heading" class="hover-link">.*<i class="ri-link-m" aria-hidden="true"></i>.*</a>.*Example H3 heading.*</h3>}ms
 
       assert content =~
                ~r{moduledoc.*Example.*<samp class="nc">CompiledWithDocs</samp><samp class="o">\.</samp><samp class="n">example</samp>.*}ms

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -47,61 +47,54 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
     test "generates headers with hovers" do
       assert Templates.link_headings("<h2>Foo</h2><h2>Bar</h2>") == """
              <h2 id="foo" class="section-heading">
-               <a href="#foo">
+               <a href="#foo" class="hover-link">
                  <i class="ri-link-m" aria-hidden="true"></i>
-                 Foo
-               </a>
+               </a>Foo
              </h2>
              <h2 id="bar" class="section-heading">
-               <a href="#bar">
+               <a href="#bar" class="hover-link">
                  <i class="ri-link-m" aria-hidden="true"></i>
-                 Bar
-               </a>
+               </a>Bar
              </h2>
              """
 
       assert Templates.link_headings("<h2>Foo</h2>\n<h2>Bar</h2>") == """
              <h2 id="foo" class="section-heading">
-               <a href="#foo">
+               <a href="#foo" class="hover-link">
                  <i class="ri-link-m" aria-hidden="true"></i>
-                 Foo
-               </a>
+               </a>Foo
              </h2>
 
              <h2 id="bar" class="section-heading">
-               <a href="#bar">
+               <a href="#bar" class="hover-link">
                  <i class="ri-link-m" aria-hidden="true"></i>
-                 Bar
-               </a>
+               </a>Bar
              </h2>
              """
 
       assert Templates.link_headings("<h2></h2><h2>Bar</h2>") == """
              <h2></h2><h2 id="bar" class="section-heading">
-               <a href="#bar">
+               <a href="#bar" class="hover-link">
                  <i class="ri-link-m" aria-hidden="true"></i>
-                 Bar
-               </a>
+               </a>Bar
              </h2>
              """
 
       assert Templates.link_headings("<h2></h2>\n<h2>Bar</h2>") == """
              <h2></h2>
              <h2 id="bar" class="section-heading">
-               <a href="#bar">
+               <a href="#bar" class="hover-link">
                  <i class="ri-link-m" aria-hidden="true"></i>
-                 Bar
-               </a>
+               </a>Bar
              </h2>
              """
 
       assert Templates.link_headings("<h2>Foo</h2><h2></h2>") ==
                String.trim_trailing("""
                <h2 id="foo" class="section-heading">
-                 <a href="#foo">
+                 <a href="#foo" class="hover-link">
                    <i class="ri-link-m" aria-hidden="true"></i>
-                   Foo
-                 </a>
+                 </a>Foo
                </h2>
                <h2></h2>
                """)
@@ -109,10 +102,9 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       assert Templates.link_headings("<h2>Foo</h2>\n<h2></h2>") ==
                String.trim_trailing("""
                <h2 id="foo" class="section-heading">
-                 <a href="#foo">
+                 <a href="#foo" class="hover-link">
                    <i class="ri-link-m" aria-hidden="true"></i>
-                   Foo
-                 </a>
+                 </a>Foo
                </h2>
 
                <h2></h2>
@@ -120,10 +112,9 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
 
       assert Templates.link_headings("<h3>Foo</h3>") == """
              <h3 id="foo" class="section-heading">
-               <a href="#foo">
+               <a href="#foo" class="hover-link">
                  <i class="ri-link-m" aria-hidden="true"></i>
-                 Foo
-               </a>
+               </a>Foo
              </h3>
              """
     end
@@ -131,17 +122,15 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
     test "generates headers with unique id's" do
       assert Templates.link_headings("<h3>Foo</h3>\n<h3>Foo</h3>") == """
              <h3 id="foo" class="section-heading">
-               <a href="#foo">
+               <a href="#foo" class="hover-link">
                  <i class="ri-link-m" aria-hidden="true"></i>
-                 Foo
-               </a>
+               </a>Foo
              </h3>
 
              <h3 id="foo-1" class="section-heading">
-               <a href="#foo-1">
+               <a href="#foo-1" class="hover-link">
                  <i class="ri-link-m" aria-hidden="true"></i>
-                 Foo
-               </a>
+               </a>Foo
              </h3>
              """
     end
@@ -153,10 +142,9 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
 
       assert Templates.link_headings(admonition_block) == """
              <blockquote><h3 id="foo" class="warning section-heading">
-               <a href="#foo">
+               <a href="#foo" class="hover-link">
                  <i class="ri-link-m" aria-hidden="true"></i>
-                 Foo
-               </a>
+               </a>Foo
              </h3>
              </blockquote>
              """
@@ -471,10 +459,10 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
                ~r{moduledoc.*Example.*<span class="nc">CompiledWithDocs</span><span class="o">\.</span><span class="n">example</span>.*}ms
 
       assert content =~
-               ~r{<h2 id="module-example-unicode-escaping" class="section-heading">.*<a href="#module-example-unicode-escaping">.*<i class="ri-link-m" aria-hidden="true"></i>.*Example.*</a>.*</h2>}ms
+               ~r{<h2 id="module-example-unicode-escaping" class="section-heading">.*<a href="#module-example-unicode-escaping" class="hover-link">.*<i class="ri-link-m" aria-hidden="true"></i>.*</a>.*Example.*</h2>}ms
 
       assert content =~
-               ~r{<h3 id="module-example-h3-heading" class="section-heading">.*<a href="#module-example-h3-heading">.*<i class="ri-link-m" aria-hidden="true"></i>.*Example H3 heading.*</a>.*</h3>}ms
+               ~r{<h3 id="module-example-h3-heading" class="section-heading">.*<a href="#module-example-h3-heading" class="hover-link">.*<i class="ri-link-m" aria-hidden="true"></i>.*</a>.*Example H3 heading.*</h3>}ms
 
       # Summaries
       assert content =~ ~r{example/2.*Some example}ms
@@ -567,7 +555,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
       content = get_module_page([CompiledWithDocs], context)
 
       assert content =~
-               ~r{<h3 id="example_with_h3/0-examples" class="section-heading">.*<a href="#example_with_h3/0-examples">.*<i class="ri-link-m" aria-hidden="true"></i>.*Examples.*</a>.*</h3>}ms
+               ~r{<h3 id="example_with_h3/0-examples" class="section-heading">.*<a href="#example_with_h3/0-examples" class="hover-link">.*<i class="ri-link-m" aria-hidden="true"></i>.*</a>.*Examples.*</h3>}ms
     end
 
     test "do not output overlapping functions, causing duplicate IDs", context do

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -365,10 +365,10 @@ defmodule ExDoc.Formatter.HTMLTest do
       assert content =~ ~r{<title>README [^<]*</title>}
 
       assert content =~
-               ~r{<h2 id="header-sample" class="section-heading">.*<a href="#header-sample">.*<i class="ri-link-m" aria-hidden="true"></i>.*<code(\sclass="inline")?>Header</code> sample.*</a>.*</h2>}ms
+               ~r{<h2 id="header-sample" class="section-heading">.*<a href="#header-sample" class="hover-link">.*<i class="ri-link-m" aria-hidden="true"></i>.*</a>.*<code(\sclass="inline")?>Header</code> sample.*</h2>}ms
 
       assert content =~
-               ~r{<h2 id="more-than" class="section-heading">.*<a href="#more-than">.*<i class="ri-link-m" aria-hidden="true"></i>.*more &gt; than.*</a>.*</h2>}ms
+               ~r{<h2 id="more-than" class="section-heading">.*<a href="#more-than" class="hover-link">.*<i class="ri-link-m" aria-hidden="true"></i>.*</a>.*more &gt; than.*</h2>}ms
 
       assert content =~ ~r{<a href="RandomError.html"><code(\sclass="inline")?>RandomError</code>}
 


### PR DESCRIPTION
Fixes https://github.com/elixir-lang/ex_doc/commit/28bb43e4bb2c20c7111524be34ed9100e1bfefab#r125061077

Also makes the link underline color the same as the text (usinig `currentColor`, which is black or white) for admonition headings.