### PR TITLE
Add top margin to nested module prefix in sidebar

### DIFF
--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -245,6 +245,7 @@
   font-size: 0.9em;
   line-height: 1.8em;
   color: var(--sidebarSubheadings);
+  margin-top: 10px;
   padding-left: 15px;
 }
 


### PR DESCRIPTION
I was browsing some docs earlier that used the `:nest_modules_by_prefix` config and found that, with a very long module list, it was very difficult to see the prefixes and almost impossible to quickly scan for (e.g. while scrolling down to find the next section).

This PR just adds 10px of margin above those prefixes, which is sufficient to visually set them apart. (10px is chosen because it's the same amount used when you expand a module subheader in the sidebar.)

### Before

![image](https://github.com/elixir-lang/ex_doc/assets/503938/27a07d01-3125-4010-b157-825500002bbe)


### After

![image](https://github.com/elixir-lang/ex_doc/assets/503938/e3c0b7b4-9a45-486c-bd17-e15cef942530)
