### PR TITLE
Use IO.warn for autolink warnings

### DIFF
--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -513,7 +513,15 @@ defmodule ExDoc.Autolink do
         message
       end
 
-    IO.warn(message, file: config.file, line: config.line)
+    # TODO: Remove on Elixir v1.14
+    stacktrace_info =
+      if unquote(Version.match?(System.version(), ">= 1.14.0")) do
+        [file: config.file, line: config.line]
+      else
+        []
+      end
+
+    IO.warn(message, stacktrace_info)
   end
 
   defp warn(config, ref, visibility, metadata)

--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -506,14 +506,14 @@ defmodule ExDoc.Autolink do
 
   @doc false
   def warn(config, message) do
-    warning = IO.ANSI.format([:yellow, "warning: ", :reset])
+    message =
+      if config.id do
+        config.id <> " " <> message
+      else
+        message
+      end
 
-    stacktrace =
-      "  #{config.file}" <>
-        if(config.line, do: ":#{config.line}", else: "") <>
-        if(config.id, do: ": #{config.id}", else: "")
-
-    IO.puts(:stderr, [warning, message, ?\n, stacktrace, ?\n])
+    IO.warn(message, file: config.file, line: config.line)
   end
 
   defp warn(config, ref, visibility, metadata)

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -125,15 +125,15 @@ defmodule ExDoc.Formatter.HTMLTest do
   end
 
   test "warns on undefined functions", context do
-    output =
+    out =
       capture_io(:stderr, fn ->
         generate_docs(doc_config(context, skip_undefined_reference_warnings_on: []))
       end)
 
-    assert output =~ ~r"Warnings.bar/0.*\n  test/fixtures/warnings.ex:2: Warnings"
-    assert output =~ ~r"Warnings.bar/0.*\n  test/fixtures/warnings.ex:18: Warnings.foo/0"
-    assert output =~ ~r"Warnings.bar/0.*\n  test/fixtures/warnings.ex:13: c:Warnings.handle_foo/0"
-    assert output =~ ~r"Warnings.bar/0.*\n  test/fixtures/warnings.ex:8: t:Warnings.t/0"
+    assert out =~ ~s| Warnings.foo/0 documentation references function "Warnings.bar/0" |
+    assert out =~ ~s| c:Warnings.handle_foo/0 documentation references function "Warnings.bar/0" |
+    assert out =~ ~s| t:Warnings.t/0 documentation references function "Warnings.bar/0" |
+    assert out =~ ~s| Warnings documentation references function "Warnings.bar/0" |
   end
 
   test "generates headers for index.html and module pages", %{tmp_dir: tmp_dir} = context do

--- a/test/ex_doc/language/elixir_test.exs
+++ b/test/ex_doc/language/elixir_test.exs
@@ -488,40 +488,23 @@ defmodule ExDoc.Language.ElixirTest do
       {{:type, AutolinkTest.Foo, :bad, 0}, :hidden}
     ])
 
-    captured =
-      warn(fn ->
-        assert autolink_doc("`AutolinkTest.Foo.bar/1`", file: "lib/foo.ex", line: 1, id: nil) ==
-                 ~s|<code class="inline">AutolinkTest.Foo.bar/1</code>|
-      end)
-
-    assert captured =~
-             ~s|documentation references function "AutolinkTest.Foo.bar/1" but it is hidden|
-
-    assert captured =~ ~r{lib/foo.ex:1\n$}
+    assert warn(fn ->
+             assert autolink_doc("`AutolinkTest.Foo.bar/1`") ==
+                      ~s|<code class="inline">AutolinkTest.Foo.bar/1</code>|
+           end) =~
+             ~s|documentation references function "AutolinkTest.Foo.bar/1" but it is hidden\n|
 
     assert warn(fn ->
-             assert autolink_doc("`t:AutolinkTest.Foo.bad/0`",
-                      file: "lib/foo.ex",
-                      id: "AutolinkTest.Foo.foo/0"
-                    ) == ~s|<code class="inline">t:AutolinkTest.Foo.bad/0</code>|
+             assert autolink_doc("`t:AutolinkTest.Foo.bad/0`") ==
+                      ~s|<code class="inline">t:AutolinkTest.Foo.bad/0</code>|
            end) =~
              ~s|documentation references type "t:AutolinkTest.Foo.bad/0" but it is hidden or private|
 
     assert warn(fn ->
-             assert autolink_doc("`t:Elixir.AutolinkTest.Foo.bad/0`",
-                      file: "lib/foo.ex",
-                      id: "AutolinkTest.Foo.foo/0"
-                    ) == ~s|<code class="inline">t:Elixir.AutolinkTest.Foo.bad/0</code>|
+             assert autolink_doc("`t:Elixir.AutolinkTest.Foo.bad/0`") ==
+                      ~s|<code class="inline">t:Elixir.AutolinkTest.Foo.bad/0</code>|
            end) =~
              ~s|documentation references type "t:Elixir.AutolinkTest.Foo.bad/0" but it is hidden or private|
-
-    assert warn(fn ->
-             assert autolink_doc("`t:AutolinkTest.Foo.bad/0`",
-                      file: "lib/foo.ex",
-                      id: "AutolinkTest.Foo.foo/0"
-                    ) == ~s|<code class="inline">t:AutolinkTest.Foo.bad/0</code>|
-           end) =~
-             ~s|documentation references type "t:AutolinkTest.Foo.bad/0" but it is hidden or private|
 
     assert warn(fn ->
              assert autolink_doc("`Code.Typespec`") ==


### PR DESCRIPTION
Demo:

<img width="900" alt="image" src="https://github.com/elixir-lang/ex_doc/assets/76071/9998b272-8599-433c-8d61-da1f943a6afd">