### PR TITLE
Do not parse math expressions as markdown

### DIFF
--- a/lib/ex_doc/markdown/earmark.ex
+++ b/lib/ex_doc/markdown/earmark.ex
@@ -29,7 +29,8 @@ defmodule ExDoc.Markdown.Earmark do
       line: 1,
       file: "nofile",
       breaks: false,
-      pure_links: true
+      pure_links: true,
+      math: true
     ]
 
     options = Keyword.merge(options, opts)
@@ -61,6 +62,16 @@ defmodule ExDoc.Markdown.Earmark do
 
   defp fixup({tag, attrs, ast}) do
     fixup({tag, attrs, ast, %{}})
+  end
+
+  # Rewrite math back to the original syntax, it's up to the user to render it
+
+  defp fixup({"code", [{"class", "math-inline"}], [content], _}) do
+    "$#{content}$"
+  end
+
+  defp fixup({"code", [{"class", "math-display"}], [content], _}) do
+    "$$\n#{content}\n$$"
   end
 
   defp fixup({tag, attrs, ast, meta}) when is_binary(tag) and is_list(attrs) and is_map(meta) do

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,8 @@ defmodule ExDoc.Mixfile do
 
   defp deps do
     [
-      {:earmark_parser, "~> 1.4.38"},
+      # {:earmark_parser, "~> 1.4.38"},
+      {:earmark_parser, github: "jonatanklosko/earmark_parser", branch: "jk-math"},
       {:makeup_elixir, "~> 0.14"},
       {:makeup_erlang, "~> 0.1"},
       # Add other makeup lexers as optional for the executable

--- a/mix.exs
+++ b/mix.exs
@@ -34,8 +34,7 @@ defmodule ExDoc.Mixfile do
 
   defp deps do
     [
-      # {:earmark_parser, "~> 1.4.38"},
-      {:earmark_parser, github: "jonatanklosko/earmark_parser", branch: "jk-math"},
+      {:earmark_parser, "~> 1.4.39"},
       {:makeup_elixir, "~> 0.14"},
       {:makeup_erlang, "~> 0.1"},
       # Add other makeup lexers as optional for the executable

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "earmark_parser": {:git, "https://github.com/jonatanklosko/earmark_parser.git", "b73e6591983320f4eced3292b6ed12f4fcbdbe2b", [branch: "jk-math"]},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.39", "424642f8335b05bb9eb611aa1564c148a8ee35c9c8a8bba6e129d51a3e3c6769", [:mix], [], "hexpm", "06553a88d1f1846da9ef066b87b57c6f605552cfbe40d20bd8d59cc6bde41944"},
   "easyhtml": {:hex, :easyhtml, "0.2.0", "0cd913f920392b5b5f74ff94c1795f8fc5c0812213ef4c466af7705348e1c05d", [:mix], [{:floki, "~> 0.30", [hex: :floki, repo: "hexpm", optional: false]}], "hexpm", "f827387bbafe03b70df5e392f5e536b579a1dfa315714fb827ffde4e620d44a9"},
   "floki": {:hex, :floki, "0.34.2", "5fad07ef153b3b8ec110b6b155ec3780c4b2c4906297d0b4be1a7162d04a7e02", [:mix], [], "hexpm", "26b9d50f0f01796bc6be611ca815c5e0de034d2128e39cc9702eee6b66a4d1c8"},
   "jason": {:hex, :jason, "1.2.0", "10043418c42d2493d0ee212d3fddd25d7ffe484380afad769a0a38795938e448", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "116747dbe057794c3a3e4e143b7c8390b29f634e16c78a7f59ba75bfa6852e7f"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "earmark_parser": {:hex, :earmark_parser, "1.4.38", "b42252eddf63bda05554ba8be93a1262dc0920c721f1aaf989f5de0f73a2e367", [:mix], [], "hexpm", "2cd0907795aaef0c7e8442e376633c5b3bd6edc8dbbdc539b22f095501c1cdb6"},
+  "earmark_parser": {:git, "https://github.com/jonatanklosko/earmark_parser.git", "b73e6591983320f4eced3292b6ed12f4fcbdbe2b", [branch: "jk-math"]},
   "easyhtml": {:hex, :easyhtml, "0.2.0", "0cd913f920392b5b5f74ff94c1795f8fc5c0812213ef4c466af7705348e1c05d", [:mix], [{:floki, "~> 0.30", [hex: :floki, repo: "hexpm", optional: false]}], "hexpm", "f827387bbafe03b70df5e392f5e536b579a1dfa315714fb827ffde4e620d44a9"},
   "floki": {:hex, :floki, "0.34.2", "5fad07ef153b3b8ec110b6b155ec3780c4b2c4906297d0b4be1a7162d04a7e02", [:mix], [], "hexpm", "26b9d50f0f01796bc6be611ca815c5e0de034d2128e39cc9702eee6b66a4d1c8"},
   "jason": {:hex, :jason, "1.2.0", "10043418c42d2493d0ee212d3fddd25d7ffe484380afad769a0a38795938e448", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "116747dbe057794c3a3e4e143b7c8390b29f634e16c78a7f59ba75bfa6852e7f"},

--- a/test/ex_doc/markdown/earmark_test.exs
+++ b/test/ex_doc/markdown/earmark_test.exs
@@ -74,5 +74,15 @@ defmodule ExDoc.Markdown.EarmarkTest do
                {:pre, [], [{:code, [class: "mermaid output"], ["graph TD; A-->B;"], %{}}], %{}}
              ]
     end
+
+    test "keeps math syntax without interpreting math as markdown" do
+      assert Markdown.to_ast("Math $x *y* y$", []) == [
+               {:p, [], ["Math ", "$x *y* y$"], %{}}
+             ]
+
+      assert Markdown.to_ast("Math $$x$$", []) == [
+               {:p, [], ["Math ", "$$\nx\n$$"], %{}}
+             ]
+    end
   end
 end


### PR DESCRIPTION
Closes #1571. Depends on https://github.com/RobertDober/earmark_parser/pull/142.

With this change we parse math expressions in Markdown and then rewrite them back to `$` and `$$`. Rendering the expressions is still up to the user, but this way we don't parse the expression contents as Markdown.