### PR TITLE
epub: fix fatal errors while parsing EPUB files

### DIFF
--- a/test/fixtures/README.md
+++ b/test/fixtures/README.md
@@ -15,3 +15,7 @@ hello
 ## more > than
 
 <p><strong>raw content</strong></p>
+
+The following text includes a reference to an anchor that causes problems in EPUB documents.
+
+To remove this anti-pattern, we can replace `&&/2`, `||/2`, and `!/1` by `and/2`, `or/2`, and `not/1` respectively.


### PR DESCRIPTION
After generating the EPUB file for the Elixir docs with this version, and reviewing the result with `epubcheck`, I got the following summary:

```console
$ epubcheck doc/elixir/Elixir.epub --json elixir_docs.json
Check finished with errors
Messages: 0 fatals / 141 errors / 0 warnings / 0 infos
```

If you compare the previous result with what we had on #1851

```
Messages: 9 fatals / 425 errors / 0 warnings / 0 infos
```

you can see that now we don't have messages with `fatal` severity and we have reduced considerably the number of `errors` =)

I manually checked the generated EPUB on Apple Books and the previous truncated sections are fixed, I don't see the banner _Below is a rendering of the page up to the first error_ and also the links to different anchors seems to work.

Fixes: #1851