### PR TITLE
fix: mix task regex didn't consider tasks with underscores

### DIFF
--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -250,7 +250,7 @@ defmodule ExDoc.Autolink do
 
   defp mix_task(name, string, mode, config) do
     {module, url, visibility} =
-      if name =~ ~r/^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)*$/ do
+      if name =~ ~r/^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*$/ do
         parts = name |> String.split(".") |> Enum.map(&Macro.camelize/1)
         module = Module.concat([Mix, Tasks | parts])
 

--- a/test/ex_doc/language/elixir_test.exs
+++ b/test/ex_doc/language/elixir_test.exs
@@ -214,6 +214,9 @@ defmodule ExDoc.Language.ElixirTest do
       assert autolink_doc("`mix compile.elixir`") ==
                ~s|<a href="https://hexdocs.pm/mix/Mix.Tasks.Compile.Elixir.html"><code class="inline">mix compile.elixir</code></a>|
 
+      assert autolink_doc("`mix task_with_docs`") ==
+               ~s|<a href=\"Mix.Tasks.TaskWithDocs.html\"><code class=\"inline\">mix task_with_docs</code></a>|
+
       assert autolink_doc("`mix help compile.elixir`") ==
                ~s|<a href="https://hexdocs.pm/mix/Mix.Tasks.Compile.Elixir.html"><code class="inline">mix help compile.elixir</code></a>|
 


### PR DESCRIPTION
`mix ash_phoenix.gen.live` was not auto-linked, but it is now