### PR TITLE
Fix SVG logo without width/height attrs not displaying

### DIFF
--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -53,8 +53,8 @@
 }
 
 .sidebar .sidebar-projectImage img {
-  width: 48px;
-  height: auto;
+  display: block;
+  max-width: 48px;
   max-height: 48px;
 }
 

--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -53,7 +53,8 @@
 }
 
 .sidebar .sidebar-projectImage img {
-  max-width: 48px;
+  width: 48px;
+  height: auto;
   max-height: 48px;
 }
 

--- a/lib/ex_doc/cli.ex
+++ b/lib/ex_doc/cli.ex
@@ -174,9 +174,8 @@ defmodule ExDoc.CLI do
           --homepage-url  URL to link to for the site name
           --language      Identify the primary language of the documents, its value must be
                           a valid [BCP 47](https://tools.ietf.org/html/bcp47) language tag, default: "en"
-      -l, --logo          Path to a logo image for the project. Must be PNG, JPEG or SVG.
-                          The image should be square; it will be shown at 48x48px.
-                          The image file will be copied to the output assets directory.
+      -l, --logo          Path to a logo image for the project. Must be PNG, JPEG or SVG. The image will
+                          be placed in the output "assets" directory.
       -m, --main          The entry-point page in docs, default: "api-reference"
       -o, --output        Path to output docs, default: "doc"
           --package       Hex package name

--- a/lib/ex_doc/cli.ex
+++ b/lib/ex_doc/cli.ex
@@ -174,8 +174,9 @@ defmodule ExDoc.CLI do
           --homepage-url  URL to link to for the site name
           --language      Identify the primary language of the documents, its value must be
                           a valid [BCP 47](https://tools.ietf.org/html/bcp47) language tag, default: "en"
-      -l, --logo          Path to the image logo of the project (only PNG or JPEG accepted)
-                          The image size will be 64x64 and copied to the assets directory
+      -l, --logo          Path to a logo image for the project. Must be PNG, JPEG or SVG.
+                          The image should be square; it will be shown at 48x48px.
+                          The image file will be copied to the output assets directory.
       -m, --main          The entry-point page in docs, default: "api-reference"
       -o, --output        Path to output docs, default: "doc"
           --package       Hex package name

--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -560,14 +560,14 @@ defmodule ExDoc.Formatter.HTML do
       |> Path.extname()
       |> String.downcase()
 
-    if extname in ~w(.png .jpg .svg) do
+    if extname in ~w(.png .jpg .jpeg .svg) do
       filename = Path.join(dir, "#{name}#{extname}")
       target = Path.join(output, filename)
       File.mkdir_p!(Path.dirname(target))
       File.copy!(image, target)
       [filename]
     else
-      raise ArgumentError, "image format not recognized, allowed formats are: .jpg, .png"
+      raise ArgumentError, "image format not recognized, allowed formats are: .png, .jpg, .svg"
     end
   end
 

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -127,10 +127,10 @@ defmodule Mix.Tasks.Docs do
     * `:language` - Identify the primary language of the documents, its value must be
       a valid [BCP 47](https://tools.ietf.org/html/bcp47) language tag; default: "en"
 
-    * `:logo` - Path to the image logo of the project (only PNG or JPEG accepted)
-      The image size will be 64x64. When specified, the logo will be placed under
-      the "assets" directory in the output path under the name "logo" and the
-      appropriate extension.
+    * `:logo` - Path to a logo image file for the project. Must be PNG, JPEG or SVG.
+      The image should be square; it will be shown at 48x48px. When specified, the
+      logo will be placed in the "assets" directory in the output path with the
+      name "logo" and the appropriate extension.
 
     * `:main` - Main page of the documentation. It may be a module or a
       generated page, like "Plug" or "api-reference"; default: "api-reference".

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -127,10 +127,11 @@ defmodule Mix.Tasks.Docs do
     * `:language` - Identify the primary language of the documents, its value must be
       a valid [BCP 47](https://tools.ietf.org/html/bcp47) language tag; default: "en"
 
-    * `:logo` - Path to a logo image file for the project. Must be PNG, JPEG or SVG.
-      The image should be square; it will be shown at 48x48px. When specified, the
-      logo will be placed in the "assets" directory in the output path with the
-      name "logo" and the appropriate extension.
+    * `:logo` - Path to a logo image file for the project. Must be PNG, JPEG or SVG. When
+      specified, the image file will be placed in the output "assets" directory, named
+      "logo.EXTENSION". The image will be shown within a 48x48px area. If using SVG, ensure
+      appropriate width, height and viewBox attributes are present in order to ensure
+      predictable sizing and cropping.
 
     * `:main` - Main page of the documentation. It may be a module or a
       generated page, like "Plug" or "api-reference"; default: "api-reference".

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -300,7 +300,7 @@ defmodule ExDoc.Formatter.HTMLTest do
       config = doc_config(context, logo: "README.md")
 
       assert_raise ArgumentError,
-                   "image format not recognized, allowed formats are: .jpg, .png",
+                   "image format not recognized, allowed formats are: .png, .jpg, .svg",
                    fn -> generate_docs(config) end
     end
   end


### PR DESCRIPTION
Sets width and (auto) height of logo image.

Also allows for 'jpeg' filename extension to be used and updates docs.

Fix #1847