### PR TITLE
Use blue links for Erlang

### DIFF
--- a/assets/css/custom-props/_elixir.css
+++ b/assets/css/custom-props/_elixir.css
@@ -4,6 +4,15 @@
   --mainDarkest:   hsl(250, 68%, 49%);
   --mainLight:     hsl(250, 68%, 74%);
   --mainLightest:  hsl(250, 68%, 79%);
-  --searchBarFocusColor: #8E7CE6;
+
+  --searchBarFocusColor:  #8E7CE6;
   --searchBarBorderColor: rgba(142, 124, 230, 0.25);
+
+  --linksNoUnderline:            var(--mainDark);
+  --linksNoUnderlineVisited:     var(--mainDarkest);
+}
+
+body.dark {
+  --linksNoUnderline:            var(--mainLightest);
+  --linksNoUnderlineVisited:     var(--mainLight);
 }

--- a/assets/css/custom-props/_erlang.css
+++ b/assets/css/custom-props/_erlang.css
@@ -4,7 +4,15 @@
   --mainDarkest:   hsl(0, 100%, 24%);
   --mainLight:     hsl(0, 100%, 64%);
   --mainLightest:  hsl(0, 100%, 74%);
-  --searchBarFocusColor: hsl(0, 100%, 50%);
+
+  --searchBarFocusColor:  hsl(0, 100%, 50%);
   --searchBarBorderColor: rgb(255, 71, 71, 0.1);
 
+  --linksNoUnderline:            #0969da;
+  --linksNoUnderlineVisited:     #085fc4;
+}
+
+body.dark {
+  --linksNoUnderline:            #71b7ff;
+  --linksNoUnderlineVisited:     #65a4e5;
 }

--- a/assets/css/custom-props/theme-dark.css
+++ b/assets/css/custom-props/theme-dark.css
@@ -9,8 +9,6 @@ body.dark {
 
   --links:                       var(--gray100);
   --linksVisited:                var(--gray100);
-  --linksNoUnderline:            var(--mainLightest);
-  --linksNoUnderlineVisited:     var(--mainLight);
   --linksDecoration:             var(--gray450);
 
   --iconAction:                  var(--coldGray-lightened-10);

--- a/assets/css/custom-props/theme-light.css
+++ b/assets/css/custom-props/theme-light.css
@@ -9,8 +9,6 @@
 
   --links:                       var(--black);
   --linksVisited:                var(--black);
-  --linksNoUnderline:            var(--mainDark);
-  --linksNoUnderlineVisited:     var(--mainDarkest);
   --linksDecoration:             var(--gray450);
 
   --iconAction:                  var(--coldGray);


### PR DESCRIPTION
Examples below. Please use thumbs up (you prefer blue) or down (you prefer the current) to state your preference.

<img width="677" alt="Screenshot 2024-01-25 at 21 51 31" src="https://github.com/elixir-lang/ex_doc/assets/9582/a407ec48-0c0d-4a30-9474-ec2b16115aad">

<img width="647" alt="Screenshot 2024-01-25 at 21 51 43" src="https://github.com/elixir-lang/ex_doc/assets/9582/10a768ce-b963-4a9e-9afa-08c15e09b55f">
