### PR TITLE
Adds a `v` shortcut to open/focus the version select

### DIFF
--- a/assets/js/keyboard-shortcuts.js
+++ b/assets/js/keyboard-shortcuts.js
@@ -1,5 +1,6 @@
 import { isAppleOS, qs } from './helpers'
-import { toggleSidebar } from './sidebar/sidebar-drawer'
+import { isSidebarOpened, openSidebar, toggleSidebar } from './sidebar/sidebar-drawer'
+import { openVersionSelect } from './sidebar/sidebar-version-select'
 import { focusSearchInput } from './search-bar'
 import { cycleTheme } from './theme'
 import { openQuickSwitchModal } from './quick-switch'
@@ -33,6 +34,11 @@ export const keyboardShortcuts = [
     key: 'k',
     hasModifier: true,
     action: searchKeyAction
+  },
+  {
+    key: 'v',
+    description: 'Open/focus version select',
+    action: versionKeyAction
   },
   {
     key: 'g',
@@ -99,6 +105,16 @@ function handleKeyUp (event) {
 function searchKeyAction (event) {
   closeModal()
   focusSearchInput()
+}
+
+function versionKeyAction () {
+  closeModal()
+
+  if (isSidebarOpened()) {
+    openVersionSelect()
+  } else {
+    openSidebar().then(openVersionSelect)
+  }
 }
 
 function toggleHelpModal () {

--- a/assets/js/keyboard-shortcuts.js
+++ b/assets/js/keyboard-shortcuts.js
@@ -74,7 +74,7 @@ function addEventListeners () {
 
 function handleKeyDown (event) {
   if (state.shortcutBeingPressed) { return }
-  if (event.target.matches('input, textarea')) { return }
+  if (event.target.matches('input, select, textarea')) { return }
 
   const matchingShortcut = keyboardShortcuts.find(shortcut => {
     if (shortcut.hasModifier) {

--- a/assets/js/sidebar/sidebar-drawer.js
+++ b/assets/js/sidebar/sidebar-drawer.js
@@ -138,7 +138,7 @@ export function isSidebarOpened () {
  *
  * @returns {Promise} A promise resolving once the animation is finished.
  */
-export function openSidebar() {
+export function openSidebar () {
   clearTimeoutIfAny()
   sessionStorage.setItem('sidebar_state', 'opened')
   qs(SIDEBAR_TOGGLE_SELECTOR).setAttribute('aria-expanded', 'true')

--- a/assets/js/sidebar/sidebar-drawer.js
+++ b/assets/js/sidebar/sidebar-drawer.js
@@ -127,22 +127,29 @@ function isSidebarOpen () {
 }
 
 /**
+ * Returns if sidebar is fully open.
+ */
+export function isSidebarOpened () {
+  return document.body.classList.contains(SIDEBAR_CLASS.opened)
+}
+
+/**
  * Opens the sidebar by applying an animation.
  *
  * @returns {Promise} A promise resolving once the animation is finished.
  */
-export function openSidebar () {
+export function openSidebar() {
   clearTimeoutIfAny()
   sessionStorage.setItem('sidebar_state', 'opened')
   qs(SIDEBAR_TOGGLE_SELECTOR).setAttribute('aria-expanded', 'true')
 
-  requestAnimationFrame(() => {
-    setClass(SIDEBAR_CLASS.openingStart)
-
+  return new Promise((resolve, reject) => {
     requestAnimationFrame(() => {
-      setClass(SIDEBAR_CLASS.opening)
+      setClass(SIDEBAR_CLASS.openingStart)
 
-      return new Promise((resolve, reject) => {
+      requestAnimationFrame(() => {
+        setClass(SIDEBAR_CLASS.opening)
+
         state.togglingTimeout = setTimeout(() => {
           setClass(SIDEBAR_CLASS.opened)
           resolve()
@@ -162,13 +169,13 @@ export function closeSidebar () {
   sessionStorage.setItem('sidebar_state', 'closed')
   qs(SIDEBAR_TOGGLE_SELECTOR).setAttribute('aria-expanded', 'false')
 
-  requestAnimationFrame(() => {
-    setClass(SIDEBAR_CLASS.closingStart)
-
+  return new Promise((resolve, reject) => {
     requestAnimationFrame(() => {
-      setClass(SIDEBAR_CLASS.closing)
+      setClass(SIDEBAR_CLASS.closingStart)
 
-      return new Promise((resolve, reject) => {
+      requestAnimationFrame(() => {
+        setClass(SIDEBAR_CLASS.closing)
+
         state.togglingTimeout = setTimeout(() => {
           setClass(SIDEBAR_CLASS.closed)
           resolve()

--- a/assets/js/sidebar/sidebar-version-select.js
+++ b/assets/js/sidebar/sidebar-version-select.js
@@ -83,6 +83,14 @@ export function openVersionSelect () {
   if (select) {
     select.focus()
 
+    // Prevent subsequent 'v' press from submitting form
+    select.addEventListener('keydown', event => {
+      if (event.key === 'Escape' || event.key === 'v') {
+        event.preventDefault()
+        select.blur()
+      }
+    })
+
     if (navigator.userActivation.isActive && 'showPicker' in HTMLSelectElement.prototype) {
       select.showPicker()
     }

--- a/assets/js/sidebar/sidebar-version-select.js
+++ b/assets/js/sidebar/sidebar-version-select.js
@@ -70,3 +70,21 @@ function handleVersionSelected (event) {
       }
     })
 }
+
+/**
+ * Opens the version select if available.
+ * Only focuses the version select if
+ *   - the browser's HTMLSelectElement lacks the showPicker method
+ *   - there has been transient user interaction
+ */
+export function openVersionSelect () {
+ const select = qs(VERSIONS_DROPDOWN_SELECTOR)
+
+  if (select) {
+    select.focus()
+
+    if (navigator.userActivation.isActive && "showPicker" in HTMLSelectElement.prototype) {
+      select.showPicker()
+    }
+  }
+}

--- a/assets/js/sidebar/sidebar-version-select.js
+++ b/assets/js/sidebar/sidebar-version-select.js
@@ -78,12 +78,12 @@ function handleVersionSelected (event) {
  *   - there has been transient user interaction
  */
 export function openVersionSelect () {
- const select = qs(VERSIONS_DROPDOWN_SELECTOR)
+  const select = qs(VERSIONS_DROPDOWN_SELECTOR)
 
   if (select) {
     select.focus()
 
-    if (navigator.userActivation.isActive && "showPicker" in HTMLSelectElement.prototype) {
+    if (navigator.userActivation.isActive && 'showPicker' in HTMLSelectElement.prototype) {
       select.showPicker()
     }
   }


### PR DESCRIPTION
When searching for docs in a search engine, the results don't always include the latest version as the first choice. This adds a `v` shortcut that will open the version select (if the user's browser supports it, otherwise it will focus it) to make selecting versions easier.