### PR TITLE
Add links to jump to latest version of docs

### DIFF
--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -110,8 +110,15 @@
 }
 
 .sidebar .sidebar-projectVersionsLatestLink {
-  background-color: red;
-  color: white;
+  border-left: var(--navTabBorderWidth) solid var(--sidebarLanguageAccentBar);
+  padding: 0 10px;
+  background-color: var(--sidebarAccentMain);
+}
+
+.sidebar .sidebar-projectVersionsLatestLink a {
+  color: var(--sidebarBackground);
+  font-weight: bold;
+  ;
 }
 
 .sidebar .sidebar-listNav {

--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -109,6 +109,11 @@
   display: none;
 }
 
+.sidebar .sidebar-projectVersionsLatestLink {
+  background-color: red;
+  color: white;
+}
+
 .sidebar .sidebar-listNav {
   display: flex;
   margin: 0;

--- a/assets/js/handlebars/templates/versions-dropdown.handlebars
+++ b/assets/js/handlebars/templates/versions-dropdown.handlebars
@@ -10,7 +10,8 @@
       {{/each}}
     </select>
     {{#if jumpToLatestUrl }}
-      <span class="sidebar-projectVersionsLatestLink"><a href="{{jumpToLatestUrl}}">⚠️ Go to latest</a></span>
+      <br />
+      <span class="sidebar-projectVersionsLatestLink"><a href="{{jumpToLatestUrl}}">Go to latest</a></span>
     {{/if}}
   </label>
 </form>

--- a/assets/js/handlebars/templates/versions-dropdown.handlebars
+++ b/assets/js/handlebars/templates/versions-dropdown.handlebars
@@ -9,5 +9,8 @@
         </option>
       {{/each}}
     </select>
+    {{#if jumpToLatestUrl }}
+      <span class="sidebar-projectVersionsLatestLink"><a href="{{jumpToLatestUrl}}">⚠️ Go to latest</a></span>
+    {{/if}}
   </label>
 </form>

--- a/assets/js/handlebars/templates/versions-dropdown.handlebars
+++ b/assets/js/handlebars/templates/versions-dropdown.handlebars
@@ -9,9 +9,10 @@
         </option>
       {{/each}}
     </select>
-    {{#if jumpToLatestUrl }}
+    {{#if latestUrl }}
       <br />
-      <span class="sidebar-projectVersionsLatestLink"><a href="{{jumpToLatestUrl}}">Go to latest</a></span>
+      <span class="sidebar-projectVersionsLatestLink"><a href="{{latestUrl}}">View latest
+          ({{latestVersion}})</a></span>
     {{/if}}
   </label>
 </form>

--- a/assets/js/sidebar/sidebar-version-select.js
+++ b/assets/js/sidebar/sidebar-version-select.js
@@ -14,16 +14,19 @@ export function initialize () {
     const versionsContainer = qs(VERSIONS_CONTAINER_SELECTOR)
     // Initially the container contains only text with the current version
     const currentVersion = versionsContainer.textContent.trim()
+    const latestVersionNode = versionNodes.find(node => node.latest)
+    const jumpToLatestUrl = latestVersionNode?.version !== currentVersion ? latestVersionNode?.url : null
+
     const nodes = decorateVersionNodes(versionNodes, currentVersion)
 
-    renderVersionsDropdown({ nodes })
+    renderVersionPicker(nodes, jumpToLatestUrl)
   }
 }
 
-function renderVersionsDropdown ({ nodes }) {
+function renderVersionPicker (nodes, jumpToLatestUrl) {
   const versionsContainer = qs(VERSIONS_CONTAINER_SELECTOR)
-  const versionsDropdownHtml = Handlebars.templates['versions-dropdown']({ nodes })
-  versionsContainer.innerHTML = versionsDropdownHtml
+  const versionPickerHtml = Handlebars.templates['versions-dropdown']({ nodes, jumpToLatestUrl })
+  versionsContainer.innerHTML = versionPickerHtml
 
   qs(VERSIONS_DROPDOWN_SELECTOR).addEventListener('change', handleVersionSelected)
 }

--- a/assets/js/sidebar/sidebar-version-select.js
+++ b/assets/js/sidebar/sidebar-version-select.js
@@ -15,17 +15,18 @@ export function initialize () {
     // Initially the container contains only text with the current version
     const currentVersion = versionsContainer.textContent.trim()
     const latestVersionNode = versionNodes.find(node => node.latest)
-    const jumpToLatestUrl = latestVersionNode?.version !== currentVersion ? latestVersionNode?.url : null
+    const latestVersion = latestVersionNode?.version !== currentVersion ? latestVersionNode?.version : null
+    const latestUrl = latestVersionNode?.version !== currentVersion ? latestVersionNode?.url : null
 
     const nodes = decorateVersionNodes(versionNodes, currentVersion)
 
-    renderVersionPicker(nodes, jumpToLatestUrl)
+    renderVersionPicker(nodes, latestVersion, latestUrl)
   }
 }
 
-function renderVersionPicker (nodes, jumpToLatestUrl) {
+function renderVersionPicker (nodes, latestVersion, latestUrl) {
   const versionsContainer = qs(VERSIONS_CONTAINER_SELECTOR)
-  const versionPickerHtml = Handlebars.templates['versions-dropdown']({ nodes, jumpToLatestUrl })
+  const versionPickerHtml = Handlebars.templates['versions-dropdown']({ nodes, latestVersion, latestUrl })
   versionsContainer.innerHTML = versionPickerHtml
 
   qs(VERSIONS_DROPDOWN_SELECTOR).addEventListener('change', handleVersionSelected)


### PR DESCRIPTION
Hello! 👋 

This PR addresses #1917 . It adds support for specifying which version is the latest via docs_config.js:

```javascript
var versionNodes = [
    { version: 'v1.0.0', url: '/foo'},
    { version: 'v2.0.0', url: "/bar", latest: true },
    { version: 'v0.34.0-dev', url: "/baz" }
];
```

 which will trigger a warning hyperlink to the latest version when viewing other versions:

<img width="222" alt="image" src="https://github.com/elixir-lang/ex_doc/assets/1106188/784d8a29-cea5-4104-b56c-58a86d6dcddb">

It is not required to have a latest version in docs_config.js. Existing docs_config.js files will continue to produce the existing behaviour with no warning links.

Rather than try to determine which version is the latest through javascript logic, it seemed more appropriate to delegate to the author of docs_config.js, for example hexdocs. This avoids the risk of behaviour that differs from the documentation host's opinion on which version is the latest. This does mean that the PR doesn't do anything interesting without a small enhancement to (in practice) hexdocs.

This PR has the drawback that docs published prior to this PR will not get warnings. But due to the way exdocs works, I don't see how any attempt at fixing #1917 could get around this.