### PR TITLE
Partially fix abstract Erlang types (`{@type ...}`)

### DIFF
--- a/lib/ex_doc/language/erlang.ex
+++ b/lib/ex_doc/language/erlang.ex
@@ -215,6 +215,24 @@ defmodule ExDoc.Language.Erlang do
     binary
   end
 
+  defp walk_doc({:code, attrs, [{:a, a_attrs, [a_inner], _a_meta} | _] = a, meta}, _config) do
+    {arity, extra} =
+      case :lists.keydelete(:a, 1, a) do
+        [] ->
+          {0, ""}
+
+        [extra] ->
+          # a_meta is not broken down, so we have to parse stuff like (X, Y)
+          {extra |> String.split(",") |> Enum.count(), extra}
+      end
+
+    type = type_from_fragment(:otp, a_attrs[:href])
+    url = fragment(:ex_doc, :type, type, arity)
+    text = a_inner <> extra
+
+    {:a, [href: url], {:code, attrs, [text], meta}, %{}}
+  end
+
   defp walk_doc({:code, attrs, [code], meta} = ast, config) do
     {text, url} =
       case parse_autolink(code) do
@@ -455,6 +473,8 @@ defmodule ExDoc.Language.Erlang do
   defp fragment(:ex_doc, :type, name, arity) do
     "#t:#{name}/#{arity}"
   end
+
+  defp type_from_fragment(:otp, "#type-" <> name), do: name
 
   defp kind("c:" <> rest), do: {:callback, rest}
   defp kind("t:" <> rest), do: {:type, rest}

--- a/test/ex_doc/language/erlang_test.exs
+++ b/test/ex_doc/language/erlang_test.exs
@@ -124,6 +124,27 @@ defmodule ExDoc.Language.ErlangTest do
                ~s|<a href="https://www.erlang.org/doc/man/array.html#type-array"><code>array:array()</code></a>|
     end
 
+    test "abstract types - description", c do
+      # if type exists:
+      # <code><a href="#type-myList">myList</a>(X)</code>
+      assert autolink_doc("{@type myList(X). A special kind of lists ...}", c) ==
+               ~s|<a href="#t:myList/1"><code>myList(X)</code></a>|
+    end
+
+    test "abstract types - description+dot", c do
+      # if type exists:
+      # <code><a href="#type-myList">myList</a>(X)</code>
+      assert autolink_doc("{@type myList(X, Y).}", c) ==
+               ~s|<a href="#t:myList/2"><code>myList(X, Y)</code></a>|
+    end
+
+    test "abstract types - no description", c do
+      # if type exists:
+      # <code><a href="#type-myList">myList</a>(X)</code>
+      assert autolink_doc("{@type myList()}", c) ==
+               ~s|<a href="#t:myList/0"><code>myList()</code></a>|
+    end
+
     test "bad module", c do
       assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
                assert autolink_doc("{@link bad}", c) == ~s|<code>bad</code>|


### PR DESCRIPTION
`@type` is deprecated but [still documented](https://www.erlang.org/doc/apps/edoc/chapter.html): you get a warning upon documentation generation.

This surfaced at https://github.com/starbelly/rebar3_ex_doc/issues/38.

Code out in the wild may contain references like the ones we include in the test.

This pull request attempts at solving a basic case for those.

EDoc seems broken for some types of `@type` (or at least not generating useful information), but at least this commit prevents a crash.

While discussing the solution with @starbelly we didn't know where to put the normalisation code. It might be good here, or it might belong in the `doc_ast.ex` module.