### PR TITLE
Give example when showing deprecation warning for binary assets config

### DIFF
--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -289,9 +289,11 @@ defmodule ExDoc.Formatter.HTML do
       if is_map(assets) do
         Enum.map(assets, fn {source, target} -> {source, Path.join(namespace, target)} end)
       else
-        IO.warn(
-          "giving a binary to :assets is deprecated, please give a map from source to target instead"
-        )
+        IO.warn("""
+        giving a binary to :assets is deprecated, please give a map from source to target instead:
+
+            #{inspect(assets: %{assets => "assets"})}
+        """)
 
         [{assets, Path.join(namespace, "assets")}]
       end


### PR DESCRIPTION
I encountered this warning when upgrading and it wasn't immediately clear to me what I should do to fix it. This change updates the printed warning to show the exact valid config you could copy/paste into your `mix.exs`.