### PR TITLE
Prevent search bar from overlapping settings cog

### DIFF
--- a/assets/css/search-bar.css
+++ b/assets/css/search-bar.css
@@ -4,6 +4,7 @@
 
 .search-settings {
   display: flex;
+  column-gap: 12px;
   align-items: center;
 }
 
@@ -13,7 +14,6 @@
   height: 48px;
   position: relative;
   flex-grow: 1;
-  width: 96%;
 }
 
 .top-search .search-bar .search-input {
@@ -95,7 +95,6 @@
 
 .top-search .search-settings .icon-settings {
   font-size: 20px;
-  width: 4%;
   float: right;
   color: var(--iconAction);
   text-decoration: none;
@@ -103,7 +102,7 @@
   transition: color .3s ease-in-out;
   background-color: transparent;
   cursor: pointer;
-  padding: 1px 0px 1px 5px;
+  padding: 0;
 }
 
 .top-search .search-settings .icon-settings:hover {
@@ -113,25 +112,9 @@
   color: var(--iconAction);
 }
 
-@media (max-width: 480px) {
+@media (max-width: 480px) or ((min-width: 481px) and (max-width: 768px)) {
   .search-bar {
-    width: 90%;
     margin-left: 35px;
-  }
-
-  .top-search .search-settings .icon-settings {
-    width: 10%;
-  }
-}
-
-@media (min-width: 481px) and (max-width: 768px) {
-  .search-bar {
-    width: 95%;
-    margin-left: 35px;
-  }
-
-  .top-search .search-settings .icon-settings {
-    width: 5%;
   }
 }
 


### PR DESCRIPTION
This PR fixes an issue where the settings cog gets partially hidden under the search bar at certain sizes.

I've just added a `row-gap` between the search-bar and settings cog which seems to do the trick.  I feel there is some unnecessary CSS (which I will annotate) which doesn't seem to do anything, at least not once there is the gap.  I could be related to other browsers, of course.

I also removed some padding which seems to line up the cog with the code icon below a bit better, but I will undo that if requested (it's very subtle).

### Before

https://github.com/elixir-lang/ex_doc/assets/3752792/ce3c3142-9a3e-4294-b441-191821b5c07f

### After

https://github.com/elixir-lang/ex_doc/assets/3752792/2e81abaf-e0ca-43c3-913c-829e53d03edf

