### PR TITLE
Make a function acceptable for :skip_undefined_reference_warnings_on option

### DIFF
--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -24,7 +24,8 @@ defmodule ExDoc.Autolink do
   #
   # * `:extras` - map of extras
   #
-  # * `:skip_undefined_reference_warnings_on` - list of modules to skip the warning on
+  # * `:skip_undefined_reference_warnings_on` - function that will be called with
+  #    a module/function/file/etc and return a boolean whether to skip warning on it.
   #
   # * `:skip_code_autolink_to` - function that will be called with a term and return a boolean
   #    whether to skip autolinking to it.
@@ -54,7 +55,7 @@ defmodule ExDoc.Autolink do
     ext: ".html",
     current_kfa: nil,
     siblings: [],
-    skip_undefined_reference_warnings_on: [],
+    skip_undefined_reference_warnings_on: &ExDoc.Config.skip_undefined_reference_warnings_on/1,
     skip_code_autolink_to: &ExDoc.Config.skip_code_autolink_to/1,
     force_module_prefix: nil,
     filtered_modules: [],
@@ -165,10 +166,12 @@ defmodule ExDoc.Autolink do
   end
 
   def maybe_warn(config, ref, visibility, metadata) do
-    skipped = config.skip_undefined_reference_warnings_on
     file = Path.relative_to_cwd(config.file)
 
-    unless Enum.any?([config.id, config.module_id, file], &(&1 in skipped)) do
+    unless Enum.any?(
+             [config.id, config.module_id, file],
+             config.skip_undefined_reference_warnings_on
+           ) do
       warn(config, ref, visibility, metadata)
     end
   end

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -153,12 +153,14 @@ defmodule Mix.Tasks.Docs do
     * `:skip_undefined_reference_warnings_on` - ExDoc warns when it can't create a `Mod.fun/arity`
       reference in the current project docs e.g. because of a typo. This list controls where to
       skip the warnings, for a given module/function/callback/type (e.g.: `["Foo", "Bar.baz/0"]`)
-      or on a given file (e.g.: `["pages/deprecations.md"]`); default: `[]`.
+      or on a given file (e.g.: `["pages/deprecations.md"]`). This option can also be a function
+      from a reference string to a boolean (e.g.: `&String.match?(&1, ~r/Foo/)`);
+      default is nothing to be skipped.
 
     * `:skip_code_autolink_to` - Similar to `:skip_undefined_reference_warnings_on`, this option
       controls which terms will be skipped by ExDoc when building documentation.
       Useful for example if you want to highlight private modules or functions without warnings.
-      This option can be a function from a term to a boolean (e.g.: `&String.match?(&1, ~r/PrivateModule/)`
+      This option can be a function from a term to a boolean (e.g.: `&String.match?(&1, ~r/PrivateModule/)`)
       or a list of terms (e.g.:`["PrivateModule", "PrivateModule.func/1"]`);
       default is nothing to be skipped.
 

--- a/test/ex_doc/config_test.exs
+++ b/test/ex_doc/config_test.exs
@@ -31,6 +31,26 @@ defmodule ExDoc.ConfigTest do
     refute config.filter_modules.(Foo, %{works: false})
   end
 
+  test "normalizes skip_undefined_reference_warnings_on" do
+    config =
+      ExDoc.Config.build(@project, @version,
+        skip_undefined_reference_warnings_on: ["Foo", "Bar.baz/0"]
+      )
+
+    assert config.skip_undefined_reference_warnings_on.("Foo")
+    assert config.skip_undefined_reference_warnings_on.("Bar.baz/0")
+    refute config.skip_undefined_reference_warnings_on.("Foo.bar/1")
+
+    config =
+      ExDoc.Config.build(@project, @version,
+        skip_undefined_reference_warnings_on: &String.match?(&1, ~r/Foo/)
+      )
+
+    assert config.skip_undefined_reference_warnings_on.("Foo")
+    refute config.skip_undefined_reference_warnings_on.("Bar.baz/0")
+    assert config.skip_undefined_reference_warnings_on.("Foo.bar/1")
+  end
+
   test "normalizes skip_code_autolink_to" do
     config =
       ExDoc.Config.build(@project, @version,

--- a/test/ex_doc/language/elixir_test.exs
+++ b/test/ex_doc/language/elixir_test.exs
@@ -668,7 +668,7 @@ defmodule ExDoc.Language.ElixirTest do
 
     opts = [
       warnings: :send,
-      skip_undefined_reference_warnings_on: ["MyModule"],
+      skip_undefined_reference_warnings_on: &(&1 in ["MyModule"]),
       module_id: "MyModule"
     ]
 


### PR DESCRIPTION
In https://github.com/elixir-lang/ex_doc/pull/1878, `:skip_code_autolink_to` option has been updated to accept a function.
For consistency, the `:skip_undefined_reference_warnings_on` option should also be enhanced to accept a function.
