### PR TITLE
Add `equiv` handling for types and callbacks for Erlang

### DIFF
--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -342,8 +342,8 @@ defmodule ExDoc.Retriever do
         callback_data.extra_annotations ++ annotations_from_metadata(metadata, module_metadata)
 
     doc_ast =
-      (source_doc && doc_ast(content_type, source_doc, file: doc_file, line: doc_line + 1)) ||
-        (callback_data[:doc_fallback] && callback_data.doc_fallback.())
+      doc_ast(content_type, source_doc, file: doc_file, line: doc_line + 1) ||
+        doc_fallback(callback_data)
 
     group =
       GroupMatcher.match_function(
@@ -404,8 +404,8 @@ defmodule ExDoc.Retriever do
         type_data.extra_annotations
 
     doc_ast =
-      (source_doc && doc_ast(content_type, source_doc, file: doc_file, line: doc_line + 1)) ||
-        (type_data[:doc_fallback] && type_data.doc_fallback.())
+      doc_ast(content_type, source_doc, file: doc_file, line: doc_line + 1) ||
+        doc_fallback(type_data)
 
     group =
       GroupMatcher.match_function(
@@ -432,6 +432,10 @@ defmodule ExDoc.Retriever do
   end
 
   ## General helpers
+
+  defp doc_fallback(data) do
+    data[:doc_fallback] && data.doc_fallback.()
+  end
 
   defp nil_or_name(name, arity) do
     if name == nil do

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -341,7 +341,9 @@ defmodule ExDoc.Retriever do
       annotations_for_docs.(metadata) ++
         callback_data.extra_annotations ++ annotations_from_metadata(metadata, module_metadata)
 
-    doc_ast = doc_ast(content_type, source_doc, file: doc_file, line: doc_line + 1)
+    doc_ast =
+      (source_doc && doc_ast(content_type, source_doc, file: doc_file, line: doc_line + 1)) ||
+        (callback_data[:doc_fallback] && callback_data.doc_fallback.())
 
     group =
       GroupMatcher.match_function(
@@ -401,7 +403,9 @@ defmodule ExDoc.Retriever do
         annotations_from_metadata(metadata, module_metadata) ++
         type_data.extra_annotations
 
-    doc_ast = doc_ast(content_type, source_doc, file: doc_file, line: doc_line + 1)
+    doc_ast =
+      (source_doc && doc_ast(content_type, source_doc, file: doc_file, line: doc_line + 1)) ||
+        (type_data[:doc_fallback] && type_data.doc_fallback.())
 
     group =
       GroupMatcher.match_function(

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -245,7 +245,9 @@ defmodule Mix.Tasks.Docs do
   Functions and callbacks inside a module can also be organized in groups.
   This is done via the `:groups_for_docs` configuration which is a
   keyword list of group titles and filtering functions that receive the
-  documentation metadata of functions as argument.
+  documentation metadata of functions as argument. The metadata received will also
+  contain `:module`, `:name`, `:arity` and `:kind` to help identify which entity is
+  currently being processed.
 
   For example, imagine that you have an API client library with a large surface
   area for all the API endpoints you need to support. It would be helpful to


### PR DESCRIPTION
This PR adds `equiv` handling for types and callbacks to the Erlang mode by adding `doc_fallback` support to the retriever for types and callbacks. 

Also sneaking in a doc fix to describe keys available in metadata in `groups_for_*` functions.