### PR TITLE
Fix `ArgumentError` with empty lists

### DIFF
--- a/lib/ex_doc/language/elixir.ex
+++ b/lib/ex_doc/language/elixir.ex
@@ -96,7 +96,7 @@ defmodule ExDoc.Language.Elixir do
   # If it is none, then we need to look at underscore.
   # TODO: We can remove this on Elixir v1.13 as all underscored are hidden.
   defp doc?({{_, name, _}, _, _, :none, _}, _type) do
-    hd(Atom.to_charlist(name)) != ?_
+    ExDoc.Utils.starts_with_underscore?(name) !=true
   end
 
   # Everything else is hidden.

--- a/lib/ex_doc/language/elixir.ex
+++ b/lib/ex_doc/language/elixir.ex
@@ -96,7 +96,7 @@ defmodule ExDoc.Language.Elixir do
   # If it is none, then we need to look at underscore.
   # TODO: We can remove this on Elixir v1.13 as all underscored are hidden.
   defp doc?({{_, name, _}, _, _, :none, _}, _type) do
-    ExDoc.Utils.starts_with_underscore?(name) !=true
+    ExDoc.Utils.starts_with_underscore?(name) != true
   end
 
   # Everything else is hidden.

--- a/lib/ex_doc/refs.ex
+++ b/lib/ex_doc/refs.ex
@@ -116,8 +116,6 @@ defmodule ExDoc.Refs do
 
   defguardp has_no_docs(doc) when doc == :none or doc == %{}
 
-  defp starts_with_underscore?(name), do: hd(Atom.to_charlist(name)) == ?_
-
   defp visibility(:hidden),
     do: :hidden
 
@@ -139,7 +137,7 @@ defmodule ExDoc.Refs do
       kind in [:callback, :type] ->
         :public
 
-      kind == :function and starts_with_underscore?(name) ->
+      kind == :function and ExDoc.Utils.starts_with_underscore?(name) ->
         :hidden
 
       kind == :function ->

--- a/lib/ex_doc/utils.ex
+++ b/lib/ex_doc/utils.ex
@@ -179,4 +179,9 @@ defmodule ExDoc.Utils do
         nil
     end
   end
+
+  def starts_with_underscore?(name) when is_atom(name), do: Atom.to_charlist(name) |> starts_with_underscore?()
+  def starts_with_underscore?([head | _]), do: head == ?_
+  def starts_with_underscore?(_), do: false
+
 end

--- a/lib/ex_doc/utils.ex
+++ b/lib/ex_doc/utils.ex
@@ -180,8 +180,9 @@ defmodule ExDoc.Utils do
     end
   end
 
-  def starts_with_underscore?(name) when is_atom(name), do: Atom.to_charlist(name) |> starts_with_underscore?()
+  def starts_with_underscore?(name) when is_atom(name),
+    do: Atom.to_charlist(name) |> starts_with_underscore?()
+
   def starts_with_underscore?([head | _]), do: head == ?_
   def starts_with_underscore?(_), do: false
-
 end


### PR DESCRIPTION
After adding LiveViewNative to a project I was no longer able to generate docs, with this error:
```
Generating docs...
** (ArgumentError) errors were found at the given arguments:

  * 1st argument: not a nonempty list

    (erts 14.1) :erlang.hd([])
    (ex_doc 0.30.6) lib/ex_doc/refs.ex:119: ExDoc.Refs.starts_with_underscore?/1
    (ex_doc 0.30.6) lib/ex_doc/refs.ex:142: ExDoc.Refs.visibility/2
    (ex_doc 0.30.6) lib/ex_doc/refs.ex:97: anonymous fn/4 in ExDoc.Refs.fetch_entries/2
    (elixir 1.15.6) lib/enum.ex:2510: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ex_doc 0.30.6) lib/ex_doc/refs.ex:95: ExDoc.Refs.fetch_entries/2
    (ex_doc 0.30.6) lib/ex_doc/refs.ex:64: ExDoc.Refs.insert_from_chunk/2
    (ex_doc 0.30.6) lib/ex_doc/retriever.ex:66: ExDoc.Retriever.docs_chunk/1
```

It seems that was caused by a macro who's name appears as `:""` which seems strange but anyway here's a fix.