### PR TITLE
Add Devbox environment config

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,16 @@
+{
+  "packages": [
+    "nodejs@18.16.1",
+    "elixir_1_15@latest",
+    "google-chrome@latest"
+  ],
+  "shell": {
+    "init_hook": [
+      "export ERL_AFLAGS='-kernel shell_history enabled'",
+      "mix setup"
+    ]
+  },
+  "nixpkgs": {
+    "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
+  }
+}

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,20 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "elixir_1_15@latest": {
+      "last_modified": "2023-07-23T03:35:12Z",
+      "resolved": "github:NixOS/nixpkgs/af8cd5ded7735ca1df1a1174864daab75feeb64a#elixir_1_15",
+      "version": "1.15.4"
+    },
+    "google-chrome@latest": {
+      "last_modified": "2023-08-08T03:07:33Z",
+      "resolved": "github:NixOS/nixpkgs/844ffa82bbe2a2779c86ab3a72ff1b4176cec467#google-chrome",
+      "version": "115.0.5790.170"
+    },
+    "nodejs@18.16.1": {
+      "last_modified": "2023-06-29T16:20:38Z",
+      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#nodejs_18",
+      "version": "18.16.1"
+    }
+  }
+}


### PR DESCRIPTION
[Devbox](https://www.jetpack.io/devbox/) uses [Nix](https://nixos.org/guides/how-nix-works), a purely functional package manager, and provides a simple way to take advantage of that without requiring learning of the Nix language.

I'm suggesting adding its two `devbox.(json|lock)` files for optional usage because:

- I use it and the config being present in the main branch would mean I don't have to switch branches and subsequently cherry-pick to contribute :smiley: 
- it provides a simple, declarative way of specifying and using versions (Elixir, Node, and Chrome for the JS tests) across MacOS, Linux and Windows without having to otherwise install them or deal with images.

[Installation](https://www.jetpack.io/devbox/docs/installing_devbox/) is a curl command. Then, to use in a project with the devbox files:

```plain
$ devbox shell
```

The specified versions of Elixir, Node and Chrome are installed/activated, and the mix setup command is called so that Elixir and Node dependencies are also installed if they're not already present.

Versions currently specified:

- Elixir 1.15.4
- Node 18.16.1
- Chrome 115.0.5790.170 (latest available for Nix)
