### PR TITLE
Hide search bar when printing

### DIFF
--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -8,6 +8,10 @@
     display: none;
   }
 
+  .top-search {
+    display: none;
+  }
+
   .content {
     padding-left: 0;
     overflow: visible;


### PR DESCRIPTION
Noticed this when trying to print a cheatsheet, though it should apply to printing any documentation page as we cannot use it to search on paper / PDF :)