### PR TITLE
replace OTP /man/ links with /apps/:app/

### DIFF
--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -65,40 +65,19 @@ defmodule ExDoc.Autolink do
   @hexdocs "https://hexdocs.pm/"
   @otpappdocs "https://www.erlang.org/doc/apps/"
 
-  def app_module_url(tool, module, anchor \\ nil, config)
+  def app_module_url(tool, module, anchor \\ "#content", config)
 
-  def app_module_url(:ex_doc, module, nil, %{current_module: module} = config) do
-    app_module_url(:ex_doc, module, "#content", config)
-  end
+  def app_module_url(:no_tool, _, _, _), do: nil
 
-  def app_module_url(:ex_doc, module, anchor, config) do
+  def app_module_url(tool, module, anchor, config) do
+    base_url =
+      case tool do
+        :ex_doc -> @hexdocs
+        :otp -> @otpappdocs
+      end
+
     path = module |> inspect() |> String.trim_leading(":")
-    ex_doc_app_url(module, config, path, config.ext, "#{anchor}")
-  end
-
-  def app_module_url(:otp, module, nil, %{current_module: module} = config) do
-    app_module_url(:otp, module, "#content", config)
-  end
-
-  def app_module_url(:otp, module, anchor, config) do
-    path = module |> inspect() |> String.trim_leading(":")
-
-    # IO.inspect(
-    #   [
-    #     module: module,
-    #     anchor: anchor,
-    #     config: config,
-    #     prev: @otpdocs <> "#{module}.html#{anchor}",
-    #     new: app_url(@otpappdocs, module, config, path, config.ext, "#{anchor}")
-    #   ],
-    #   label: "app_module_url"
-    # )
-
-    app_url(@otpappdocs, module, config, path, config.ext, "#{anchor}")
-  end
-
-  def app_module_url(:no_tool, _, _, _) do
-    nil
+    app_url(base_url, module, config, path, config.ext, "#{anchor}")
   end
 
   defp string_app_module_url(string, tool, module, anchor, config) do

--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -63,7 +63,6 @@ defmodule ExDoc.Autolink do
   ]
 
   @hexdocs "https://hexdocs.pm/"
-  @otpdocs "https://www.erlang.org/doc/man/"
   @otpappdocs "https://www.erlang.org/doc/apps/"
 
   def app_module_url(tool, module, anchor \\ nil, config)
@@ -72,18 +71,30 @@ defmodule ExDoc.Autolink do
     app_module_url(:ex_doc, module, "#content", config)
   end
 
-  def app_module_url(:ex_doc, module, anchor, %{current_module: module} = config) do
-    path = module |> inspect() |> String.trim_leading(":")
-    ex_doc_app_url(module, config, path, config.ext, "#{anchor}")
-  end
-
   def app_module_url(:ex_doc, module, anchor, config) do
     path = module |> inspect() |> String.trim_leading(":")
     ex_doc_app_url(module, config, path, config.ext, "#{anchor}")
   end
 
-  def app_module_url(:otp, module, anchor, _config) do
-    @otpdocs <> "#{module}.html#{anchor}"
+  def app_module_url(:otp, module, nil, %{current_module: module} = config) do
+    app_module_url(:otp, module, "#content", config)
+  end
+
+  def app_module_url(:otp, module, anchor, config) do
+    path = module |> inspect() |> String.trim_leading(":")
+
+    # IO.inspect(
+    #   [
+    #     module: module,
+    #     anchor: anchor,
+    #     config: config,
+    #     prev: @otpdocs <> "#{module}.html#{anchor}",
+    #     new: app_url(@otpappdocs, module, config, path, config.ext, "#{anchor}")
+    #   ],
+    #   label: "app_module_url"
+    # )
+
+    app_url(@otpappdocs, module, config, path, config.ext, "#{anchor}")
   end
 
   def app_module_url(:no_tool, _, _, _) do
@@ -109,12 +120,16 @@ defmodule ExDoc.Autolink do
 
   @doc false
   def ex_doc_app_url(module, config, path, ext, suffix) do
+    app_url(@hexdocs, module, config, path, ext, suffix)
+  end
+
+  defp app_url(base_url, module, config, path, ext, suffix) do
     if app = app(module) do
       if app in config.apps do
         path <> ext <> suffix
       else
         config.deps
-        |> Keyword.get_lazy(app, fn -> @hexdocs <> "#{app}" end)
+        |> Keyword.get_lazy(app, fn -> base_url <> "#{app}" end)
         |> String.trim_trailing("/")
         |> Kernel.<>("/" <> path <> ".html" <> suffix)
       end

--- a/test/ex_doc/formatter/html/erlang_test.exs
+++ b/test/ex_doc/formatter/html/erlang_test.exs
@@ -36,10 +36,10 @@ defmodule ExDoc.Formatter.HTML.ErlangTest do
              ~s|-spec</span> foo(<a href=\"#t:t/0\">t</a>()) -&gt; <a href=\"#t:t/0\">t</a>().|
 
     assert html =~
-             ~s|-type</span> t() :: <a href=\"https://www.erlang.org/doc/man/erlang.html#t:atom/0\">atom</a>().|
+             ~s|-type</span> t() :: <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:atom/0\">atom</a>().|
 
     assert html =~
-             ~s|-type</span> t2() :: #rec{k1 :: <a href=\"https://www.erlang.org/doc/man/uri_string.html#t:uri_string/0\">uri_string:uri_string</a>(), k2 :: <a href=\"https://www.erlang.org/doc/man/uri_string.html#t:uri_string/0\">uri_string:uri_string</a>() \| undefined}.|
+             ~s|-type</span> t2() :: #rec{k1 :: <a href=\"https://www.erlang.org/doc/apps/stdlib/uri_string.html#t:uri_string/0\">uri_string:uri_string</a>(), k2 :: <a href=\"https://www.erlang.org/doc/apps/stdlib/uri_string.html#t:uri_string/0\">uri_string:uri_string</a>() \| undefined}.|
   end
 
   defp generate_docs(c) do

--- a/test/ex_doc/formatter/html/erlang_test.exs
+++ b/test/ex_doc/formatter/html/erlang_test.exs
@@ -33,13 +33,13 @@ defmodule ExDoc.Formatter.HTML.ErlangTest do
     html = Floki.raw_html(doc)
 
     assert html =~
-             ~s|-spec</span> foo(<a href=\"#t:t/0\">t</a>()) -&gt; <a href=\"#t:t/0\">t</a>().|
+             ~s|-spec</span> foo(<a href="#t:t/0">t</a>()) -&gt; <a href="#t:t/0">t</a>().|
 
     assert html =~
-             ~s|-type</span> t() :: <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:atom/0\">atom</a>().|
+             ~s|-type</span> t() :: <a href="https://www.erlang.org/doc/apps/erts/erlang.html#t:atom/0">atom</a>().|
 
     assert html =~
-             ~s|-type</span> t2() :: #rec{k1 :: <a href=\"https://www.erlang.org/doc/apps/stdlib/uri_string.html#t:uri_string/0\">uri_string:uri_string</a>(), k2 :: <a href=\"https://www.erlang.org/doc/apps/stdlib/uri_string.html#t:uri_string/0\">uri_string:uri_string</a>() \| undefined}.|
+             ~s|-type</span> t2() :: #rec{k1 :: <a href="https://www.erlang.org/doc/apps/stdlib/uri_string.html#t:uri_string/0">uri_string:uri_string</a>(), k2 :: <a href="https://www.erlang.org/doc/apps/stdlib/uri_string.html#t:uri_string/0">uri_string:uri_string</a>() \| undefined}.|
   end
 
   defp generate_docs(c) do

--- a/test/ex_doc/language/elixir_test.exs
+++ b/test/ex_doc/language/elixir_test.exs
@@ -40,12 +40,12 @@ defmodule ExDoc.Language.ElixirTest do
 
     test "m:module with Erlang module" do
       assert autolink_doc("`m::array`") ==
-               ~s|<a href="https://www.erlang.org/doc/man/array.html"><code class="inline">:array</code></a>|
+               ~s|<a href="https://www.erlang.org/doc/apps/stdlib/array.html"><code class="inline">:array</code></a>|
     end
 
     test "m:module with Erlang module and fragment" do
       assert autolink_doc("`m::array#fragment`") ==
-               ~s|<a href="https://www.erlang.org/doc/man/array.html#fragment"><code class="inline">:array</code></a>|
+               ~s|<a href="https://www.erlang.org/doc/apps/stdlib/array.html#fragment"><code class="inline">:array</code></a>|
     end
 
     test "module with fragment without m: does not link" do
@@ -99,7 +99,7 @@ defmodule ExDoc.Language.ElixirTest do
 
     test "erlang stdlib function" do
       assert autolink_doc("`:lists.all/2`") ==
-               ~s|<a href="https://www.erlang.org/doc/man/lists.html#all/2"><code class="inline">:lists.all/2</code></a>|
+               ~s|<a href="https://www.erlang.org/doc/apps/stdlib/lists.html#all/2"><code class="inline">:lists.all/2</code></a>|
     end
 
     test "local function" do
@@ -150,7 +150,7 @@ defmodule ExDoc.Language.ElixirTest do
 
     test "erlang callback" do
       assert autolink_doc("`c::gen_server.handle_call/3`") ==
-               ~s|<a href="https://www.erlang.org/doc/man/gen_server.html#c:handle_call/3"><code class="inline">:gen_server.handle_call/3</code></a>|
+               ~s|<a href="https://www.erlang.org/doc/apps/stdlib/gen_server.html#c:handle_call/3"><code class="inline">:gen_server.handle_call/3</code></a>|
     end
 
     test "elixir type" do
@@ -171,7 +171,7 @@ defmodule ExDoc.Language.ElixirTest do
 
     test "erlang type" do
       assert autolink_doc("`t::array.array/0`") ==
-               ~s|<a href="https://www.erlang.org/doc/man/array.html#t:array/0"><code class="inline">:array.array/0</code></a>|
+               ~s|<a href="https://www.erlang.org/doc/apps/stdlib/array.html#t:array/0"><code class="inline">:array.array/0</code></a>|
     end
 
     test "special forms" do
@@ -204,10 +204,10 @@ defmodule ExDoc.Language.ElixirTest do
                ~s|<a href="https://hexdocs.pm/elixir/String.html#at/2">custom text</a>|
 
       assert autolink_doc("[custom text](`:lists`)") ==
-               ~s|<a href="https://www.erlang.org/doc/man/lists.html">custom text</a>|
+               ~s|<a href="https://www.erlang.org/doc/apps/stdlib/lists.html">custom text</a>|
 
       assert autolink_doc("[custom text](`:lists.all/2`)") ==
-               ~s|<a href="https://www.erlang.org/doc/man/lists.html#all/2">custom text</a>|
+               ~s|<a href="https://www.erlang.org/doc/apps/stdlib/lists.html#all/2">custom text</a>|
     end
 
     test "mix task" do
@@ -450,7 +450,7 @@ defmodule ExDoc.Language.ElixirTest do
 
     test "Erlang stdlib types" do
       assert autolink_spec(quote(do: t() :: :sets.set())) ==
-               ~s[t() :: <a href="https://www.erlang.org/doc/man/sets.html#t:set/0">:sets.set</a>()]
+               ~s[t() :: <a href="https://www.erlang.org/doc/apps/stdlib/sets.html#t:set/0">:sets.set</a>()]
     end
 
     test "escape special HTML characters" do

--- a/test/ex_doc/language/erlang_test.exs
+++ b/test/ex_doc/language/erlang_test.exs
@@ -20,7 +20,7 @@ defmodule ExDoc.Language.ErlangTest do
 
     test "OTP module", c do
       assert autolink_edoc("{@link array}", c) ==
-               ~s|<a href="https://www.erlang.org/doc/man/array.html"><code>array</code></a>|
+               ~s|<a href="https://www.erlang.org/doc/apps/stdlib/array.html"><code>array</code></a>|
     end
 
     test "OTP module when generating OTP docs", c do
@@ -30,7 +30,7 @@ defmodule ExDoc.Language.ErlangTest do
 
     test "app module", c do
       assert autolink_edoc("{@link //stdlib/array}", c) ==
-               ~s|<a href="https://www.erlang.org/doc/man/array.html"><code>array</code></a>|
+               ~s|<a href="https://www.erlang.org/doc/apps/stdlib/array.html"><code>array</code></a>|
     end
 
     @tag warnings: :send
@@ -57,19 +57,19 @@ defmodule ExDoc.Language.ErlangTest do
          [{:code, [], ["array"], %{}}], %{}}
 
       assert do_autolink_doc(ast) ==
-               ~s|<a href="https://www.erlang.org/doc/man/array.html#anchor"><code>array</code></a>|
+               ~s|<a href="https://www.erlang.org/doc/apps/stdlib/array.html#anchor"><code>array</code></a>|
 
       ast =
         {:a, [href: "stdlib:array#anchor", rel: "https://erlang.org/doc/link/seeerl"],
          [{:code, [], ["array"], %{}}], %{}}
 
       assert do_autolink_doc(ast) ==
-               ~s|<a href="https://www.erlang.org/doc/man/array.html#anchor"><code>array</code></a>|
+               ~s|<a href="https://www.erlang.org/doc/apps/stdlib/array.html#anchor"><code>array</code></a>|
     end
 
     test "custom text", c do
       assert autolink_edoc("{@link array. The <code>array</code> module}", c) ==
-               ~s|<a href="https://www.erlang.org/doc/man/array.html">The <code>array</code> module</a>|
+               ~s|<a href="https://www.erlang.org/doc/apps/stdlib/array.html">The <code>array</code> module</a>|
     end
 
     test "local function", c do
@@ -84,7 +84,7 @@ defmodule ExDoc.Language.ErlangTest do
 
     test "OTP function", c do
       assert autolink_edoc("{@link array:new/0}", c) ==
-               ~s|<a href="https://www.erlang.org/doc/man/array.html#new/0"><code>array:new/0</code></a>|
+               ~s|<a href="https://www.erlang.org/doc/apps/stdlib/array.html#new/0"><code>array:new/0</code></a>|
     end
 
     test "OTP function when generating OTP docs", c do
@@ -99,12 +99,12 @@ defmodule ExDoc.Language.ErlangTest do
 
     test "ERTS function", c do
       assert autolink_edoc("{@link zlib:gunzip/1}", c) ==
-               ~s|<a href="https://www.erlang.org/doc/man/zlib.html#gunzip/1"><code>zlib:gunzip/1</code></a>|
+               ~s|<a href="https://www.erlang.org/doc/apps/erts/zlib.html#gunzip/1"><code>zlib:gunzip/1</code></a>|
     end
 
     test "app function", c do
       assert autolink_edoc("{@link //stdlib/array:new/0}", c) ==
-               ~s|<a href="https://www.erlang.org/doc/man/array.html#new/0"><code>array:new/0</code></a>|
+               ~s|<a href="https://www.erlang.org/doc/apps/stdlib/array.html#new/0"><code>array:new/0</code></a>|
     end
 
     test "external function", c do
@@ -124,12 +124,12 @@ defmodule ExDoc.Language.ErlangTest do
 
     test "OTP type", c do
       assert autolink_edoc("{@link array:array()}", c) ==
-               ~s|<a href="https://www.erlang.org/doc/man/array.html#t:array/0"><code>array:array()</code></a>|
+               ~s|<a href="https://www.erlang.org/doc/apps/stdlib/array.html#t:array/0"><code>array:array()</code></a>|
     end
 
     test "app type", c do
       assert autolink_edoc("{@link //stdlib/array:array()}", c) ==
-               ~s|<a href="https://www.erlang.org/doc/man/array.html#t:array/0"><code>array:array()</code></a>|
+               ~s|<a href="https://www.erlang.org/doc/apps/stdlib/array.html#t:array/0"><code>array:array()</code></a>|
     end
 
     @myList (if :erlang.system_info(:otp_release) >= ~c"27" do
@@ -310,7 +310,7 @@ defmodule ExDoc.Language.ErlangTest do
 
     test "function in module autoimport using slash", c do
       assert autolink_doc("`node/0`", c) ==
-               ~s|<a href="https://www.erlang.org/doc/man/erlang.html#node/0"><code class="inline">node/0</code></a>|
+               ~s|<a href="https://www.erlang.org/doc/apps/erts/erlang.html#node/0"><code class="inline">node/0</code></a>|
     end
 
     test "type in module autoimport", c do
@@ -320,7 +320,7 @@ defmodule ExDoc.Language.ErlangTest do
 
     test "type in module autoimport using slash", c do
       assert autolink_doc("`t:integer/0`", c) ==
-               ~s|<a href="https://www.erlang.org/doc/man/erlang.html#t:integer/0"><code class="inline">integer/0</code></a>|
+               ~s|<a href="https://www.erlang.org/doc/apps/erts/erlang.html#t:integer/0"><code class="inline">integer/0</code></a>|
     end
 
     test "bad function in module code", c do
@@ -335,7 +335,7 @@ defmodule ExDoc.Language.ErlangTest do
 
     test "linking to auto-imported nil works", c do
       assert autolink_doc("[`[]`](`t:nil/0`)", c) ==
-               ~s|<a href="https://www.erlang.org/doc/man/erlang.html#t:nil/0"><code class="inline">[]</code></a>|
+               ~s|<a href="https://www.erlang.org/doc/apps/erts/erlang.html#t:nil/0"><code class="inline">[]</code></a>|
     end
 
     test "linking to local nil works", c do
@@ -543,7 +543,7 @@ defmodule ExDoc.Language.ErlangTest do
 
     test "OTP function", c do
       assert autolink_extra("`lists:reverse/1`", c) ==
-               ~s|<a href="https://www.erlang.org/doc/man/lists.html#reverse/1"><code class="inline">lists:reverse/1</code></a>|
+               ~s|<a href="https://www.erlang.org/doc/apps/stdlib/lists.html#reverse/1"><code class="inline">lists:reverse/1</code></a>|
     end
 
     test "type", c do
@@ -553,7 +553,7 @@ defmodule ExDoc.Language.ErlangTest do
 
     test "OTP type", c do
       assert autolink_extra("`t:array:array/0`", c) ==
-               ~s|<a href="https://www.erlang.org/doc/man/array.html#t:array/0"><code class="inline">array:array/0</code></a>|
+               ~s|<a href="https://www.erlang.org/doc/apps/stdlib/array.html#t:array/0"><code class="inline">array:array/0</code></a>|
     end
 
     test "module", c do
@@ -563,7 +563,7 @@ defmodule ExDoc.Language.ErlangTest do
 
     test "OTP module", c do
       assert autolink_extra("`m:rpc`", c) ==
-               ~s|<a href="https://www.erlang.org/doc/man/rpc.html"><code class="inline">rpc</code></a>|
+               ~s|<a href="https://www.erlang.org/doc/apps/kernel/rpc.html"><code class="inline">rpc</code></a>|
     end
 
     test "bad module function", c do
@@ -684,9 +684,9 @@ defmodule ExDoc.Language.ErlangTest do
 
     test "spec when fun is called record", c do
       assert autolink_spec("-spec record(module()) -> [[{module(), atom()}]].", c) ==
-               ~s|record(<a href="https://www.erlang.org/doc/man/erlang.html#t:module/0">module</a>())| <>
-                 ~s| -> [[{<a href="https://www.erlang.org/doc/man/erlang.html#t:module/0">module</a>(),| <>
-                 ~s| <a href="https://www.erlang.org/doc/man/erlang.html#t:atom/0">atom</a>()}]].|
+               ~s|record(<a href="https://www.erlang.org/doc/apps/erts/erlang.html#t:module/0">module</a>())| <>
+                 ~s| -> [[{<a href="https://www.erlang.org/doc/apps/erts/erlang.html#t:module/0">module</a>(),| <>
+                 ~s| <a href="https://www.erlang.org/doc/apps/erts/erlang.html#t:atom/0">atom</a>()}]].|
     end
 
     test "callback", c do
@@ -724,7 +724,7 @@ defmodule ExDoc.Language.ErlangTest do
                ~S"-spec foo() -> #{atom() := sets:set(integer()), float() => t()}.",
                c
              ) ==
-               ~S|foo() -> #{<a href="https://www.erlang.org/doc/man/erlang.html#t:atom/0">atom</a>() := <a href="https://www.erlang.org/doc/man/sets.html#t:set/1">sets:set</a>(<a href="https://www.erlang.org/doc/man/erlang.html#t:integer/0">integer</a>()), <a href="https://www.erlang.org/doc/man/erlang.html#t:float/0">float</a>() => <a href="#t:t/0">t</a>()}.|
+               ~S|foo() -> #{<a href="https://www.erlang.org/doc/apps/erts/erlang.html#t:atom/0">atom</a>() := <a href="https://www.erlang.org/doc/apps/stdlib/sets.html#t:set/1">sets:set</a>(<a href="https://www.erlang.org/doc/apps/erts/erlang.html#t:integer/0">integer</a>()), <a href="https://www.erlang.org/doc/apps/erts/erlang.html#t:float/0">float</a>() => <a href="#t:t/0">t</a>()}.|
     end
 
     test "vars", c do
@@ -744,12 +744,12 @@ defmodule ExDoc.Language.ErlangTest do
 
     test "record - one field", c do
       assert autolink_spec(~s"-spec foo() -> #x{x :: atom()} | t().", c) ==
-               ~s[foo() -> #x{x :: <a href="https://www.erlang.org/doc/man/erlang.html#t:atom/0">atom</a>()} | <a href="#t:t/0">t</a>().]
+               ~s[foo() -> #x{x :: <a href="https://www.erlang.org/doc/apps/erts/erlang.html#t:atom/0">atom</a>()} | <a href="#t:t/0">t</a>().]
     end
 
     test "record - two fields", c do
       assert autolink_spec(~s"-spec foo() -> #x{x :: atom(), y :: sets:set(integer())} | t().", c) ==
-               ~s[foo() -> #x{x :: <a href="https://www.erlang.org/doc/man/erlang.html#t:atom/0">atom</a>(), y :: <a href="https://www.erlang.org/doc/man/sets.html#t:set/1">sets:set</a>(<a href="https://www.erlang.org/doc/man/erlang.html#t:integer/0">integer</a>())} | <a href="#t:t/0">t</a>().]
+               ~s[foo() -> #x{x :: <a href="https://www.erlang.org/doc/apps/erts/erlang.html#t:atom/0">atom</a>(), y :: <a href="https://www.erlang.org/doc/apps/stdlib/sets.html#t:set/1">sets:set</a>(<a href="https://www.erlang.org/doc/apps/erts/erlang.html#t:integer/0">integer</a>())} | <a href="#t:t/0">t</a>().]
     end
 
     test "record - two fields, known types", c do
@@ -789,12 +789,12 @@ defmodule ExDoc.Language.ErlangTest do
 
     test "OTP type", c do
       assert autolink_spec(~S"-spec foo() -> sets:set().", c) ==
-               ~s|foo() -> <a href="https://www.erlang.org/doc/man/sets.html#t:set/0">sets:set</a>().|
+               ~s|foo() -> <a href="https://www.erlang.org/doc/apps/stdlib/sets.html#t:set/0">sets:set</a>().|
     end
 
     test "OTP private type", c do
       assert autolink_spec(~S"-spec foo() -> array:array_indx().", c) ==
-               ~s|foo() -> <a href="https://www.erlang.org/doc/man/array.html#t:array_indx/0">array:array_indx</a>().|
+               ~s|foo() -> <a href="https://www.erlang.org/doc/apps/stdlib/array.html#t:array_indx/0">array:array_indx</a>().|
     end
 
     test "skip typespec name", c do
@@ -820,7 +820,7 @@ defmodule ExDoc.Language.ErlangTest do
     test "bad remote type", c do
       assert warn(fn ->
                assert autolink_spec(~S"-spec foo() -> bad:bad(atom()).", c, warnings: :send) ==
-                        ~s|foo() -> bad:bad(<a href="https://www.erlang.org/doc/man/erlang.html#t:atom/0">atom</a>()).|
+                        ~s|foo() -> bad:bad(<a href="https://www.erlang.org/doc/apps/erts/erlang.html#t:atom/0">atom</a>()).|
              end) =~ ~s|references type "bad:bad/1" but it is undefined or private|
     end
   end

--- a/test/ex_doc/language/erlang_test.exs
+++ b/test/ex_doc/language/erlang_test.exs
@@ -142,21 +142,21 @@ defmodule ExDoc.Language.ErlangTest do
       assert autolink_edoc("{@type myList(X). A special kind of lists ...}", c,
                extra_foo_code: "-export_type([myList/0]).\n-type myList() :: term().\n%% A type"
              ) ==
-               ~s|<code><a href=\"##{@myList}\">myList</a>(X)</code>|
+               ~s|<code><a href="##{@myList}">myList</a>(X)</code>|
     end
 
     test "abstract types - description+dot", c do
       assert autolink_edoc("{@type myList(X, Y).}", c,
                extra_foo_code: "-export_type([myList/0]).\n-type myList() :: term().\n%% A type"
              ) ==
-               ~s|<code><a href=\"##{@myList}\">myList</a>(X, Y)</code>|
+               ~s|<code><a href="##{@myList}">myList</a>(X, Y)</code>|
     end
 
     test "abstract types - no description", c do
       assert autolink_edoc("{@type myList()}", c,
                extra_foo_code: "-export_type([myList/0]).\n-type myList() :: term().\n%% A type"
              ) ==
-               ~s|<code><a href=\"##{@myList}\">myList()</a></code>|
+               ~s|<code><a href="##{@myList}">myList()</a></code>|
     end
   end
 
@@ -226,12 +226,12 @@ defmodule ExDoc.Language.ErlangTest do
 
     test "m:module in module code", c do
       assert autolink_doc("`m:erlang_bar`", c) ==
-               ~s|<a href=\"erlang_bar.html\"><code class="inline">erlang_bar</code></a>|
+               ~s|<a href="erlang_bar.html"><code class="inline">erlang_bar</code></a>|
     end
 
     test "m:module with anchor in module code", c do
       assert autolink_doc("`m:erlang_bar#anchor`", c) ==
-               ~s|<a href=\"erlang_bar.html#anchor\"><code class="inline">erlang_bar</code></a>|
+               ~s|<a href="erlang_bar.html#anchor"><code class="inline">erlang_bar</code></a>|
     end
 
     test "invalid m:module in module code", c do
@@ -241,28 +241,28 @@ defmodule ExDoc.Language.ErlangTest do
 
     test "module in module code reference", c do
       assert autolink_doc("[`erlang_bar`](`erlang_bar`)", c) ==
-               ~s|<a href=\"erlang_bar.html\"><code class="inline">erlang_bar</code></a>|
+               ~s|<a href="erlang_bar.html"><code class="inline">erlang_bar</code></a>|
     end
 
     test "remote module with anchor in module code reference", c do
       assert autolink_doc("[`erlang_bar`](`erlang_bar#anchor`)", c) ==
-               ~s|<a href=\"erlang_bar.html#anchor\"><code class="inline">erlang_bar</code></a>|
+               ~s|<a href="erlang_bar.html#anchor"><code class="inline">erlang_bar</code></a>|
 
       assert autolink_doc("[`erlang_bar`](`m:erlang_bar#anchor`)", c) ==
-               ~s|<a href=\"erlang_bar.html#anchor\"><code class="inline">erlang_bar</code></a>|
+               ~s|<a href="erlang_bar.html#anchor"><code class="inline">erlang_bar</code></a>|
     end
 
     test "own module with anchor in module code reference", c do
       assert autolink_doc("[`erlang_foo`](`erlang_foo#anchor`)", c) ==
-               ~s|<a href=\"erlang_foo.html#anchor\"><code class="inline">erlang_foo</code></a>|
+               ~s|<a href="erlang_foo.html#anchor"><code class="inline">erlang_foo</code></a>|
 
       assert autolink_doc("[`erlang_foo`](`m:erlang_foo#anchor`)", c) ==
-               ~s|<a href=\"erlang_foo.html#anchor\"><code class="inline">erlang_foo</code></a>|
+               ~s|<a href="erlang_foo.html#anchor"><code class="inline">erlang_foo</code></a>|
     end
 
     test "function in module code", c do
       assert autolink_doc("`foo/0`", c) ==
-               ~s|<a href=\"#foo/0\"><code class="inline">foo/0</code></a>|
+               ~s|<a href="#foo/0"><code class="inline">foo/0</code></a>|
     end
 
     test "function in module ref", c do
@@ -498,7 +498,7 @@ defmodule ExDoc.Language.ErlangTest do
       assert warn(
                fn ->
                  assert autolink_doc("[extra](`e:barlib:extra.md`)", c) ==
-                          ~s|<a href=\"https://hexdocs.pm/barlib/extra.html\">extra</a>|
+                          ~s|<a href="https://hexdocs.pm/barlib/extra.html">extra</a>|
                end,
                line: nil
              ) =~
@@ -509,7 +509,7 @@ defmodule ExDoc.Language.ErlangTest do
       assert warn(
                fn ->
                  assert autolink_doc("[extra](`e:barlib:extra.md#anchor`)", c) ==
-                          ~s|<a href=\"https://hexdocs.pm/barlib/extra.html#anchor\">extra</a>|
+                          ~s|<a href="https://hexdocs.pm/barlib/extra.html#anchor">extra</a>|
                end,
                line: nil
              ) =~

--- a/test/ex_doc/language/erlang_test.exs
+++ b/test/ex_doc/language/erlang_test.exs
@@ -774,7 +774,7 @@ defmodule ExDoc.Language.ErlangTest do
 
     test "function - any arity", c do
       assert autolink_spec(~s"-spec foo() -> fun((...) -> t()) | erlang_bar:t().", c) ==
-               ~s[foo() -> fun((...) -> <a href="#t:t/0">t</a>()) | <a href="erlang_bar.html#t:t/0">erlang_bar:t</a>().]
+               ~s[foo() -> fun((...) -> t()) | <a href="#t:t/0">erlang_bar:t</a>().]
     end
 
     test "local type", c do

--- a/test/ex_doc/language/erlang_test.exs
+++ b/test/ex_doc/language/erlang_test.exs
@@ -774,7 +774,7 @@ defmodule ExDoc.Language.ErlangTest do
 
     test "function - any arity", c do
       assert autolink_spec(~s"-spec foo() -> fun((...) -> t()) | erlang_bar:t().", c) ==
-               ~s[foo() -> fun((...) -> t()) | <a href="#t:t/0">erlang_bar:t</a>().]
+               ~s[foo() -> fun((...) -> <a href="#t:t/0">t</a>()) | <a href="erlang_bar.html#t:t/0">erlang_bar:t</a>().]
     end
 
     test "local type", c do

--- a/test/ex_doc/language/erlang_test.exs
+++ b/test/ex_doc/language/erlang_test.exs
@@ -15,7 +15,7 @@ defmodule ExDoc.Language.ErlangTest do
 
     test "current module", c do
       assert autolink_edoc("{@link erlang_foo}", c, current_module: :erlang_foo) ==
-               ~s|<a href="erlang_foo.html#content"><code>erlang_foo</code></a>|
+               ~s|<a href="erlang_foo.html"><code>erlang_foo</code></a>|
     end
 
     test "OTP module", c do

--- a/test/ex_doc/retriever/erlang_test.exs
+++ b/test/ex_doc/retriever/erlang_test.exs
@@ -253,7 +253,7 @@ defmodule ExDoc.Retriever.ErlangTest do
       assert Path.basename(callback1.source_url) == "mod.erl:4"
 
       assert Erlang.autolink_spec(hd(callback1.specs), current_kfa: {:callback, :callback1, 0}) ==
-               "callback1() -> <a href=\"https://www.erlang.org/doc/man/erlang.html#type-atom\">atom</a>()."
+               "callback1() -> <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:atom/0\">atom</a>()."
 
       assert equiv_callback1.id == "c:equiv_callback1/0"
       assert equiv_callback1.type == :callback
@@ -293,7 +293,7 @@ defmodule ExDoc.Retriever.ErlangTest do
       assert opaque1.id == "t:opaque1/0"
       assert opaque1.type == :opaque
       assert opaque1.group == :Types
-      assert opaque1.signature == "opaque1/0"
+      assert opaque1.signature == "opaque1()"
       assert opaque1.doc |> DocAST.to_string() =~ "opaque1/0 docs."
 
       assert opaque1.spec |> Erlang.autolink_spec(current_kfa: {:type, :opaque1, 0}) ==

--- a/test/ex_doc/retriever/erlang_test.exs
+++ b/test/ex_doc/retriever/erlang_test.exs
@@ -415,7 +415,7 @@ defmodule ExDoc.Retriever.ErlangTest do
       assert DocAST.to_string(function1.doc) =~ "function1/0 docs."
 
       assert Erlang.autolink_spec(hd(function1.specs), current_kfa: {:function, :function1, 0}) ==
-               "function1() -> <a href=\"https://www.erlang.org/doc/man/erlang.html#t:atom/0\">atom</a>()."
+               "function1() -> <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:atom/0\">atom</a>()."
 
       %ExDoc.FunctionNode{
         id: "function2/0"
@@ -463,7 +463,7 @@ defmodule ExDoc.Retriever.ErlangTest do
       assert Path.basename(callback1.source_url) == "mod.erl:4"
 
       assert Erlang.autolink_spec(hd(callback1.specs), current_kfa: {:callback, :callback1, 0}) ==
-               "callback1() -> <a href=\"https://www.erlang.org/doc/man/erlang.html#t:atom/0\">atom</a>()."
+               "callback1() -> <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:atom/0\">atom</a>()."
 
       assert optional_callback1.id == "c:optional_callback1/0"
       assert optional_callback1.type == :callback
@@ -501,7 +501,7 @@ defmodule ExDoc.Retriever.ErlangTest do
       assert type1.doc |> DocAST.to_string() =~ "type1/0 docs."
 
       assert type1.spec |> Erlang.autolink_spec(current_kfa: {:type, :type1, 0}) ==
-               "type1() :: <a href=\"https://www.erlang.org/doc/man/erlang.html#t:atom/0\">atom</a>()."
+               "type1() :: <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:atom/0\">atom</a>()."
     end
   end
 end

--- a/test/ex_doc/retriever/erlang_test.exs
+++ b/test/ex_doc/retriever/erlang_test.exs
@@ -93,7 +93,7 @@ defmodule ExDoc.Retriever.ErlangTest do
       assert function1.doc_file =~ "mod.erl"
 
       assert Erlang.autolink_spec(hd(function1.specs), current_kfa: {:function, :function1, 0}) ==
-               "function1() -> <a href=\"https://www.erlang.org/doc/man/erlang.html#type-atom\">atom</a>()."
+               "function1() -> <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:atom/0\">atom</a>()."
 
       %ExDoc.FunctionNode{
         id: "function2/1"
@@ -293,7 +293,7 @@ defmodule ExDoc.Retriever.ErlangTest do
       assert opaque1.id == "t:opaque1/0"
       assert opaque1.type == :opaque
       assert opaque1.group == :Types
-      assert opaque1.signature == "opaque1()"
+      assert opaque1.signature == "opaque1/0"
       assert opaque1.doc |> DocAST.to_string() =~ "opaque1/0 docs."
 
       assert opaque1.spec |> Erlang.autolink_spec(current_kfa: {:type, :opaque1, 0}) ==
@@ -341,15 +341,15 @@ defmodule ExDoc.Retriever.ErlangTest do
 
       assert hd(function.specs)
              |> Erlang.autolink_spec(current_module: :mod, current_kfa: {:function, :function, 0}) ==
-               "function() -> <a href=\"#t:type/0\">type</a>() | #a{a :: <a href=\"https://www.erlang.org/doc/man/erlang.html#type-integer\">integer</a>(), b :: <a href=\"https://www.erlang.org/doc/man/erlang.html#type-integer\">integer</a>(), c :: <a href=\"https://www.erlang.org/doc/man/erlang.html#type-atom\">atom</a>(), d :: <a href=\"https://www.erlang.org/doc/man/erlang.html#type-term\">term</a>(), e :: <a href=\"https://www.erlang.org/doc/man/erlang.html#type-term\">term</a>()}."
+               "function() -> <a href=\"#t:type/0\">type</a>() | #a{a :: <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:integer/0\">integer</a>(), b :: <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:integer/0\">integer</a>(), c :: <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:atom/0\">atom</a>(), d :: <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:term/0\">term</a>(), e :: <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:term/0\">term</a>()}."
 
       assert hd(callback.specs)
              |> Erlang.autolink_spec(current_module: :mod, current_kfa: {:callback, :callback, 0}) ==
-               "callback() ->\n            #a{a :: <a href=\"https://www.erlang.org/doc/man/erlang.html#type-pos_integer\">pos_integer</a>(), b :: <a href=\"https://www.erlang.org/doc/man/erlang.html#type-non_neg_integer\">non_neg_integer</a>(), c :: <a href=\"https://www.erlang.org/doc/man/erlang.html#type-atom\">atom</a>(), d :: <a href=\"https://www.erlang.org/doc/man/erlang.html#type-term\">term</a>(), e :: <a href=\"https://www.erlang.org/doc/man/erlang.html#type-term\">term</a>()}."
+               "callback() ->\n                      #a{a :: <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:pos_integer/0\">pos_integer</a>(), b :: <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:non_neg_integer/0\">non_neg_integer</a>(), c :: <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:atom/0\">atom</a>(), d :: <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:term/0\">term</a>(), e :: <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:term/0\">term</a>()}."
 
       assert type.spec
              |> Erlang.autolink_spec(current_module: :mod, current_kfa: {:type, :type, 0}) ==
-               "type() :: #a{a :: <a href=\"https://www.erlang.org/doc/man/erlang.html#type-pos_integer\">pos_integer</a>(), b :: <a href=\"https://www.erlang.org/doc/man/erlang.html#type-non_neg_integer\">non_neg_integer</a>(), c :: <a href=\"https://www.erlang.org/doc/man/erlang.html#type-atom\">atom</a>(), d :: <a href=\"https://www.erlang.org/doc/man/erlang.html#type-term\">term</a>(), e :: <a href=\"https://www.erlang.org/doc/man/erlang.html#type-term\">term</a>()}."
+               "type() :: #a{a :: <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:pos_integer/0\">pos_integer</a>(), b :: <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:non_neg_integer/0\">non_neg_integer</a>(), c :: <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:atom/0\">atom</a>(), d :: <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:term/0\">term</a>(), e :: <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:term/0\">term</a>()}."
     end
   end
 


### PR DESCRIPTION
This PR [continues](https://github.com/elixir-lang/ex_doc/pull/1908#issuecomment-2137138477) #1908 and replaces https://www.erlang.org/doc/man/ links with https://www.erlang.org/doc/apps/APP