### PR TITLE
Fix search bar input on focus 1px shift

### DIFF
--- a/assets/css/search-bar.css
+++ b/assets/css/search-bar.css
@@ -25,7 +25,7 @@
 
 .top-search .search-bar .search-input {
   background-color: var(--searchSearch);
-  border: none;
+  border: 1px solid transparent;
   border-radius: 8px;
   color: var(--searchAccentMain);
   position: relative;


### PR DESCRIPTION
Previously, the `.search-input` set of styles defined `border: none`, while its `:focus` state has 1px border set. This led to the “micro-jump” of the placeholder text when the input field gets user focus (and it “jumps” back when it loses one).

With this simple fix, we always have an invisible 1px border set to the input, so it prevents “jumping”.

### Screen Recordings

| Before | After |
|--------|-------|
| <video src="https://github.com/elixir-lang/ex_doc/assets/113878/5b74403e-7297-4564-b007-63cd29a58a0f"></video> | <video src="https://github.com/elixir-lang/ex_doc/assets/113878/3bf9c06e-14d8-4dd0-af79-262a1de20e14"></video> |
