### PR TITLE
Allow the modal to close when we click outside the modal content

### DIFF
--- a/assets/js/modal.js
+++ b/assets/js/modal.js
@@ -34,6 +34,15 @@ function renderModal () {
   qs(MODAL_CLOSE_BUTTON_SELECTOR).addEventListener('click', event => {
     closeModal()
   })
+
+  qs(MODAL_SELECTOR).addEventListener('click', event => {
+    const classList = event.target.classList
+    // if we clicked on the modal overlay/parent but not the modal content
+    if (classList.contains('modal') && classList.contains('shown') && classList.length === 2) {
+      closeModal()
+    }
+  })
+
 }
 
 /**

--- a/assets/js/modal.js
+++ b/assets/js/modal.js
@@ -42,7 +42,6 @@ function renderModal () {
       closeModal()
     }
   })
-
 }
 
 /**


### PR DESCRIPTION
With many modals when you click outside the content the modal should close. This is helpful in the scenario where you press the 'g' keyboard shortcut and want to close it. The only way we can do so right now is by clicking the 'X' on the modal. I think this makes things more consistent with standard modal UI experiences and is a nice utility to have.