### PR TITLE
Add borders dividing table rows in rendered content

### DIFF
--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -109,6 +109,7 @@
 
 .content-inner table {
   margin: 2em 0;
+  border-collapse: collapse;
 }
 
 .content-inner th {
@@ -119,13 +120,25 @@
   padding-bottom: .5em;
 }
 
+.content-inner thead tr {
+  border-bottom: 1px solid var(--tableHeadBorder);
+}
+
+.content-inner tbody tr {
+  border-bottom: 1px solid var(--tableBodyBorder);
+}
+
+.content-inner tbody tr:last-child {
+  border-bottom: none
+}
+
 .content-inner tr {
-  border-bottom: 1px solid var(--gray50);
   vertical-align: bottom;
   height: 2.5em;
 }
 
 .content-inner :is(td, th) {
+  padding: 0.25em;
   padding-left: 1em;
   line-height: 2em;
   vertical-align: top;

--- a/assets/css/custom-props/theme-dark.css
+++ b/assets/css/custom-props/theme-dark.css
@@ -18,6 +18,9 @@ body.dark {
   --blockquoteBackground:        var(--coldGrayDim);
   --blockquoteBorder:            var(--coldGrayDark);
 
+  --tableHeadBorder:             var(--gray600);
+  --tableBodyBorder:             var(--gray700);
+
   --warningBackground:           hsl( 40,  67%,  79%);
   --warningHeadingBackground:    hsl( 27,  66%,  29%);
   --warningHeading:              var(--white);

--- a/assets/css/custom-props/theme-light.css
+++ b/assets/css/custom-props/theme-light.css
@@ -18,6 +18,9 @@
   --blockquoteBackground:        var(--coldGrayFaint);
   --blockquoteBorder:            var(--coldGrayLight);
 
+  --tableHeadBorder:             var(--gray100);
+  --tableBodyBorder:             var(--gray50);
+
   --warningBackground:           hsl( 33, 100%,  97%);
   --warningHeadingBackground:    hsl( 33,  87%,  64%);
   --warningHeading:              var(--black);


### PR DESCRIPTION
It looks like they were attempted to be added, but weren't rendering due to missing `border-collapse: collapse` on the table.

So now there are borders for both light and dark mode:

**After**:

<img width="859" alt="Screenshot 2023-11-14 at 11 16 16 am" src="https://github.com/elixir-lang/ex_doc/assets/543859/9001f658-7867-45fd-abb0-0997d552caf7">

<img width="863" alt="Screenshot 2023-11-14 at 11 18 23 am" src="https://github.com/elixir-lang/ex_doc/assets/543859/af6cf477-c44b-49fa-9304-c290f0e9255e">
