### PR TITLE
Screen reader accessibility

### DIFF
--- a/assets/css/copy-button.css
+++ b/assets/css/copy-button.css
@@ -37,12 +37,8 @@ pre .copy-button:hover svg, pre .copy-button:focus-visible svg {
 }
 
 .copy-button.clicked {
-  display: block;
   opacity: 1;
   color: var(--success);
-}
-.copy-button.clicked::after {
-  content: "Copied! \2713";
 }
 
 .copy-button.clicked svg {

--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -94,11 +94,10 @@
   color: initial;
 }
 
-.sidebar .sidebar-projectVersion form::after {
+.sidebar .sidebar-projectVersionsDropdownCaret {
   position: absolute;
   left: 0;
   top: 2px;
-  content: "\25bc";
   z-index: 1;
   font-size: 8px;
   color: var(--sidebarMuted);

--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -113,7 +113,7 @@
   margin: 0;
 }
 
-.sidebar .sidebar-listNav :is(li, li a) {
+.sidebar .sidebar-listNav :is(li, li button) {
   text-transform: uppercase;
   font-size: 14px;
   color: var(--sidebarMuted);
@@ -124,18 +124,26 @@
   padding: 0;
 }
 
-.sidebar .sidebar-listNav li a {
+.sidebar .sidebar-listNav li button {
+  background: none;
+  border: 0;
+  border-radius: 0;
+  -webkit-appearance: none;
+  text-align: inherit;
+  color: inherit;
+  font-weight: inherit;
+  cursor: pointer;
   display: inline-block;
   line-height: 27px;
   border-bottom: 3px solid transparent;
   padding: 0 10px;
 }
 
-.sidebar .sidebar-listNav li:is(:hover, .selected) a {
+.sidebar .sidebar-listNav li:is(:hover, .selected) button {
   border-color: var(--sidebarLanguageAccentBar);
 }
 
-.sidebar .sidebar-listNav li:is(:hover, .selected) a {
+.sidebar .sidebar-listNav li:is(:hover, .selected) button {
   color: var(--sidebarAccentMain);
 }
 
@@ -210,7 +218,7 @@
   font-weight: bold;
 }
 
-.sidebar #full-list {
+.sidebar .full-list {
   margin: 0;
   padding: 20px 0;
   overflow-y: auto;
@@ -220,28 +228,28 @@
   flex: 1 1 .01%;
 }
 
-.sidebar #full-list :is(li, a) {
+.sidebar .full-list :is(li, a) {
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.sidebar #full-list li {
+.sidebar .full-list li {
   padding: 0;
   margin-right: 30px;
   line-height: 27px;
   white-space: nowrap;
 }
 
-.sidebar #full-list li.docs {
+.sidebar .full-list li.docs {
   margin-right: 0;
 }
 
-.sidebar #full-list li.open > ul {
+.sidebar .full-list li.open > ul {
   display: block;
   margin-left: 10px;
 }
 
-.sidebar #full-list li a.expand + button.icon-expand {
+.sidebar .full-list li a.expand + button.icon-expand {
   appearance: none;
   background-color: transparent;
   border: 0;
@@ -257,37 +265,37 @@
   transform: translateY(calc(-100% - 4px));
 }
 
-.sidebar #full-list li a + button.icon-expand:after {
+.sidebar .full-list li a + button.icon-expand:after {
   font-family: remixicon;
   font-style: normal;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-.sidebar #full-list li a.expand + button.icon-expand:after {
+.sidebar .full-list li a.expand + button.icon-expand:after {
   content: var(--icon-arrow-down-s);
 }
 
-.sidebar #full-list li.open > a.expand + button.icon-expand:after {
+.sidebar .full-list li.open > a.expand + button.icon-expand:after {
   content: var(--icon-arrow-up-s);
 }
 
-.sidebar #full-list li.docs > a + button.icon-expand {
+.sidebar .full-list li.docs > a + button.icon-expand {
   margin-right: 12px;
   font-size: var(--sidebarFontSize);
   line-height: var(--sidebarFontSize);
   transform: translateY(calc(-100% - 5px));
 }
 
-.sidebar #full-list li.docs > a + button.icon-expand:after {
+.sidebar .full-list li.docs > a + button.icon-expand:after {
   content: var(--icon-add);
 }
 
-.sidebar #full-list li.docs.open > a + button.icon-expand:after {
+.sidebar .full-list li.docs.open > a + button.icon-expand:after {
   content: var(--icon-subtract);
 }
 
-.sidebar #full-list li.nesting-context {
+.sidebar .full-list li.nesting-context {
   font-weight: bold;
   font-size: .9em;
   line-height: 1.8em;
@@ -295,7 +303,7 @@
   padding-left: 15px;
 }
 
-.sidebar #full-list li.group {
+.sidebar .full-list li.group {
   text-transform: uppercase;
   font-weight: bold;
   font-size: .8em;
@@ -305,58 +313,58 @@
   padding-left: 15px;
 }
 
-.sidebar #full-list li a {
+.sidebar .full-list li a {
   padding: 3px 0 3px 15px;
   color: var(--sidebarItem);
 }
 
-.sidebar #full-list > li > a {
+.sidebar .full-list > li > a {
   display: block;
   width: 100%;
   height: 27px;
   line-height: var(--sidebarLineHeight);
 }
 
-.sidebar #full-list li .current-section > a {
+.sidebar .full-list li .current-section > a {
   color: var(--sidebarActiveItem);
 }
 
-.sidebar #full-list li .current-section > a + button.icon-expand {
+.sidebar .full-list li .current-section > a + button.icon-expand {
   color: var(--sidebarActiveItem);
 }
 
-.sidebar #full-list > li > a:hover {
+.sidebar .full-list > li > a:hover {
   border-left: 3px solid var(--sidebarLanguageAccentBar);
   padding-left: 12px;
 }
 
-.sidebar #full-list > li.current-page > a {
+.sidebar .full-list > li.current-page > a {
   color: var(--sidebarActiveItem);
   border-left: 3px solid var(--sidebarLanguageAccentBar);
   padding-left: 12px;
 }
 
-.sidebar #full-list > li.current-page > a:after,
-.sidebar #full-list > li.current-page {
+.sidebar .full-list > li.current-page > a:after,
+.sidebar .full-list > li.current-page {
   color: var(--sidebarActiveItem);
 }
 
-.sidebar #full-list > li:last-child {
+.sidebar .full-list > li:last-child {
   margin-bottom: 30px;
 }
 
-.sidebar #full-list > li.group:first-child {
+.sidebar .full-list > li.group:first-child {
   margin-top: 0;
 }
 
-.sidebar #full-list ul {
+.sidebar .full-list ul {
   display: none;
   margin: 10px 15px;
   margin-right: 0;
   padding: 0;
 }
 
-.sidebar #full-list ul li {
+.sidebar .full-list ul li {
   font-weight: 300;
   line-height: var(--sidebarFontSize);
   padding: 0 8px;
@@ -364,65 +372,65 @@
   color: var(--sidebarAccentMain);
 }
 
-.non-apple-os .sidebar #full-list ul li {
+.non-apple-os .sidebar .full-list ul li {
   font-weight: 400; /* Non-Apple OSes render small light type too thinly */
 }
 
-.sidebar #full-list ul li.current-hash {
+.sidebar .full-list ul li.current-hash {
   color: var(--sidebarActiveItem);
 }
 
-.sidebar #full-list ul li.current-hash > a {
+.sidebar .full-list ul li.current-hash > a {
   color: var(--sidebarActiveItem);
 }
 
-.sidebar #full-list ul li.current-hash > a:before,
-.sidebar #full-list > li > ul > li > a:hover:before {
+.sidebar .full-list ul li.current-hash > a:before,
+.sidebar .full-list > li > ul > li > a:hover:before {
   content: "\2022";
   position: absolute;
   margin-left: -15px;
   color: var(--sidebarActiveItem);
 }
 
-.sidebar #full-list ul li a {
+.sidebar .full-list ul li a {
   padding-left: 15px;
   display: block;
   width: 100%;
   height: 24px;
 }
 
-.sidebar #full-list ul li ul {
+.sidebar .full-list ul li ul {
   display: none;
   margin: 9px 20px;
   margin-right: 0;
 }
 
-.sidebar #full-list ul li ul li {
+.sidebar .full-list ul li ul li {
   margin-right: 0;
   height: 20px;
   color: var(--sidebarAccentMain);
 }
 
-.sidebar #full-list ul li ul li a {
+.sidebar .full-list ul li ul li a {
   border-left: 1px solid var(--sidebarInactiveItemMarker);
   padding: 0 10px;
   height: 20px;
 }
 
-.sidebar #full-list ul li ul li.current-hash > a:before {
+.sidebar .full-list ul li ul li.current-hash > a:before {
   content: none;
 }
 
-.sidebar #full-list ul li ul li > a:hover {
+.sidebar .full-list ul li ul li > a:hover {
   border-color: var(--sidebarLanguageAccentBar);
 }
 
-.sidebar #full-list ul li ul li.current-hash > a {
+.sidebar .full-list ul li ul li.current-hash > a {
   color: var(--sidebarActiveItem);
   border-color: var(--sidebarLanguageAccentBar);
 }
 
-.sidebar #full-list ul li ul li.current-hash > a {
+.sidebar .full-list ul li ul li.current-hash > a {
   color: var(--sidebarActiveItem);
   margin-left: 0;
 }
@@ -465,7 +473,7 @@
     overflow-y: auto;
   }
 
-  .sidebar #full-list {
+  .sidebar .full-list {
     overflow: visible;
   }
 }

--- a/assets/js/copy-button.js
+++ b/assets/js/copy-button.js
@@ -1,6 +1,6 @@
 import { qsAll } from './helpers'
 
-const BUTTON = '<button class="copy-button" aria-label="copy"><svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="currentColor"><path d="M0 0h24v24H0z" fill="none"/><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg></button>'
+const BUTTON = '<button class="copy-button"><svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="currentColor"><path d="M0 0h24v24H0z" fill="none"/><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg><span class="sr-only">copy</span><span aria-live="polite"></span></button>'
 
 /**
  * Initializes copy buttons.
@@ -22,6 +22,7 @@ function addCopyButtons () {
   Array.from(qsAll('.copy-button')).forEach(button => {
     let timeout
     button.addEventListener('click', () => {
+      const ariaLiveContent = button.querySelector('[aria-live]')
       timeout && clearTimeout(timeout)
 
       const text =
@@ -32,7 +33,11 @@ function addCopyButtons () {
 
       navigator.clipboard.writeText(text)
       button.classList.add('clicked')
-      timeout = setTimeout(() => button.classList.remove('clicked'), 3000)
+      ariaLiveContent.innerHTML = 'Copied! &#x2713;'
+      timeout = setTimeout(() => {
+        button.classList.remove('clicked')
+        ariaLiveContent.innerHTML = ''
+      }, 3000)
     })
   })
 }

--- a/assets/js/handlebars/templates/modal-layout.handlebars
+++ b/assets/js/handlebars/templates/modal-layout.handlebars
@@ -2,7 +2,7 @@
   <div class="modal-contents">
     <div class="modal-header">
       <div class="modal-title"></div>
-      <button class="modal-close">×</button>
+      <button class="modal-close" aria-label="close">×</button>
     </div>
     <div class="modal-body">
     </div>

--- a/assets/js/handlebars/templates/sidebar-items.handlebars
+++ b/assets/js/handlebars/templates/sidebar-items.handlebars
@@ -10,7 +10,7 @@
   {{/nestingChanged}}
 
   <li class="{{#isLocal node.id}}current-page open{{/isLocal}}">
-    <a href="{{node.id}}.html{{#isLocal node.id}}#content{{/isLocal}}" class="expand" {{#isArray node.headers}}{{else}}translate="no"{{/isArray}}>
+    <a href="{{node.id}}.html{{#isLocal node.id}}#content{{/isLocal}}" class="expand" aria-current="{{#isLocal node.id}}page{{else}}false{{/isLocal}}" {{#isArray node.headers}}{{else}}translate="no"{{/isArray}}>
       {{#if node.nested_title}}
         {{{node.nested_title}}}
       {{else}}

--- a/assets/js/handlebars/templates/sidebar-items.handlebars
+++ b/assets/js/handlebars/templates/sidebar-items.handlebars
@@ -20,12 +20,12 @@
 
     {{#isEmptyArray node.headers}}
     {{else}}
-      <button class="icon-expand" aria-label="expand"></button>
+      <button class="icon-expand" aria-label="expand" aria-expanded="{{#isLocal node.id}}true{{else}}false{{/isLocal}}" aria-controls="node-{{node.id}}-headers"></button>
     {{/isEmptyArray}}
 
     {{#isArray node.headers}}
       {{#isNonEmptyArray node.headers}}
-        <ul>
+        <ul id="node-{{node.id}}-headers">
           {{#each node.headers}}
             <li>
               <a href="{{node.id}}.html#{{{anchor}}}">{{{id}}}</a>
@@ -34,14 +34,14 @@
         </ul>
       {{/isNonEmptyArray}}
     {{else}}
-      <ul>
+      <ul id="node-{{node.id}}-headers">
         {{#showSections node}}
           <li class="docs {{#isLocal node.id}}open{{/isLocal}}">
             <a href="{{node.id}}.html#content" class="expand">
               Sections
             </a>
-            <button class="icon-expand" aria-label="expand"></button>
-            <ul class="sections-list deflist">
+            <button class="icon-expand" aria-label="expand" aria-expanded="{{#isLocal node.id}}true{{else}}false{{/isLocal}}" aria-controls="{{node.id}}-sections-list"></button>
+            <ul id="{{node.id}}-sections-list" class="sections-list deflist">
               {{#each sections}}
                 <li>
                   <a href="{{node.id}}.html#{{anchor}}">{{{id}}}</a>
@@ -60,8 +60,8 @@
             <a href="{{node.id}}.html#{{group.key}}" class="expand">
               {{group.name}}
             </a>
-            <button class="icon-expand" aria-label="expand"></button>
-            <ul class="{{group.key}}-list deflist">
+            <button class="icon-expand" aria-label="expand" aria-expanded="false" aria-controls="node-{{node.id}}-group-{{group.key}}-list"></button>
+            <ul id="node-{{node.id}}-group-{{group.key}}-list" class="{{group.key}}-list deflist">
               {{#each group.nodes}}
                 <li>
                   <a href="{{node.id}}.html#{{anchor}}" title="{{title}}" translate="no">{{id}}</a>

--- a/assets/js/handlebars/templates/versions-dropdown.handlebars
+++ b/assets/js/handlebars/templates/versions-dropdown.handlebars
@@ -1,9 +1,13 @@
 <form autocomplete="off">
-  <select class="sidebar-projectVersionsDropdown">
-    {{#each nodes}}
-      <option translate="no" value="{{url}}"{{#if isCurrentVersion}} selected disabled{{/if}}>
-        {{version}}
-      </option>
-    {{/each}}
-  </select>
+  <label>
+    <span class="sidebar-projectVersionsDropdownCaret" aria-hidden="true">&#x25bc;</span>
+    <span class="sr-only">Project version</span>
+    <select class="sidebar-projectVersionsDropdown">
+      {{#each nodes}}
+        <option translate="no" value="{{url}}"{{#if isCurrentVersion}} selected disabled{{/if}}>
+          {{version}}
+        </option>
+      {{/each}}
+    </select>
+  </label>
 </form>

--- a/assets/js/sidebar/sidebar-drawer.js
+++ b/assets/js/sidebar/sidebar-drawer.js
@@ -45,10 +45,13 @@ function setDefaultSidebarState () {
   // check & set persistent session state
   const persistentSessionState = sessionStorage.getItem('sidebar_state')
   // set default for closed state only, so sidebar will still auto close on window resize
-  if (persistentSessionState === 'closed') return setClass(SIDEBAR_CLASS.closed)
-
-  // else
-  setClass(isScreenSmall() ? SIDEBAR_CLASS.closed : SIDEBAR_CLASS.opened)
+  if (persistentSessionState === 'closed' || isScreenSmall()) {
+    setClass(SIDEBAR_CLASS.closed)
+    qs(SIDEBAR_TOGGLE_SELECTOR).setAttribute('aria-expanded', 'false')
+  } else {
+    setClass(SIDEBAR_CLASS.opened)
+    qs(SIDEBAR_TOGGLE_SELECTOR).setAttribute('aria-expanded', 'true')
+  }
 }
 
 function isScreenSmall () {
@@ -106,6 +109,7 @@ function isSidebarOpen () {
 export function openSidebar () {
   clearTimeoutIfAny()
   sessionStorage.setItem('sidebar_state', 'opened')
+  qs(SIDEBAR_TOGGLE_SELECTOR).setAttribute('aria-expanded', 'true')
 
   requestAnimationFrame(() => {
     setClass(SIDEBAR_CLASS.openingStart)
@@ -131,6 +135,7 @@ export function openSidebar () {
 export function closeSidebar () {
   clearTimeoutIfAny()
   sessionStorage.setItem('sidebar_state', 'closed')
+  qs(SIDEBAR_TOGGLE_SELECTOR).setAttribute('aria-expanded', 'false')
 
   requestAnimationFrame(() => {
     setClass(SIDEBAR_CLASS.closingStart)

--- a/assets/js/sidebar/sidebar-list.js
+++ b/assets/js/sidebar/sidebar-list.js
@@ -40,6 +40,7 @@ function renderSidebarNodeList (nodesByType, type) {
 
   // Render the list
   const nodeList = qs(sidebarNodeListSelector(type))
+  if (!nodeList) { return }
   const listContentHtml = Handlebars.templates['sidebar-items']({ nodes, group: '' })
   nodeList.innerHTML = listContentHtml
 

--- a/assets/js/sidebar/sidebar-list.js
+++ b/assets/js/sidebar/sidebar-list.js
@@ -71,7 +71,7 @@ function renderSidebarNodeList (nodesByType, type) {
 
       // Clear the previous current section
       if (previousSection) {
-        previousSection.classList.remove('current-section')
+        clearCurrentSectionElement(previousSection)
       }
 
       if (anchor.matches('.expand') && anchor.pathname === window.location.pathname) {
@@ -97,6 +97,26 @@ function toggleListItem (listItem) {
   } else {
     openListItem(listItem)
   }
+}
+
+function markElementAsCurrentSection (section) {
+  section.classList.add('current-section')
+  section.querySelector('a').setAttribute('aria-current', 'true')
+}
+
+function clearCurrentSectionElement (section) {
+  section.classList.remove('current-section')
+  section.querySelector('a').setAttribute('aria-current', 'false')
+}
+
+function markElementAsCurrentHash (listItem) {
+  listItem.classList.add('current-hash')
+  listItem.querySelector('a').setAttribute('aria-current', 'true')
+}
+
+function clearCurrentHashElement (listItem) {
+  listItem.classList.remove('current-hash')
+  listItem.querySelector('a').setAttribute('aria-current', 'false')
 }
 
 function highlightNavigationLink (activeType) {
@@ -134,9 +154,9 @@ function markCurrentHashInSidebar () {
   if (hashEl) {
     const deflist = hashEl.closest('ul')
     if (deflist.classList.contains('deflist')) {
-      deflist.closest('li').classList.add('current-section')
+      markElementAsCurrentSection(deflist.closest('li'))
     }
-    hashEl.closest('li').classList.add('current-hash')
+    markElementAsCurrentHash(hashEl.closest('li'))
   }
 }
 
@@ -159,7 +179,7 @@ function addEventListeners () {
     const nodeList = qs(SIDEBAR_NODE_LIST_SELECTOR)
     const currentListItem = nodeList.querySelector('li.current-page li.current-hash')
     if (currentListItem) {
-      currentListItem.classList.remove('current-hash')
+      clearCurrentHashElement(currentListItem)
     }
 
     markCurrentHashInSidebar()

--- a/assets/js/sidebar/sidebar-list.js
+++ b/assets/js/sidebar/sidebar-list.js
@@ -59,7 +59,7 @@ function renderSidebarNodeList (nodesByType, type) {
     button.addEventListener('click', event => {
       const target = event.target
       const listItem = target.closest('li')
-      listItem.classList.toggle('open')
+      toggleListItem(listItem)
     })
   })
 
@@ -75,10 +75,28 @@ function renderSidebarNodeList (nodesByType, type) {
       }
 
       if (anchor.matches('.expand') && anchor.pathname === window.location.pathname) {
-        listItem.classList.add('open')
+        openListItem(listItem)
       }
     })
   })
+}
+
+function openListItem (listItem) {
+  listItem.classList.add('open')
+  listItem.querySelector('button[aria-controls]').setAttribute('aria-expanded', 'true')
+}
+
+function closeListItem (listItem) {
+  listItem.classList.remove('open')
+  listItem.querySelector('button[aria-controls]').setAttribute('aria-expanded', 'false')
+}
+
+function toggleListItem (listItem) {
+  if (listItem.classList.contains('open')) {
+    closeListItem(listItem)
+  } else {
+    openListItem(listItem)
+  }
 }
 
 function highlightNavigationLink (activeType) {
@@ -109,7 +127,7 @@ function markCurrentHashInSidebar () {
 
   const categoryEl = nodeList.querySelector(`li.current-page a.expand[href$="#${category}"]`)
   if (categoryEl) {
-    categoryEl.closest('li').classList.add('open')
+    openListItem(categoryEl.closest('li'))
   }
 
   const hashEl = nodeList.querySelector(`li.current-page a[href$="#${hash}"]`)

--- a/lib/ex_doc/formatter/html/templates/footer_template.eex
+++ b/lib/ex_doc/formatter/html/templates/footer_template.eex
@@ -37,7 +37,7 @@
       </footer>
     </div>
   </div>
-</section>
+</main>
 </div>
   <%# Extra content specified by the user (e.g. custom Javascript) %>
   <%= before_closing_body_tag(config, :html) %>

--- a/lib/ex_doc/formatter/html/templates/sidebar_template.eex
+++ b/lib/ex_doc/formatter/html/templates/sidebar_template.eex
@@ -6,16 +6,16 @@
 
 <nav id="sidebar" class="sidebar">
   <form class="sidebar-search" action="search.html">
+    <label class="search-label">
+      <span class="sr-only">Search documentation of <%= config.project %></span>
+      <input name="q" type="text" class="search-input" placeholder="Search..." autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
+    </label>
     <button type="submit" class="search-button" aria-label="Submit Search">
       <i class="ri-search-2-line" aria-hidden="true" title="Submit search"></i>
     </button>
-    <button type="button" tabindex="-1" class="search-close-button" aria-label="Cancel Search">
-      <i class="ri-close-line ri-lg" aria-hidden="true" title="Cancel search"></i>
+    <button type="button" tabindex="-1" class="search-close-button" aria-hidden="true">
+      <i class="ri-close-line ri-lg" title="Cancel search"></i>
     </button>
-    <label class="search-label">
-      <p class="sr-only">Search</p>
-      <input name="q" type="text" class="search-input" placeholder="Search..." aria-label="Input your search terms" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
-    </label>
   </form>
 
   <div class="autocomplete">

--- a/lib/ex_doc/formatter/html/templates/sidebar_template.eex
+++ b/lib/ex_doc/formatter/html/templates/sidebar_template.eex
@@ -4,7 +4,7 @@
   <i class="ri-menu-line ri-lg" title="Collapse/expand sidebar"></i>
 </button>
 
-<section class="sidebar">
+<nav class="sidebar">
   <form class="sidebar-search" action="search.html">
     <button type="submit" class="search-button" aria-label="Submit Search">
       <i class="ri-search-2-line" aria-hidden="true" title="Submit search"></i>
@@ -52,9 +52,9 @@
   </div>
 
   <ul id="full-list"></ul>
-</section>
+</nav>
 
-<section class="content">
+<main class="content">
   <output role="status" id="toast"></output>
   <div class="content-outer">
     <div id="content" class="content-inner">

--- a/lib/ex_doc/formatter/html/templates/sidebar_template.eex
+++ b/lib/ex_doc/formatter/html/templates/sidebar_template.eex
@@ -38,20 +38,41 @@
         v<%= config.version %>
       </div>
     </div>
-    <ul class="sidebar-listNav">
-      <li><a id="extras-list-link" href="#full-list"><%= config.extra_section || "Pages" %></a></li>
+    <ul id="sidebar-listNav" class="sidebar-listNav" role="tablist">
+      <li>
+        <button id="extras-list-tab-button" role="tab" data-type="extras" aria-controls="extras-full-list" aria-selected="true" tabindex="0">
+          <%= config.extra_section || "Pages" %>
+        </button>
+      </li>
 
       <%= if nodes_map.modules != [] do %>
-        <li><a id="modules-list-link" href="#full-list">Modules</a></li>
+        <li>
+          <button id="modules-list-tab-button" role="tab" data-type="modules" aria-controls="modules-full-list" aria-selected="false" tabindex="-1">
+            Modules
+          </button>
+        </li>
       <% end %>
 
       <%= if nodes_map.tasks != [] do %>
-        <li><a id="tasks-list-link" href="#full-list"><span translate="no">Mix</span> Tasks</a></li>
+        <li>
+          <button id="tasks-list-tab-button" role="tab" data-type="tasks" aria-controls="tasks-full-list" aria-selected="false" tabindex="-1">
+            <span translate="no">Mix</span> Tasks
+          </button>
+        </li>
       <% end %>
     </ul>
   </div>
 
-  <ul id="full-list"></ul>
+  <ul id="extras-full-list" class="full-list" role="tabpanel" aria-labelledby="extras-list-tab-button"></ul>
+
+  <%= if nodes_map.modules != [] do %>
+    <ul id="modules-full-list" class="full-list" role="tabpanel" aria-labelledby="modules-list-tab-button" hidden></ul>
+  <% end %>
+
+  <%= if nodes_map.tasks != [] do %>
+    <ul id="tasks-full-list" class="full-list" role="tabpanel" aria-labelledby="tasks-list-tab-button" hidden></ul>
+  <% end %>
+
 </nav>
 
 <main class="content">

--- a/lib/ex_doc/formatter/html/templates/sidebar_template.eex
+++ b/lib/ex_doc/formatter/html/templates/sidebar_template.eex
@@ -1,10 +1,10 @@
 <div class="main">
 
-<button class="sidebar-button sidebar-toggle" aria-label="toggle sidebar">
+<button class="sidebar-button sidebar-toggle" aria-label="toggle sidebar" aria-controls="sidebar">
   <i class="ri-menu-line ri-lg" title="Collapse/expand sidebar"></i>
 </button>
 
-<nav class="sidebar">
+<nav id="sidebar" class="sidebar">
   <form class="sidebar-search" action="search.html">
     <button type="submit" class="search-button" aria-label="Submit Search">
       <i class="ri-search-2-line" aria-hidden="true" title="Submit search"></i>

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -242,9 +242,16 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
           tasks: []
         })
 
-      assert content =~ ~r{<li><a id="modules-list-link" href="#full-list">Modules</a></li>}
-      refute content =~ ~r{<li><a id="exceptions-list" href="#full-list">Exceptions</a></li>}
-      refute content =~ ~r{<li><a id="tasks-list-link" href="#full-list">Mix Tasks</a></li>}
+      assert content =~
+               ~r{<li>[\s\n]*<button id="modules-list-tab-button" role="tab" data-type="modules" aria-controls="modules-full-list" aria-selected="false" tabindex="-1">[\s\n]*Modules[\s\n]*</button>[\s\n]*</li>}
+
+      assert content =~
+               ~r{<ul id="modules-full-list" class="full-list" role="tabpanel" aria-labelledby="modules-list-tab-button" hidden></ul>}
+
+      refute content =~ ~r{id="exceptions-list-tab-button">}
+      refute content =~ ~r{id="exceptions-full-list">}
+      refute content =~ ~r{id="tasks-list-tab-button"}
+      refute content =~ ~r{id="tasks-full-list"}
     end
 
     test "display built with footer by proglang option", context do


### PR DESCRIPTION
Resolves #1756

Task list:

- Missing landmark elements: `<nav>`, `<main>` ✅  https://github.com/elixir-lang/ex_doc/pull/1760/commits/c9d58cebf349a372f7cf9982b8c5f757ef391518
- Expand menu button is missing `aria-controls` and `aria-expanded` properties  ✅ https://github.com/elixir-lang/ex_doc/pull/1760/commits/132ccb2b7563c365ae67224ffafe1830e9d448b0
- Search input: `<p>` is not a valid child of `<label>`  ✅ https://github.com/elixir-lang/ex_doc/pull/1760/commits/17adec572f5d5d35206f8ee2bfd403991fe0e0f4
- Version select:
	- Lacks a label.  ✅ https://github.com/elixir-lang/ex_doc/pull/1760/commits/86194b2d47f9c8d9c90922db7b62674a97885c45
	- Decorative character "\25bc" in version select is being read as "down pointing black pointer".  ✅ https://github.com/elixir-lang/ex_doc/pull/1760/commits/86194b2d47f9c8d9c90922db7b62674a97885c45
- Expand buttons in navigation links are missing `aria-controls` and `aria-expanded` properties. ✅ https://github.com/elixir-lang/ex_doc/pull/1760/commits/b65fe77252b61cbeb561064535d5bb6d686701e1
- Consider using aria-current for links visually styled as "active". ✅  https://github.com/elixir-lang/ex_doc/pull/1760/commits/56c0cf1bd93fa737cb4409fde25ff7ef132dff18
- "Pages / modules / mix tasks" lack feedback after clicking, rewrite using buttons and role=tablist, use aria-selected ✅ https://github.com/elixir-lang/ex_doc/pull/1760/commits/c868c2a8274cf7f0bee244677d964115bf723337
- Settings modal:
	- Close button lacks a label, being read as "times button". ✅ https://github.com/elixir-lang/ex_doc/pull/1760/commits/e4e895324af0d9a1471d83d278d34a661810fd56
	- Theme select lacks a label. ✅ I was mistaken here, it has a label already
- Copy button for code snippets:
	- Lacks aural feedback after successful copying, consider `aria-live` on the "copied!" text. ✅  https://github.com/elixir-lang/ex_doc/pull/1760/commits/7be1ee0701c0af6fb2e1bf0dd9f4349fc9d174e6
- Search HexDocs modal: close button lacks a label, being read as "times button". ✅ https://github.com/elixir-lang/ex_doc/pull/1760/commits/e4e895324af0d9a1471d83d278d34a661810fd56
- Consider a "skip to main content" button to quickly bypass the navigation entirely. ✅ After a second thought, I decided it's not necessary since the first element on the page is a button that closes the whole sidebar, which allows you to navigate to main content fast

