### PR TITLE
Remove links from module page self-pointing “hover link” headings in EPUB

### DIFF
--- a/lib/ex_doc/formatter/epub/templates/module_template.eex
+++ b/lib/ex_doc/formatter/epub/templates/module_template.eex
@@ -17,24 +17,14 @@
 
     <%= if summary != [] do %>
       <section id="summary" class="details-list">
-        <h1 class="section-heading">
-          <a class="hover-link" href="#summary">
-            <i class="ri-link-m" aria-hidden="true"></i>
-            Summary
-          </a>
-        </h1>
+        <h1 class="section-heading">Summary</h1>
         <%= for {name, nodes} <- summary, do: H.summary_template(name, nodes) %>
       </section>
     <% end %>
 
     <%= for {name, nodes} <- summary, key = HTML.text_to_id(name) do %>
       <section id="<%= key %>" class="details-list">
-        <h1 class="section-heading">
-          <a class="hover-link" href="#<%= key %>">
-            <i class="ri-link-m" aria-hidden="true"></i>
-            <%= name %>
-          </a>
-        </h1>
+        <h1 class="section-heading"><%= name %></h1>
         <div class="<%= key %>-list">
           <%= for node <- nodes, do: H.detail_template(node, module) %>
         </div>

--- a/test/ex_doc/formatter/epub/templates_test.exs
+++ b/test/ex_doc/formatter/epub/templates_test.exs
@@ -59,6 +59,8 @@ defmodule ExDoc.Formatter.EPUB.TemplatesTest do
       assert content =~ ~r{<title>CompiledWithDocs [^<]*</title>}
       assert content =~ ~r{<h1 id="content">\s*CompiledWithDocs\s*}
 
+      assert content =~ ~s{<h1 class="section-heading">Summary</h1>}
+
       assert content =~
                ~r{<h2 id="module-example-unicode-escaping" class="section-heading">.*<a href="#module-example-unicode-escaping">.*<i class="ri-link-m" aria-hidden="true"></i>.*Example.*</a>.*</h2>}ms
 
@@ -85,8 +87,8 @@ defmodule ExDoc.Formatter.EPUB.TemplatesTest do
           ]
         )
 
-      assert content =~ ~r{id="example-functions".*href="#example-functions".*Example functions}ms
-      assert content =~ ~r{id="legacy".*href="#legacy".*Legacy}ms
+      assert content =~ ~r{id="example-functions".*Example functions}ms
+      assert content =~ ~r{id="legacy".*Legacy}ms
       assert content =~ ~r{id="example-functions".*id="example/2"}ms
       refute content =~ ~r{id="legacy".*id="example/2"}ms
       refute content =~ ~r{id="functions".*id="example/2"}ms


### PR DESCRIPTION
As discussed [here](https://github.com/elixir-lang/ex_doc/pull/1752#issuecomment-1713397635).