### PR TITLE
Accept a function in :deps option

### DIFF
--- a/test/mix/tasks/docs_test.exs
+++ b/test/mix/tasks/docs_test.exs
@@ -276,6 +276,32 @@ defmodule Mix.Tasks.DocsTest do
              {:earmark_parser, "foo"}
   end
 
+  test "allows setting deps through a function", context do
+    assert [
+             {"ex_doc", "dev",
+              [
+                formatter: "html",
+                formatters: _,
+                deps: deps,
+                apps: _,
+                source_beam: _,
+                proglang: :elixir
+              ]},
+             {"ex_doc", "dev",
+              [
+                formatter: "epub",
+                formatters: _,
+                deps: deps,
+                apps: _,
+                source_beam: _,
+                proglang: :elixir
+              ]}
+           ] = run(context, [], app: :ex_doc, docs: [deps: fn -> [earmark_parser: "foo"] end])
+
+    assert List.keyfind(deps, :earmark_parser, 0) ==
+             {:earmark_parser, "foo"}
+  end
+
   test "accepts lazy docs", context do
     assert [
              {"ex_doc", "dev",


### PR DESCRIPTION
When you are having private packages not published in hex there is no easy way to set the docs base url. You can use `:deps` but this has the following limitations:

- It is not applied recursively, so you need to define in the `:deps` non direct mix dependencies.
- For big projects with multiple internal dependencies it becomes difficult to maintain, unless you write custom linter tasks.
- If the base url of a dependency changes you need to update all packages depending on it.

`:base_url` allows setting the docs base url on the package itself.

Marking it as draft, since tests are missing