### PR TITLE
epub: fix logo not declared in the OPF manifest

### DIFF
--- a/lib/ex_doc/formatter/epub/templates/content_template.eex
+++ b/lib/ex_doc/formatter/epub/templates/content_template.eex
@@ -17,40 +17,30 @@
   <manifest>
     <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav scripted"/>
     <item id="cover" href="title.xhtml" media-type="application/xhtml+xml" properties="scripted"/>
-    <%= for {_title, extras} <- config.extras do %>
-      <%= for extra <- extras do %>
-        <item id="<%= URI.encode extra.id %>" href="<%= URI.encode extra.id %>.xhtml" media-type="application/xhtml+xml" properties="scripted"/>
-      <% end %>
+    <%= for {_title, extras} <- config.extras, extra <- extras do %>
+      <item id="<%= URI.encode extra.id %>" href="<%= URI.encode extra.id %>.xhtml" media-type="application/xhtml+xml" properties="scripted"/>
     <% end %>
-    <%= for filter <- [:modules, :tasks] do %>
-      <%= for node <- nodes[filter] do %>
-        <item id="<%= URI.encode node.id %>" href="<%= URI.encode node.id %>.xhtml" media-type="application/xhtml+xml" properties="scripted"/>
-      <% end %>
+    <%= for filter <- [:modules, :tasks], node <- nodes[filter] do %>
+      <item id="<%= URI.encode node.id %>" href="<%= URI.encode node.id %>.xhtml" media-type="application/xhtml+xml" properties="scripted"/>
     <% end %>
     <%= for static_file <- static_files do %>
       <item id="<%= static_file_to_id(static_file) %>" href="<%= static_file %>" media-type="<%= media_type(Path.extname(static_file)) %>"/>
     <% end %>
     <%= if config.cover do %>
-      <%= if Path.extname(config.cover) == ".png" do %>
-        <item id="cover-image" href="assets/cover.png" media-type="image/png"/>
-      <% end %>
-      <%= if Path.extname(config.cover) == ".jpg" do %>
-        <item id="cover-image" href="assets/cover.jpg" media-type="image/jpeg"/>
-      <% end %>
+      <item id="cover-image" href="assets/cover<%= Path.extname(config.cover) %>" media-type="<%= media_type(Path.extname(config.cover))%>"/>
+    <% end %>
+    <%= if config.logo do %>
+      <item id="logo" href="assets/logo<%= Path.extname(config.logo) %>" media-type="<%= media_type(Path.extname(config.logo))%>"/>
     <% end %>
   </manifest>
   <spine>
     <itemref idref="cover"/>
     <itemref idref="nav"/>
-    <%= for {_title, extras} <- config.extras do %>
-      <%= for extra <- extras do %>
-        <itemref idref="<%= URI.encode extra.id %>"/>
-      <% end %>
+    <%= for {_title, extras} <- config.extras, extra <- extras do %>
+      <itemref idref="<%= URI.encode extra.id %>"/>
     <% end %>
-    <%= for filter <- [:modules, :tasks] do %>
-      <%= for node <- nodes[filter] do %>
-        <itemref idref="<%= URI.encode node.id %>"/>
-      <% end %>
+    <%= for filter <- [:modules, :tasks], node <- nodes[filter] do %>
+      <itemref idref="<%= URI.encode node.id %>"/>
     <% end %>
   </spine>
 </package>

--- a/test/ex_doc/formatter/epub/templates_test.exs
+++ b/test/ex_doc/formatter/epub/templates_test.exs
@@ -38,7 +38,53 @@ defmodule ExDoc.Formatter.EPUB.TemplatesTest do
     :ok
   end
 
-  describe "module_page" do
+  describe "content_template/5" do
+    test "includes logo as a resource if specified in the config" do
+      nodes = %{modules: [], tasks: []}
+
+      content =
+        [logo: "my_logo.png"]
+        |> doc_config()
+        |> Templates.content_template(nodes, "uuid", "datetime", _static_files = [])
+
+      assert content =~ ~S|<item id="logo" href="assets/logo.png" media-type="image/png"/>|
+    end
+
+    test "includes cover as a resource if specified in the config" do
+      nodes = %{modules: [], tasks: []}
+
+      content =
+        [cover: "my_cover.svg"]
+        |> doc_config()
+        |> Templates.content_template(nodes, "uuid", "datetime", _static_files = [])
+
+      assert content =~ ~S|<meta name="cover" content="cover-image"/>|
+
+      assert content =~
+               ~S|<item id="cover-image" href="assets/cover.svg" media-type="image/svg+xml"/>|
+    end
+
+    test "includes modules as a resource" do
+      module_node = %ExDoc.ModuleNode{
+        module: XPTOModule,
+        doc: nil,
+        id: "XPTOModule",
+        title: "XPTOModule"
+      }
+
+      nodes = %{modules: [module_node], tasks: []}
+
+      content =
+        Templates.content_template(doc_config(), nodes, "uuid", "datetime", _static_files = [])
+
+      assert content =~
+               ~S|<item id="XPTOModule" href="XPTOModule.xhtml" media-type="application/xhtml+xml" properties="scripted"/>|
+
+      assert content =~ ~S|<itemref idref="XPTOModule"/>|
+    end
+  end
+
+  describe "module_page/2" do
     test "generates only the module name when there's no more info" do
       module_node = %ExDoc.ModuleNode{
         module: XPTOModule,


### PR DESCRIPTION
We need to list all the resources included in the EPUB file in the OPF manifest, we missed doing that for the logo.

Basically this PR fix the following error found by `epubcheck`:

```json
  {
    "ID" : "RSC-008",
    "severity" : "ERROR",
    "message" : "Referenced resource \"OEBPS/assets/logo.png\" is not declared in the OPF manifest.",
    "locations" : [ {
      "path" : "OEBPS/title.xhtml",
      "line" : 21,
      "column" : 55
    } ]
  }
```

I also did some small refactor in this template.