### PR TITLE
Make light theme sidebar light

### DIFF
--- a/assets/css/custom-props/theme-light.css
+++ b/assets/css/custom-props/theme-light.css
@@ -76,18 +76,18 @@
                                                  var(--white) 20%,
                                                  var(--white-opacity-50) 70%,
                                                  var(--white-opacity-0) 100%);
-  --sidebarAccentMain:           var(--gray50);
-  --sidebarBackground:           var(--gray800);
-  --sidebarHeader:               var(--gray700);
-  --sidebarMuted:                var(--gray300);
-  --sidebarHover:                var(--white);
-  --sidebarScrollbarThumb:       var(--coldGray);
+  --sidebarAccentMain:           var(--gray800);
+  --sidebarBackground:           var(--gray50);
+  --sidebarHeader:               var(--gray100);
+  --sidebarMuted:                var(--gray600);
+  --sidebarHover:                var(--black);
+  --sidebarScrollbarThumb:       var(--coldGrayLight);
   --sidebarScrollbarTrack:       var(--sidebarBackground);
-  --sidebarSubheadings:          var(--gray400);
-  --sidebarItem:                 var(--gray200);
-  --sidebarInactiveItemMarker:   var(--gray600);
-  --sidebarLanguageAccentBar:    var(--mainLight);
-  --sidebarActiveItem:           var(--mainLightest);
+  --sidebarSubheadings:          var(--gray800);
+  --sidebarItem:                 var(--gray600);
+  --sidebarInactiveItemMarker:   var(--gray300);
+  --sidebarLanguageAccentBar:    var(--mainDark);
+  --sidebarActiveItem:           var(--mainDarkest);
   --searchBarBorder:             var(--gray200);
   --searchAccentMain:            var(--gray-400);
   --searchLanguageAccentBar:     var(--main);

--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -152,8 +152,8 @@
 }
 
 .sidebar .sidebar-listNav li:is(:hover):not(.selected) button {
-  background-color: var(--gray600);
-  border-top: var(--navTabBorderWidth) solid var(--gray400);
+  background-color: var(--sidebarInactiveItemMarker);
+  border-top: var(--navTabBorderWidth) solid var(--sidebarSubheadings);
   color: var(--sidebarAccentMain);
   transition: all 150ms;
 }


### PR DESCRIPTION
As proposed in [Truly light theme](https://github.com/elixir-lang/ex_doc/issues/1900) issue, I updated the light theme stylesheets so the sidebar coloring is dark text on light background.

I used only already existing color variables.
I had to change `sidebar.css`, because inactive navigation tabs were styled with non-themed variables for hover.

resolves #1900 