### PR TITLE
Build precompiled ExDoc scripts on every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: write
+
+jobs:
+  create_release:
+    continue-on-error: true
+    runs-on: ubuntu-22.04
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Create release
+        run: |
+          echo "Creating release..."
+          gh release create \
+            --repo ${{ github.repository }} \
+            --title ${{ github.ref_name }} \
+            ${{ github.ref_name }}
+
+  release_pre_built:
+    needs: create_release
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - otp: 24
+            otp_version: "24.0"
+          - otp: 25
+            otp_version: "25.0.4"
+          - otp: 26
+            otp_version: "26.0.2"
+          # - otp: 27
+          #   otp_version: "27.0"
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+      - uses: ./.github/workflows/release_pre_built
+        with:
+          otp_version: ${{ matrix.otp_version }}
+          otp: ${{ matrix.otp }}
+
+      - name: Upload Pre-built
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload --clobber "${{ github.ref_name }}" \
+            ex_doc_otp_${{ matrix.otp }} \
+            ex-doc-otp-${{ matrix.otp }}.sha{1,256}sum \

--- a/.github/workflows/release_pre_built/action.yml
+++ b/.github/workflows/release_pre_built/action.yml
@@ -1,0 +1,23 @@
+name: "Release pre built"
+description: "Builds ex_doc scripts"
+inputs:
+  otp:
+    description: "The major OTP version"
+  otp_version:
+    description: "The exact OTP version (major.minor[.patch])"
+runs:
+  using: "composite"
+  steps:
+    - uses: erlef/setup-beam@v1.16.0
+      with:
+        otp-version: ${{ inputs.otp_version }}
+        elixir-version: "1.16.0"
+    - name: Build ex_doc
+      shell: bash
+      run: |
+        mix deps.get
+        mix escript.build
+        mv ex_doc ex_doc_otp_${{ inputs.otp }}
+        shasum -a 1 ex_doc_otp_${{ inputs.otp }} > ex-doc-otp-${{ inputs.otp }}.sha1sum
+        shasum -a 256 ex_doc_otp_${{ inputs.otp }} > ex-doc-otp-${{ inputs.otp }}.sha256sum
+        echo "$PWD/bin" >> $GITHUB_PATH


### PR DESCRIPTION
~Just cheking if I am on the right path here for [this one](https://github.com/elixir-lang/ex_doc/issues/1810) @josevalim.~

1. **`release.yml`**:
     - Checks for the existence of a release corresponding to the pushed tag.
     - Creates a new release if it does not already exist.
     - Deploys pre-built binaries for different OTP versions.
     - Supports OTP versions 24, 25, and 26, with placeholders for future versions.

2. **`release_pre_built/action.yml`**:
     - Configurable for different major and minor OTP versions.
     - Utilizes `erlef/setup-beam@v1.16.0` for setting up the Elixir environment.
     - Generates SHA1 and SHA256 checksums for the built binaries.
   

closes #1810 