### PR TITLE
Make a function acceptable for :skip_code_autolink_to option

### DIFF
--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -26,7 +26,8 @@ defmodule ExDoc.Autolink do
   #
   # * `:skip_undefined_reference_warnings_on` - list of modules to skip the warning on
   #
-  # * `:skip_code_autolink_to` - list of terms that will be skipped when autolinking (e.g: "PrivateModule")
+  # * `:skip_code_autolink_to` - function that will be called with a term and return a boolean
+  #    whether to skip autolinking to it.
   #
   # * `:filtered_modules` - A list of module nodes that were filtered by the retriever
   #
@@ -54,7 +55,7 @@ defmodule ExDoc.Autolink do
     current_kfa: nil,
     siblings: [],
     skip_undefined_reference_warnings_on: [],
-    skip_code_autolink_to: [],
+    skip_code_autolink_to: &ExDoc.Config.skip_code_autolink_to/1,
     force_module_prefix: nil,
     filtered_modules: [],
     warnings: :emit
@@ -201,7 +202,7 @@ defmodule ExDoc.Autolink do
   end
 
   def url(string, mode, config) do
-    if Enum.any?(config.skip_code_autolink_to, &(&1 == string)) do
+    if config.skip_code_autolink_to.(string) do
       nil
     else
       parse_url(string, mode, config)

--- a/lib/ex_doc/language/erlang.ex
+++ b/lib/ex_doc/language/erlang.ex
@@ -631,7 +631,7 @@ defmodule ExDoc.Language.Erlang do
             visibility = Refs.get_visibility(ref)
 
             cond do
-              Enum.any?(config.skip_code_autolink_to, &(&1 == "t:#{name}/#{arity}")) ->
+              config.skip_code_autolink_to.("t:#{name}/#{arity}") ->
                 nil
 
               visibility in [:public] ->
@@ -657,7 +657,7 @@ defmodule ExDoc.Language.Erlang do
             visibility = Refs.get_visibility(ref)
 
             cond do
-              Enum.any?(config.skip_code_autolink_to, &(&1 == "t:#{module}:#{name}/#{arity}")) ->
+              config.skip_code_autolink_to.("t:#{module}:#{name}/#{arity}") ->
                 nil
 
               visibility in [:public] ->

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -157,9 +157,10 @@ defmodule Mix.Tasks.Docs do
 
     * `:skip_code_autolink_to` - Similar to `:skip_undefined_reference_warnings_on`, this option
       controls which terms will be skipped by ExDoc when building documentation.
-      Useful for example if you want to highlight private modules or functions
-      without warnings (e.g.: `["PrivateModule", "PrivateModule.func/1"]`);
-      default: `[]`.
+      Useful for example if you want to highlight private modules or functions without warnings.
+      This option can be a function from a term to a boolean (e.g.: `&String.match?(&1, ~r/PrivateModule/)`
+      or a list of terms (e.g.:`["PrivateModule", "PrivateModule.func/1"]`);
+      default is nothing to be skipped.
 
     * `:source_beam` - Path to the beam directory; default: mix's compile path.
 

--- a/test/ex_doc/config_test.exs
+++ b/test/ex_doc/config_test.exs
@@ -30,4 +30,28 @@ defmodule ExDoc.ConfigTest do
     assert config.filter_modules.(Foo, %{works: true})
     refute config.filter_modules.(Foo, %{works: false})
   end
+
+  test "normalizes skip_code_autolink_to" do
+    config =
+      ExDoc.Config.build(@project, @version,
+        skip_code_autolink_to: ["ConfigTest.Hidden", "ConfigTest.Hidden.foo/1"]
+      )
+
+    assert config.skip_code_autolink_to.("ConfigTest.Hidden")
+    assert config.skip_code_autolink_to.("ConfigTest.Hidden.foo/1")
+    refute config.skip_code_autolink_to.("ConfigTest.Hidden.foo/2")
+    refute config.skip_code_autolink_to.("ConfigTest.Hidden.bar/1")
+    refute config.skip_code_autolink_to.("ConfigTest.NotHidden")
+
+    config =
+      ExDoc.Config.build(@project, @version,
+        skip_code_autolink_to: &String.match?(&1, ~r/\AConfigTest\.Hidden/)
+      )
+
+    assert config.skip_code_autolink_to.("ConfigTest.Hidden")
+    assert config.skip_code_autolink_to.("ConfigTest.Hidden.foo/1")
+    assert config.skip_code_autolink_to.("ConfigTest.Hidden.foo/2")
+    assert config.skip_code_autolink_to.("ConfigTest.Hidden.bar/1")
+    refute config.skip_code_autolink_to.("ConfigTest.NotHidden")
+  end
 end

--- a/test/ex_doc/language/elixir_test.exs
+++ b/test/ex_doc/language/elixir_test.exs
@@ -425,10 +425,7 @@ defmodule ExDoc.Language.ElixirTest do
       ])
 
       options = [
-        skip_code_autolink_to: [
-          "AutolinkTest.Hidden",
-          "AutolinkTest.Hidden.foo/1"
-        ]
+        skip_code_autolink_to: &String.match?(&1, ~r/\AAutolinkTest\.Hidden/)
       ]
 
       assert autolink_doc("`AutolinkTest.Hidden`", options) ==


### PR DESCRIPTION
Currently, the `:skip_code_autolink_to` option only accepts a list.
This approach becomes impractical when dealing with a large number of terms.

For example, I'm working on a project where some hidden modules are automatically defined, and some documentation tries to link to those modules (to be precise, types defined in those modules).
My problem there is that the number of those terms is too many to list in `:skip_code_autolink_to` option.

So it is useful if `:skip_code_autolink_to` option accepts regular expressions or, more flexibly, a function.
I choose the function approach as it aligns with the discussion in https://github.com/elixir-lang/ex_doc/pull/1759#discussion_r1314751777.
(I'm pleased to implement the same feature for `:skip_undefined_reference_warnings_on` option if this PR is approved.)

As a caveat, because `ExDoc.Autolink` is internal (`@moduledoc false`), I just removed code that expects a list for the `skip_code_autolink_to` field.
Should I keep backward compatibility at `ExDoc.Autolink` level too?
