### PR TITLE
Add before_closing_footer_tag and adjust annotation metadata

### DIFF
--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -304,7 +304,16 @@ defmodule ExDoc.Autolink do
           end
 
         config.deps
-        |> Keyword.get_lazy(String.to_atom(app), fn -> @hexdocs <> "#{app}" end)
+        |> Keyword.get_lazy(String.to_atom(app), fn ->
+          maybe_warn(
+            config,
+            "documentation references \"e:#{string}\" but #{app} cannot be found in deps.",
+            nil,
+            %{}
+          )
+
+          @hexdocs <> "#{app}"
+        end)
         |> String.trim_trailing("/")
         |> Kernel.<>("/" <> convert_extra_extension(extra, config) <> anchor)
 

--- a/lib/ex_doc/config.ex
+++ b/lib/ex_doc/config.ex
@@ -5,6 +5,7 @@ defmodule ExDoc.Config do
   @default_source_ref "main"
   def filter_modules(_module, _metadata), do: true
   def before_closing_head_tag(_), do: ""
+  def before_closing_footer_tag(_), do: ""
   def before_closing_body_tag(_), do: ""
   def annotations_for_docs(_), do: []
 
@@ -14,6 +15,7 @@ defmodule ExDoc.Config do
             assets: nil,
             authors: nil,
             before_closing_body_tag: &__MODULE__.before_closing_body_tag/1,
+            before_closing_footer_tag: &__MODULE__.before_closing_footer_tag/1,
             before_closing_head_tag: &__MODULE__.before_closing_head_tag/1,
             canonical: nil,
             cover: nil,
@@ -53,6 +55,7 @@ defmodule ExDoc.Config do
           assets: nil | String.t(),
           authors: nil | [String.t()],
           before_closing_body_tag: (atom() -> String.t()) | mfa() | map(),
+          before_closing_footer_tag: (atom() -> String.t()) | mfa() | map(),
           before_closing_head_tag: (atom() -> String.t()) | mfa() | map(),
           canonical: nil | String.t(),
           cover: nil | Path.t(),

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -2,7 +2,13 @@ defmodule ExDoc.Formatter.HTML.Templates do
   @moduledoc false
   require EEx
 
-  import ExDoc.Utils, only: [h: 1, before_closing_body_tag: 2, before_closing_head_tag: 2]
+  import ExDoc.Utils,
+    only: [
+      h: 1,
+      before_closing_body_tag: 2,
+      before_closing_footer_tag: 2,
+      before_closing_head_tag: 2
+    ]
 
   # TODO: It should not depend on the parent module. Move required HTML functions to Utils.
   # TODO: Add tests that assert on the returned structured, not on JSON

--- a/lib/ex_doc/formatter/html/templates/footer_template.eex
+++ b/lib/ex_doc/formatter/html/templates/footer_template.eex
@@ -34,6 +34,7 @@
             <a href="https://elixir-lang.org" title="Elixir" target="_blank" translate="no">Elixir programming language</a>
           <% end %>
         </p>
+        <%= before_closing_footer_tag(config, :html) %>
       </footer>
     </div>
   </div>

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -241,6 +241,12 @@ defmodule ExDoc.Retriever do
     doc_file = anno_file(anno, source)
     doc_line = anno_line(anno)
 
+    metadata =
+      Map.merge(
+        %{kind: type, name: name, arity: arity, module: module_data.module},
+        metadata
+      )
+
     source_url =
       source_link(function_data[:source_file], source, function_data.source_line)
 
@@ -255,13 +261,7 @@ defmodule ExDoc.Retriever do
         function_data.doc_fallback.()
 
     group =
-      GroupMatcher.match_function(
-        groups_for_docs,
-        Map.merge(
-          %{kind: type, name: name, arity: arity, module: module_data.module},
-          metadata
-        )
-      )
+      GroupMatcher.match_function(groups_for_docs, metadata)
 
     %ExDoc.FunctionNode{
       id: nil_or_name(name, arity),
@@ -328,6 +328,12 @@ defmodule ExDoc.Retriever do
     source_url =
       source_link(callback_data[:source_file], source, callback_data.source_line)
 
+    metadata =
+      Map.merge(
+        %{kind: kind, name: name, arity: arity, module: module_data.module},
+        metadata
+      )
+
     signature = signature(callback_data.signature)
     specs = callback_data.specs
 
@@ -342,10 +348,7 @@ defmodule ExDoc.Retriever do
     group =
       GroupMatcher.match_function(
         groups_for_docs,
-        Map.merge(
-          %{kind: kind, name: name, arity: arity, module: module_data.module},
-          metadata
-        )
+        metadata
       )
 
     %ExDoc.FunctionNode{
@@ -384,6 +387,12 @@ defmodule ExDoc.Retriever do
 
     type_data = module_data.language.type_data(type_entry, module_data)
 
+    metadata =
+      Map.merge(
+        %{kind: kind, name: name, arity: arity, module: module_data.module},
+        metadata
+      )
+
     source_url =
       source_link(type_data[:source_file], source, type_data.source_line)
 
@@ -401,10 +410,7 @@ defmodule ExDoc.Retriever do
     group =
       GroupMatcher.match_function(
         groups_for_docs,
-        Map.merge(
-          %{kind: kind, name: name, arity: arity, module: module_data.module},
-          metadata
-        )
+        metadata
       )
 
     %ExDoc.TypeNode{

--- a/lib/ex_doc/utils.ex
+++ b/lib/ex_doc/utils.ex
@@ -31,6 +31,22 @@ defmodule ExDoc.Utils do
   end
 
   @doc """
+  Runs the `before_closing_footer_tag` callback.
+  """
+  def before_closing_footer_tag(%{before_closing_footer_tag: {m, f, a}}, module) do
+    apply(m, f, [module | a])
+  end
+
+  def before_closing_footer_tag(%{before_closing_footer_tag: before_closing_footer_tag}, module)
+      when is_map(before_closing_footer_tag) do
+    Map.get(before_closing_footer_tag, module, "")
+  end
+
+  def before_closing_footer_tag(%{before_closing_footer_tag: before_closing_footer_tag}, module) do
+    before_closing_footer_tag.(module)
+  end
+
+  @doc """
   Runs the `before_closing_body_tag` callback.
   """
   def before_closing_body_tag(%{before_closing_body_tag: {m, f, a}}, module) do

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -62,7 +62,9 @@ defmodule Mix.Tasks.Docs do
   be lazily executed.
 
     * `:annotations_for_docs` - a function that receives metadata and returns a list
-      of annotations to be added to the signature.
+      of annotations to be added to the signature. The metadata received will also
+      contain `:module`, `:name`, `:arity` and `:kind` to help identify which entity is
+      currently being processed.
 
     * `:api_reference` - Whether to generate `api-reference.html`; default: `true`.
       If this is set to false, `:main` must also be set.

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -85,6 +85,12 @@ defmodule Mix.Tasks.Docs do
       The atom given as argument can be used to include different content in both formats.
       Useful to inject custom assets, such as CSS stylesheets.
 
+    * `:before_closing_footer_tag` - a function that takes as argument an atom specifying
+      the formatter being used (`:html`) and returns a literal HTML string
+      to be included just before the closing footer tag (`</footer>`).
+      This option only has effect on the html formatter.
+      Useful if you want to inject an extra footer into the documentation.
+
     * `:canonical` - String that defines the preferred URL with the rel="canonical"
       element; defaults to no canonical path.
 

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -13,12 +13,15 @@ defmodule ExDoc.Formatter.HTMLTest do
 
   @before_closing_head_tag_content_html "UNIQUE:<dont-escape>&copy;BEFORE-CLOSING-HEAD-TAG-EPUB</dont-escape>"
   @before_closing_body_tag_content_html "UNIQUE:<dont-escape>&copy;BEFORE-CLOSING-BODY-TAG-EPUB</dont-escape>"
+  @before_closing_footer_tag_content_html "UNIQUE:<dont-escape>&copy;BEFORE-CLOSING-FOOTER-TAG-EPUB</dont-escape>"
 
   defp before_closing_head_tag(:html), do: @before_closing_head_tag_content_html
   defp before_closing_body_tag(:html), do: @before_closing_body_tag_content_html
+  defp before_closing_footer_tag(:html), do: @before_closing_footer_tag_content_html
 
   def before_closing_head_tag(:html, name), do: "<meta name=#{name}>"
   def before_closing_body_tag(:html, name), do: "<p>#{name}</p>"
+  def before_closing_footer_tag(:html, name), do: "<p>#{name}</p>"
 
   defp doc_config(%{tmp_dir: tmp_dir} = _context) do
     [
@@ -654,18 +657,21 @@ defmodule ExDoc.Formatter.HTMLTest do
       generate_docs(
         doc_config(context,
           before_closing_head_tag: %{html: "<meta name=StaticDemo>"},
-          before_closing_body_tag: %{html: "<p>StaticDemo</p>"},
+          before_closing_body_tag: %{html: "<p>StaticBodyDemo</p>"},
+          before_closing_footer_tag: %{html: "<p>StaticFooterDemo</p>"},
           extras: ["test/fixtures/README.md"]
         )
       )
 
       content = File.read!(tmp_dir <> "/html/api-reference.html")
       assert content =~ ~r[<meta name=StaticDemo>\s*</head>]
-      assert content =~ ~r[<p>StaticDemo</p>\s*</body>]
+      assert content =~ ~r[<p>StaticBodyDemo</p>\s*</body>]
+      assert content =~ ~r[<p>StaticFooterDemo</p>\s*</footer>]
 
       content = File.read!(tmp_dir <> "/html/readme.html")
       assert content =~ ~r[<meta name=StaticDemo>\s*</head>]
-      assert content =~ ~r[<p>StaticDemo</p>\s*</body>]
+      assert content =~ ~r[<p>StaticBodyDemo</p>\s*</body>]
+      assert content =~ ~r[<p>StaticFooterDemo</p>\s*</footer>]
     end
 
     test "before_closing_*_tags required by the user are placed in the right place using MFA",
@@ -675,18 +681,21 @@ defmodule ExDoc.Formatter.HTMLTest do
       generate_docs(
         doc_config(context,
           before_closing_head_tag: {__MODULE__, :before_closing_head_tag, ["Demo"]},
-          before_closing_body_tag: {__MODULE__, :before_closing_body_tag, ["Demo"]},
+          before_closing_body_tag: {__MODULE__, :before_closing_body_tag, ["BodyDemo"]},
+          before_closing_footer_tag: {__MODULE__, :before_closing_footer_tag, ["FooterDemo"]},
           extras: ["test/fixtures/README.md"]
         )
       )
 
       content = File.read!(tmp_dir <> "/html/api-reference.html")
       assert content =~ ~r[<meta name=Demo>\s*</head>]
-      assert content =~ ~r[<p>Demo</p>\s*</body>]
+      assert content =~ ~r[<p>BodyDemo</p>\s*</body>]
+      assert content =~ ~r[<p>FooterDemo</p>\s*</footer>]
 
       content = File.read!(tmp_dir <> "/html/readme.html")
       assert content =~ ~r[<meta name=Demo>\s*</head>]
-      assert content =~ ~r[<p>Demo</p>\s*</body>]
+      assert content =~ ~r[<p>BodyDemo</p>\s*</body>]
+      assert content =~ ~r[<p>FooterDemo</p>\s*</footer>]
     end
 
     test "before_closing_*_tags required by the user are placed in the right place",
@@ -697,6 +706,7 @@ defmodule ExDoc.Formatter.HTMLTest do
         doc_config(context,
           before_closing_head_tag: &before_closing_head_tag/1,
           before_closing_body_tag: &before_closing_body_tag/1,
+          before_closing_footer_tag: &before_closing_footer_tag/1,
           extras: ["test/fixtures/README.md"]
         )
       )
@@ -704,10 +714,12 @@ defmodule ExDoc.Formatter.HTMLTest do
       content = File.read!(tmp_dir <> "/html/api-reference.html")
       assert content =~ ~r[#{@before_closing_head_tag_content_html}\s*</head>]
       assert content =~ ~r[#{@before_closing_body_tag_content_html}\s*</body>]
+      assert content =~ ~r[#{@before_closing_footer_tag_content_html}\s*</footer>]
 
       content = File.read!(tmp_dir <> "/html/readme.html")
       assert content =~ ~r[#{@before_closing_head_tag_content_html}\s*</head>]
       assert content =~ ~r[#{@before_closing_body_tag_content_html}\s*</body>]
+      assert content =~ ~r[#{@before_closing_footer_tag_content_html}\s*</footer>]
     end
   end
 

--- a/test/ex_doc/language/erlang_test.exs
+++ b/test/ex_doc/language/erlang_test.exs
@@ -479,6 +479,28 @@ defmodule ExDoc.Language.ErlangTest do
              ) =~ ~r/documentation references "e:extra.md" but it is invalid/
     end
 
+    test "linking to unknown application does not work", c do
+      assert warn(
+               fn ->
+                 assert autolink_doc("[extra](`e:barlib:extra.md`)", c) ==
+                          ~s|<a href=\"https://hexdocs.pm/barlib/extra.html\">extra</a>|
+               end,
+               line: nil
+             ) =~
+               ~r/documentation references "e:barlib:extra.md" but barlib cannot be found in deps/
+    end
+
+    test "linking to unknown application with anchor does not work", c do
+      assert warn(
+               fn ->
+                 assert autolink_doc("[extra](`e:barlib:extra.md#anchor`)", c) ==
+                          ~s|<a href=\"https://hexdocs.pm/barlib/extra.html#anchor\">extra</a>|
+               end,
+               line: nil
+             ) =~
+               ~r/documentation references "e:barlib:extra.md#anchor" but barlib cannot be found in deps/
+    end
+
     test "filtered module", c do
       opts = [filtered_modules: [%ExDoc.ModuleNode{module: :lists, id: "lists"}]]
 


### PR DESCRIPTION
This PR does two things:

1. Adds `before_closing_footer_tag` config option for html formatter to insert a custom footer. We use it to insert a copyright notice at the end of each page.
2. Add kmfa to the metadata before calling `annotations_for_docs` so that the fun doing the processing knows which entry it is currently working with. We use this to classify functions/types into different categories, such as built-in/predefined.

and as a bonus it also adds a warning for when an `extra` that is not in deps is referenced in a link.