### PR TITLE
improvement: add `type` field to the docs for reference in search

### DIFF
--- a/assets/js/handlebars/templates/search-results.handlebars
+++ b/assets/js/handlebars/templates/search-results.handlebars
@@ -40,7 +40,7 @@
     <li>Use <code>*</code> anywhere (such as <code>fo*</code>) as wildcard</li>
     <li>Use <code>+</code> before a word (such as <code>+foo</code>) to make its presence required</li>
     <li>Use <code>-</code> before a word (such as <code>-foo</code>) to make its absence required</li>
-    <li>Use <code>:</code> to search on a particular field (such as <code>field:word</code>). The available fields are <code>title</code> and <code>doc</code></li>
+    <li>Use <code>:</code> to search on a particular field (such as <code>field:word</code>). The available fields are <code>title</code>, <code>doc</code> and <code>type</code></li>
     <li>Use <code>WORD^NUMBER</code> (such as <code>foo^2</code>) to boost the given word</li>
     <li>Use <code>WORD~NUMBER</code> (such as <code>foo~2</code>) to do a search with edit distance on word</li>
   </ul>

--- a/assets/js/handlebars/templates/search-results.handlebars
+++ b/assets/js/handlebars/templates/search-results.handlebars
@@ -36,11 +36,11 @@
   <p>The search functionality is full-text based. Here are some tips:</p>
 
   <ul>
-    <li>Multiple words (such as <code>foo bar</code>) are searched as <code>OR</code></li>
+    <li>Multiple words (such as <code>foo bar</code>) are searched as <code>AND</code></li>
     <li>Use <code>*</code> anywhere (such as <code>fo*</code>) as wildcard</li>
-    <li>Use <code>+</code> before a word (such as <code>+foo</code>) to make its presence required</li>
+    <li>Use <code>+</code> before a word to make its presence optional. For example <code>+this +or_that </code></li>
     <li>Use <code>-</code> before a word (such as <code>-foo</code>) to make its absence required</li>
-    <li>Use <code>:</code> to search on a particular field (such as <code>field:word</code>). The available fields are <code>title</code>, <code>doc</code> and <code>type</code></li>
+    <li>Use <code>:</code> to search on a field (such as <code>field:word</code>). The available fields are <code>title</code>, <code>doc</code> and <code>type</code></li>
     <li>Use <code>WORD^NUMBER</code> (such as <code>foo^2</code>) to boost the given word</li>
     <li>Use <code>WORD~NUMBER</code> (such as <code>foo~2</code>) to do a search with edit distance on word</li>
   </ul>

--- a/assets/js/search-page.js
+++ b/assets/js/search-page.js
@@ -131,6 +131,7 @@ function createIndex () {
     this.ref('ref')
     this.field('title', { boost: 3 })
     this.field('doc')
+    this.field('type')
     this.metadataWhitelist = ['position']
     this.pipeline.remove(lunr.stopWordFilter)
     this.use(hyphenSearch)


### PR DESCRIPTION
The type is already surfaced in search results, so I don't think this is a significant change. Something I noticed is that if you do `type:function foo` you are actually getting search results for "type:function OR foo" which is pretty unexpected in that context. Might want to do `and` for field matches and `OR` for the rest. Hard to say! I wasn't sure if I should include artifacts from `mix build` or anything like that in this PR. Happy to make any changes necessary :)