### PR TITLE
Fix Erlang Scanning & Warnings 

### DIFF
--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -413,7 +413,7 @@ defmodule ExDoc.Autolink do
       {:type, _visibility} ->
         case config.language.try_builtin_type(name, arity, mode, config, original_text) do
           nil ->
-            if mode == :custom_link do
+            if mode == :custom_link or config.language == ExDoc.Language.Erlang do
               maybe_warn(config, ref, visibility, %{original_text: original_text})
             end
 
@@ -482,7 +482,9 @@ defmodule ExDoc.Autolink do
 
         nil
 
-      {:regular_link, _module_visibility, :undefined} when not same_module? ->
+      {:regular_link, _module_visibility, :undefined}
+      when not same_module? and
+             (config.language != ExDoc.Language.Erlang or kind == :function) ->
         nil
 
       {_mode, _module_visibility, visibility} ->

--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -371,29 +371,6 @@ defmodule ExDoc.Autolink do
     end
   end
 
-  # There are special forms that are forbidden by the tokenizer
-  def parse_function("__aliases__"), do: {:function, :__aliases__}
-  def parse_function("__block__"), do: {:function, :__block__}
-  def parse_function("%"), do: {:function, :%}
-
-  def parse_function(string) do
-    case Code.string_to_quoted("& #{string}/0", warnings: false) do
-      {:ok, {:&, _, [{:/, _, [{:__aliases__, _, [function]}, 0]}]}} when is_atom(function) ->
-        ## When function starts with capital letter
-        {:function, function}
-
-      ## When function is 'nil'
-      {:ok, {:&, _, [{:/, _, [nil, 0]}]}} ->
-        {:function, nil}
-
-      {:ok, {:&, _, [{:/, _, [{function, _, _}, 0]}]}} when is_atom(function) ->
-        {:function, function}
-
-      _ ->
-        :error
-    end
-  end
-
   def kind("c:" <> rest), do: {:callback, rest}
   def kind("t:" <> rest), do: {:type, rest}
   ## \\ does not work for :custom_url as Earmark strips the \...

--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -7,6 +7,9 @@ defmodule ExDoc.Autolink do
   # * `:current_module` - the module that the docs are being generated for. Used to link local
   #   calls and see if remote calls are in the same app.
   #
+  # * `:current_kfa` - the kind, function, arity that the docs are being generated for. Is nil
+  #    if there is no such thing. Used to generate more accurate warnings.
+  #
   # * `:module_id` - id of the module being documented (e.g.: `"String"`)
   #
   # * `:file` - source file location
@@ -48,6 +51,7 @@ defmodule ExDoc.Autolink do
     extras: [],
     deps: [],
     ext: ".html",
+    current_kfa: nil,
     siblings: [],
     skip_undefined_reference_warnings_on: [],
     skip_code_autolink_to: [],
@@ -495,7 +499,16 @@ defmodule ExDoc.Autolink do
     # TODO: Remove on Elixir v1.14
     stacktrace_info =
       if unquote(Version.match?(System.version(), ">= 1.14.0")) do
-        [file: config.file, line: config.line]
+        f =
+          case config.current_kfa do
+            {:function, f, a} ->
+              [function: {f, a}]
+
+            _ ->
+              []
+          end
+
+        [file: config.file, line: config.line, module: config.current_module] ++ f
       else
         []
       end

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -92,7 +92,15 @@ defmodule ExDoc.Formatter.HTML do
         docs =
           for child_node <- node.docs do
             id = id(node, child_node)
-            autolink_opts = autolink_opts ++ [id: id, line: child_node.doc_line]
+
+            autolink_opts =
+              autolink_opts ++
+                [
+                  id: id,
+                  line: child_node.doc_line,
+                  current_kfa: {:function, child_node.name, child_node.arity}
+                ]
+
             specs = Enum.map(child_node.specs, &language.autolink_spec(&1, autolink_opts))
             child_node = %{child_node | specs: specs}
             render_doc(child_node, language, autolink_opts, opts)
@@ -101,7 +109,14 @@ defmodule ExDoc.Formatter.HTML do
         typespecs =
           for child_node <- node.typespecs do
             id = id(node, child_node)
-            autolink_opts = autolink_opts ++ [id: id, line: child_node.doc_line]
+
+            autolink_opts =
+              autolink_opts ++
+                [
+                  id: id,
+                  line: child_node.doc_line,
+                  current_kfa: {child_node.type, child_node.name, child_node.arity}
+                ]
 
             child_node = %{
               child_node

--- a/lib/ex_doc/language/erlang.ex
+++ b/lib/ex_doc/language/erlang.ex
@@ -335,7 +335,7 @@ defmodule ExDoc.Language.Erlang do
         walk_doc({:a, [href: "`t:#{fixup(type)}`"], inner, meta}, config)
 
       "https://erlang.org/doc/link/" <> see ->
-        warn_ref(attrs[:href] <> " (#{see})", config)
+        warn_ref(attrs[:href] <> " (#{see})", %{config | id: nil})
         inner
 
       _ ->

--- a/lib/ex_doc/language/erlang.ex
+++ b/lib/ex_doc/language/erlang.ex
@@ -413,15 +413,25 @@ defmodule ExDoc.Language.Erlang do
     case String.split(string, ":") do
       [module_string, function_string] ->
         with {:module, module} <- parse_module_string(module_string, :custom_link),
-             {:function, function} <- Autolink.parse_function(function_string) do
+             {:function, function} <- parse_function(function_string) do
           {:remote, module, function}
         end
 
       [function_string] ->
-        with {:function, function} <- Autolink.parse_function(function_string) do
+        with {:function, function} <- parse_function(function_string) do
           {:local, function}
         end
 
+      _ ->
+        :error
+    end
+  end
+
+  defp parse_function(string) do
+    with {:ok, toks, _} <- :erl_scan.string(String.to_charlist("fun #{string}/0.")),
+         {:ok, [{:fun, _, {:function, name, _arity}}]} <- :erl_parse.parse_exprs(toks) do
+      {:function, name}
+    else
       _ ->
         :error
     end

--- a/lib/ex_doc/language/erlang.ex
+++ b/lib/ex_doc/language/erlang.ex
@@ -262,6 +262,8 @@ defmodule ExDoc.Language.Erlang do
   end
 
   defp walk_doc({:code, attrs, [code], meta} = ast, config) when is_binary(code) do
+    config = %{config | line: meta[:line]}
+
     case Autolink.url(code, :regular_link, config) do
       url when is_binary(url) ->
         code = remove_prefix(code)

--- a/test/ex_doc/language/erlang_test.exs
+++ b/test/ex_doc/language/erlang_test.exs
@@ -37,6 +37,14 @@ defmodule ExDoc.Language.ErlangTest do
                ~s|<a href="https://www.erlang.org/doc/man/array.html"><code>array</code></a>|
     end
 
+    @tag warnings: :send
+    test "app", c do
+      assert warn(fn ->
+               assert autolink_edoc("{@link //stdlib. `stdlib'}", c) ==
+                        ~s|<code>stdlib</code>|
+             end) =~ ~s|invalid reference: stdlib:index (seeapp)|
+    end
+
     test "external module", c do
       assert autolink_edoc("{@link 'Elixir.EarmarkParser'}", c) ==
                ~s|<a href="https://hexdocs.pm/earmark_parser/EarmarkParser.html"><code>'Elixir.EarmarkParser'</code></a>|

--- a/test/ex_doc/language/erlang_test.exs
+++ b/test/ex_doc/language/erlang_test.exs
@@ -197,6 +197,11 @@ defmodule ExDoc.Language.ErlangTest do
                ~s|<a href=\"erlang_bar.html\"><code class="inline">erlang_bar</code></a>|
     end
 
+    test "invalid m:module in module code", c do
+      assert autolink_doc("`m:erlang_bar()`", c) ==
+               ~s|<code class="inline">m:erlang_bar()</code>|
+    end
+
     test "module in module code reference", c do
       assert autolink_doc("[`erlang_bar`](`erlang_bar`)", c) ==
                ~s|<a href=\"erlang_bar.html\"><code class="inline">erlang_bar</code></a>|

--- a/test/ex_doc/language/erlang_test.exs
+++ b/test/ex_doc/language/erlang_test.exs
@@ -226,6 +226,25 @@ defmodule ExDoc.Language.ErlangTest do
                ~s|<a href="stdlib/c.html#ls/0">c</a>)|
     end
 
+    test "function quoted", c do
+      assert autolink_doc("`erlang_foo:'foo'/0`", c) ==
+               ~s|<a href="#foo/0"><code class="inline">erlang_foo:'foo'/0</code></a>|
+    end
+
+    test "function quoted large", c do
+      assert autolink_doc("`erlang_foo:'Foo'/0`", c,
+               extra_foo_code: "-export(['Foo'/0]).\n'Foo'() -> ok.\n"
+             ) ==
+               ~s|<a href="#Foo/0"><code class="inline">erlang_foo:'Foo'/0</code></a>|
+    end
+
+    test "function unicode", c do
+      assert autolink_doc("`erlang_foo:'😀'/0`", c,
+               extra_foo_code: "-export(['😀'/0]).\n'😀'() -> ok.\n"
+             ) ==
+               ~s|<a href="#%F0%9F%98%80/0"><code class="inline">erlang_foo:'😀'/0</code></a>|
+    end
+
     test "function in module autoimport", c do
       assert autolink_doc("`node()`", c) ==
                ~s|<code class="inline">node()</code>|
@@ -249,6 +268,16 @@ defmodule ExDoc.Language.ErlangTest do
     test "bad function in module code", c do
       assert autolink_doc("`bad/0`", c) ==
                ~s|<code class="inline">bad/0</code>|
+    end
+
+    test "Elixir keyword function", c do
+      assert autolink_doc("`do/0`", c, extra_foo_code: "-export([do/0]).\ndo() -> ok.\n") ==
+               ~s|<a href="#do/0"><code class="inline">do/0</code></a>|
+    end
+
+    test "linking to auto-imported nil works", c do
+      assert autolink_doc("[`[]`](`t:nil/0`)", c) ==
+               ~s|<a href="https://www.erlang.org/doc/man/erlang.html#type-nil"><code class="inline">[]</code></a>|
     end
 
     test "linking to local nil works", c do

--- a/test/ex_doc/language/erlang_test.exs
+++ b/test/ex_doc/language/erlang_test.exs
@@ -382,6 +382,24 @@ defmodule ExDoc.Language.ErlangTest do
              ) =~ ~s|documentation references callback "c:erlang_bar:bad/0" but it is undefined|
     end
 
+    test "bad local type in module", c do
+      assert warn(
+               fn ->
+                 assert autolink_doc("\n`t:bad/0`", c) == ~s|<code class="inline">t:bad/0</code>|
+               end,
+               line: 2
+             ) =~ ~s|documentation references type "t:bad/0" but it is undefined or private|
+    end
+
+    test "bad local callback in module", c do
+      assert warn(
+               fn ->
+                 assert autolink_doc("\n`c:bad/0`", c) == ~s|<code class="inline">c:bad/0</code>|
+               end,
+               line: 2
+             ) =~ ~s|documentation references callback "c:bad/0" but it is undefined|
+    end
+
     test "bad function in module ref", c do
       assert warn(
                fn ->
@@ -449,6 +467,18 @@ defmodule ExDoc.Language.ErlangTest do
     end
 
     @tag warnings: :send
+    test "bad type", c do
+      assert warn(
+               fn ->
+                 assert autolink_extra("`t:bad:bad/0`", c) ==
+                          ~s|<code class="inline">t:bad:bad/0</code>|
+               end,
+               file: "extra.md",
+               line: 1
+             ) =~ ~s|documentation references type "t:bad:bad/0" but it is undefined or private|
+    end
+
+    @tag warnings: :send
     test "bad type ref", c do
       assert warn(
                fn ->
@@ -458,6 +488,18 @@ defmodule ExDoc.Language.ErlangTest do
                file: "extra.md",
                line: nil
              ) =~ ~s|documentation references type "t:bad:bad/0" but it is undefined or private|
+    end
+
+    @tag warnings: :send
+    test "bad callback", c do
+      assert warn(
+               fn ->
+                 assert autolink_extra("`c:bad:bad/0`", c) ==
+                          ~s|<code class="inline">c:bad:bad/0</code>|
+               end,
+               file: "extra.md",
+               line: 1
+             ) =~ ~s|documentation references callback "c:bad:bad/0" but it is undefined|
     end
 
     test "bad module", c do


### PR DESCRIPTION
This PR does 3 things:

1. Change Erlang+Elixir autolinking to parse function links using specialized code instead of sharing. There are too many incompatible overlaps between the languages to make it possible to use the same parser for both.
2. Use correct line numbers for regular links, just as #1807 did for Elixir
3. Make Erlang docs warn when an unkown type or callback is used in regular links.

I'm a bit unsure about the last one, why is it that ExDoc Elixir does not warn for these?

```
`t:Bad:type/0`
```

Seems like there is very little chance of a false positive, and if there is one you can always silence it.