### PR TITLE
Convert admonition blockquotes to sections for screen reader users

### DIFF
--- a/assets/css/content/admonition.css
+++ b/assets/css/content/admonition.css
@@ -23,14 +23,14 @@
   background-color: var(--tipBackground);
 }
 
-.content-inner section.admonition > :first-child {
+.content-inner section.admonition > .admonition-title {
   color: var(--contrast);
   margin: 0 -1.2rem;
   padding: .7rem 1.2rem .7rem 3.3rem;
   font-weight: 700;
   font-style: normal;
 }
-.content-inner section.admonition > :first-child::before {
+.content-inner section.admonition > .admonition-title::before {
   color: var(--contrast);
   position: absolute;
   left: 1rem;
@@ -41,52 +41,52 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-.content-inner section.admonition > :first-child.warning {
+.content-inner section.admonition > .admonition-title.warning {
   background-color: var(--warningHeadingBackground);
   color: var(--warningHeading);
 }
-.content-inner section.admonition > :first-child.warning::before {
+.content-inner section.admonition > .admonition-title.warning::before {
   content: var(--icon-error-warning);
   color: var(--warningHeading);
 }
 
-.content-inner section.admonition > :first-child.error {
+.content-inner section.admonition > .admonition-title.error {
   background-color: var(--errorHeadingBackground);
   color: var(--errorHeading);
 }
-.content-inner section.admonition > :first-child.error::before {
+.content-inner section.admonition > .admonition-title.error::before {
   content: var(--icon-error-warning);
   color: var(--errorHeading);
 }
 
-.content-inner section.admonition > :first-child.info {
+.content-inner section.admonition > .admonition-title.info {
   background-color: var(--infoHeadingBackground);
   color: var(--infoHeading);
 }
-.content-inner section.admonition > :first-child.info::before {
+.content-inner section.admonition > .admonition-title.info::before {
   content: var(--icon-information);
   color: var(--infoHeading);
 }
 
-.content-inner section.admonition > :first-child.neutral {
+.content-inner section.admonition > .admonition-title.neutral {
   background-color: var(--neutralHeadingBackground);
   color: var(--neutralHeading);
 }
-.content-inner section.admonition > :first-child.neutral::before {
+.content-inner section.admonition > .admonition-title.neutral::before {
   content: var(--icon-double-quotes-l);
   color: var(--neutralHeading);
 }
 
-.content-inner section.admonition > :first-child.tip {
+.content-inner section.admonition > .admonition-title.tip {
   background-color: var(--tipHeadingBackground);
   color: var(--tipHeading);
 }
-.content-inner section.admonition > :first-child.tip::before {
+.content-inner section.admonition > .admonition-title.tip::before {
   content: var(--icon-information);
   color: var(--tipHeading);
 }
 
-.content-inner section.admonition > :first-child code {
+.content-inner section.admonition > .admonition-title code {
   margin: 0 0.5ch;
 }
 
@@ -102,7 +102,7 @@
   color: var(--admCodeColor);
 }
 
-.content-inner section.admonition > :first-child :is(a, a:visited) {
+.content-inner section.admonition > .admonition-title :is(a, a:visited) {
   color: inherit;
   text-decoration-color: currentColor;
 }
@@ -116,7 +116,7 @@
     border-radius: 0;
   }
 
-  .content-inner section.admonition > :first-child {
+  .content-inner section.admonition > .admonition-title {
     margin: 0 calc(-1 * var(--content-gutter));
   }
 }

--- a/assets/css/content/admonition.css
+++ b/assets/css/content/admonition.css
@@ -1,36 +1,36 @@
-.content-inner div.admonition:is(.warning, .error, .info, .neutral, .tip) {
+.content-inner section.admonition:is(.warning, .error, .info, .neutral, .tip) {
   border-radius: 10px;
   border-left: 0;
 }
 
-.content-inner div.admonition.warning {
+.content-inner section.admonition.warning {
   background-color: var(--warningBackground);
 }
 
-.content-inner div.admonition.error {
+.content-inner section.admonition.error {
   background-color: var(--errorBackground);
 }
 
-.content-inner div.admonition.info {
+.content-inner section.admonition.info {
   background-color: var(--infoBackground);
 }
 
-.content-inner div.admonition.neutral {
+.content-inner section.admonition.neutral {
   background-color: var(--neutralBackground);
 }
 
-.content-inner div.admonition.tip {
+.content-inner section.admonition.tip {
   background-color: var(--tipBackground);
 }
 
-.content-inner div.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
+.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
   color: var(--contrast);
   margin: 0 -1.2rem;
   padding: .7rem 1.2rem .7rem 3.3rem;
   font-weight: 700;
   font-style: normal;
 }
-.content-inner div.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip)::before {
+.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip)::before {
   color: var(--contrast);
   position: absolute;
   left: 1rem;
@@ -41,74 +41,74 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-.content-inner div.admonition :is(h3, h4).warning {
+.content-inner section.admonition :is(h3, h4).warning {
   background-color: var(--warningHeadingBackground);
   color: var(--warningHeading);
 }
-.content-inner div.admonition :is(h3, h4).warning::before {
+.content-inner section.admonition :is(h3, h4).warning::before {
   content: var(--icon-error-warning);
   color: var(--warningHeading);
 }
 
-.content-inner div.admonition :is(h3, h4).error {
+.content-inner section.admonition :is(h3, h4).error {
   background-color: var(--errorHeadingBackground);
   color: var(--errorHeading);
 }
-.content-inner div.admonition :is(h3, h4).error::before {
+.content-inner section.admonition :is(h3, h4).error::before {
   content: var(--icon-error-warning);
   color: var(--errorHeading);
 }
 
-.content-inner div.admonition :is(h3, h4).info {
+.content-inner section.admonition :is(h3, h4).info {
   background-color: var(--infoHeadingBackground);
   color: var(--infoHeading);
 }
-.content-inner div.admonition :is(h3, h4).info::before {
+.content-inner section.admonition :is(h3, h4).info::before {
   content: var(--icon-information);
   color: var(--infoHeading);
 }
 
-.content-inner div.admonition :is(h3, h4).neutral {
+.content-inner section.admonition :is(h3, h4).neutral {
   background-color: var(--neutralHeadingBackground);
   color: var(--neutralHeading);
 }
-.content-inner div.admonition :is(h3, h4).neutral::before {
+.content-inner section.admonition :is(h3, h4).neutral::before {
   content: var(--icon-double-quotes-l);
   color: var(--neutralHeading);
 }
 
-.content-inner div.admonition :is(h3, h4).tip {
+.content-inner section.admonition :is(h3, h4).tip {
   background-color: var(--tipHeadingBackground);
   color: var(--tipHeading);
 }
-.content-inner div.admonition :is(h3, h4).tip::before {
+.content-inner section.admonition :is(h3, h4).tip::before {
   content: var(--icon-information);
   color: var(--tipHeading);
 }
 
-.content-inner div.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) code {
+.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) code {
   margin: 0 0.5ch;
 }
 
-.content-inner div.admonition:is(.warning, .error, .info, .neutral, .tip) code {
+.content-inner section.admonition:is(.warning, .error, .info, .neutral, .tip) code {
   background-color: var(--admInlineCodeBackground);
   border: 1px solid var(--admInlineCodeBorder);
   color: var(--admInlineCodeColor);
 }
 
-.content-inner div.admonition:is(.warning, .error, .info, .neutral, .tip) pre code {
+.content-inner section.admonition:is(.warning, .error, .info, .neutral, .tip) pre code {
   background-color: var(--admCodeBackground);
   border: 1px solid var(--admCodeBorder);
   color: var(--admCodeColor);
 }
 
-.content-inner div.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) :is(a, a:visited) {
+.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) :is(a, a:visited) {
   color: inherit;
   text-decoration-color: currentColor;
 }
 
 @media screen and (max-width: 768px) {
-  .content-inner div.admonition:is(.warning, .error, .info, .neutral, .tip) {
+  .content-inner section.admonition:is(.warning, .error, .info, .neutral, .tip) {
     margin-left: calc(-1 * var(--content-gutter));
     margin-right: calc(-1 * var(--content-gutter));
     padding-left: var(--content-gutter);
@@ -116,7 +116,7 @@
     border-radius: 0;
   }
 
-  .content-inner div.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
+  .content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
     margin: 0 calc(-1 * var(--content-gutter));
   }
 }

--- a/assets/css/content/admonition.css
+++ b/assets/css/content/admonition.css
@@ -23,14 +23,14 @@
   background-color: var(--tipBackground);
 }
 
-.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
+.content-inner section.admonition > :first-child {
   color: var(--contrast);
   margin: 0 -1.2rem;
   padding: .7rem 1.2rem .7rem 3.3rem;
   font-weight: 700;
   font-style: normal;
 }
-.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip)::before {
+.content-inner section.admonition > :first-child::before {
   color: var(--contrast);
   position: absolute;
   left: 1rem;
@@ -41,52 +41,52 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-.content-inner section.admonition :is(h3, h4).warning {
+.content-inner section.admonition > :first-child.warning {
   background-color: var(--warningHeadingBackground);
   color: var(--warningHeading);
 }
-.content-inner section.admonition :is(h3, h4).warning::before {
+.content-inner section.admonition > :first-child.warning::before {
   content: var(--icon-error-warning);
   color: var(--warningHeading);
 }
 
-.content-inner section.admonition :is(h3, h4).error {
+.content-inner section.admonition > :first-child.error {
   background-color: var(--errorHeadingBackground);
   color: var(--errorHeading);
 }
-.content-inner section.admonition :is(h3, h4).error::before {
+.content-inner section.admonition > :first-child.error::before {
   content: var(--icon-error-warning);
   color: var(--errorHeading);
 }
 
-.content-inner section.admonition :is(h3, h4).info {
+.content-inner section.admonition > :first-child.info {
   background-color: var(--infoHeadingBackground);
   color: var(--infoHeading);
 }
-.content-inner section.admonition :is(h3, h4).info::before {
+.content-inner section.admonition > :first-child.info::before {
   content: var(--icon-information);
   color: var(--infoHeading);
 }
 
-.content-inner section.admonition :is(h3, h4).neutral {
+.content-inner section.admonition > :first-child.neutral {
   background-color: var(--neutralHeadingBackground);
   color: var(--neutralHeading);
 }
-.content-inner section.admonition :is(h3, h4).neutral::before {
+.content-inner section.admonition > :first-child.neutral::before {
   content: var(--icon-double-quotes-l);
   color: var(--neutralHeading);
 }
 
-.content-inner section.admonition :is(h3, h4).tip {
+.content-inner section.admonition > :first-child.tip {
   background-color: var(--tipHeadingBackground);
   color: var(--tipHeading);
 }
-.content-inner section.admonition :is(h3, h4).tip::before {
+.content-inner section.admonition > :first-child.tip::before {
   content: var(--icon-information);
   color: var(--tipHeading);
 }
 
-.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) code {
+.content-inner section.admonition > :first-child code {
   margin: 0 0.5ch;
 }
 
@@ -102,13 +102,13 @@
   color: var(--admCodeColor);
 }
 
-.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) :is(a, a:visited) {
+.content-inner section.admonition > :first-child :is(a, a:visited) {
   color: inherit;
   text-decoration-color: currentColor;
 }
 
 @media screen and (max-width: 768px) {
-  .content-inner section.admonition:is(.warning, .error, .info, .neutral, .tip) {
+  .content-inner section.admonition {
     margin-left: calc(-1 * var(--content-gutter));
     margin-right: calc(-1 * var(--content-gutter));
     padding-left: var(--content-gutter);
@@ -116,7 +116,7 @@
     border-radius: 0;
   }
 
-  .content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
+  .content-inner section.admonition > :first-child {
     margin: 0 calc(-1 * var(--content-gutter));
   }
 }

--- a/assets/css/content/admonition.css
+++ b/assets/css/content/admonition.css
@@ -1,36 +1,36 @@
-.content-inner .admonition {
+.content-inner section.admonition {
   border-radius: 10px;
   border-left: 0;
 }
 
-.content-inner .admonition.warning {
+.content-inner section.admonition.warning {
   background-color: var(--warningBackground);
 }
 
-.content-inner .admonition.error {
+.content-inner section.admonition.error {
   background-color: var(--errorBackground);
 }
 
-.content-inner .admonition.info {
+.content-inner section.admonition.info {
   background-color: var(--infoBackground);
 }
 
-.content-inner .admonition.neutral {
+.content-inner section.admonition.neutral {
   background-color: var(--neutralBackground);
 }
 
-.content-inner .admonition.tip {
+.content-inner section.admonition.tip {
   background-color: var(--tipBackground);
 }
 
-.content-inner .admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
+.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
   color: var(--contrast);
   margin: 0 -1.2rem;
   padding: .7rem 1.2rem .7rem 3.3rem;
   font-weight: 700;
   font-style: normal;
 }
-.content-inner .admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip)::before {
+.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip)::before {
   color: var(--contrast);
   position: absolute;
   left: 1rem;
@@ -41,74 +41,74 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-.content-inner .admonition :is(h3, h4).warning {
+.content-inner section.admonition :is(h3, h4).warning {
   background-color: var(--warningHeadingBackground);
   color: var(--warningHeading);
 }
-.content-inner .admonition :is(h3, h4).warning::before {
+.content-inner section.admonition :is(h3, h4).warning::before {
   content: var(--icon-error-warning);
   color: var(--warningHeading);
 }
 
-.content-inner .admonition :is(h3, h4).error {
+.content-inner section.admonition :is(h3, h4).error {
   background-color: var(--errorHeadingBackground);
   color: var(--errorHeading);
 }
-.content-inner .admonition :is(h3, h4).error::before {
+.content-inner section.admonition :is(h3, h4).error::before {
   content: var(--icon-error-warning);
   color: var(--errorHeading);
 }
 
-.content-inner .admonition :is(h3, h4).info {
+.content-inner section.admonition :is(h3, h4).info {
   background-color: var(--infoHeadingBackground);
   color: var(--infoHeading);
 }
-.content-inner .admonition :is(h3, h4).info::before {
+.content-inner section.admonition :is(h3, h4).info::before {
   content: var(--icon-information);
   color: var(--infoHeading);
 }
 
-.content-inner .admonition :is(h3, h4).neutral {
+.content-inner section.admonition :is(h3, h4).neutral {
   background-color: var(--neutralHeadingBackground);
   color: var(--neutralHeading);
 }
-.content-inner .admonition :is(h3, h4).neutral::before {
+.content-inner section.admonition :is(h3, h4).neutral::before {
   content: var(--icon-double-quotes-l);
   color: var(--neutralHeading);
 }
 
-.content-inner .admonition :is(h3, h4).tip {
+.content-inner section.admonition :is(h3, h4).tip {
   background-color: var(--tipHeadingBackground);
   color: var(--tipHeading);
 }
-.content-inner .admonition :is(h3, h4).tip::before {
+.content-inner section.admonition :is(h3, h4).tip::before {
   content: var(--icon-information);
   color: var(--tipHeading);
 }
 
-.content-inner .admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) code {
+.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) code {
   margin: 0 0.5ch;
 }
 
-.content-inner .admonition code {
+.content-inner section.admonition code {
   background-color: var(--admInlineCodeBackground);
   border: 1px solid var(--admInlineCodeBorder);
   color: var(--admInlineCodeColor);
 }
 
-.content-inner .admonition  pre code {
+.content-inner section.admonition  pre code {
   background-color: var(--admCodeBackground);
   border: 1px solid var(--admCodeBorder);
   color: var(--admCodeColor);
 }
 
-.content-inner .admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) :is(a, a:visited) {
+.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) :is(a, a:visited) {
   color: inherit;
   text-decoration-color: currentColor;
 }
 
 @media screen and (max-width: 768px) {
-  .content-inner .admonition:is(.warning, .error, .info, .neutral, .tip) {
+  .content-inner section.admonition:is(.warning, .error, .info, .neutral, .tip) {
     margin-left: calc(-1 * var(--content-gutter));
     margin-right: calc(-1 * var(--content-gutter));
     padding-left: var(--content-gutter);
@@ -116,7 +116,7 @@
     border-radius: 0;
   }
 
-  .content-inner .admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
+  .content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
     margin: 0 calc(-1 * var(--content-gutter));
   }
 }

--- a/assets/css/content/admonition.css
+++ b/assets/css/content/admonition.css
@@ -1,4 +1,4 @@
-.content-inner .admonition:is(.warning, .error, .info, .neutral, .tip) {
+.content-inner .admonition {
   border-radius: 10px;
   border-left: 0;
 }
@@ -90,13 +90,13 @@
   margin: 0 0.5ch;
 }
 
-.content-inner .admonition:is(.warning, .error, .info, .neutral, .tip) code {
+.content-inner .admonition code {
   background-color: var(--admInlineCodeBackground);
   border: 1px solid var(--admInlineCodeBorder);
   color: var(--admInlineCodeColor);
 }
 
-.content-inner .admonition:is(.warning, .error, .info, .neutral, .tip) pre code {
+.content-inner .admonition  pre code {
   background-color: var(--admCodeBackground);
   border: 1px solid var(--admCodeBorder);
   color: var(--admCodeColor);

--- a/assets/css/content/admonition.css
+++ b/assets/css/content/admonition.css
@@ -1,36 +1,36 @@
-.content-inner section.admonition:is(.warning, .error, .info, .neutral, .tip) {
+.content-inner .admonition:is(.warning, .error, .info, .neutral, .tip) {
   border-radius: 10px;
   border-left: 0;
 }
 
-.content-inner section.admonition.warning {
+.content-inner .admonition.warning {
   background-color: var(--warningBackground);
 }
 
-.content-inner section.admonition.error {
+.content-inner .admonition.error {
   background-color: var(--errorBackground);
 }
 
-.content-inner section.admonition.info {
+.content-inner .admonition.info {
   background-color: var(--infoBackground);
 }
 
-.content-inner section.admonition.neutral {
+.content-inner .admonition.neutral {
   background-color: var(--neutralBackground);
 }
 
-.content-inner section.admonition.tip {
+.content-inner .admonition.tip {
   background-color: var(--tipBackground);
 }
 
-.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
+.content-inner .admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
   color: var(--contrast);
   margin: 0 -1.2rem;
   padding: .7rem 1.2rem .7rem 3.3rem;
   font-weight: 700;
   font-style: normal;
 }
-.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip)::before {
+.content-inner .admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip)::before {
   color: var(--contrast);
   position: absolute;
   left: 1rem;
@@ -41,74 +41,74 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-.content-inner section.admonition :is(h3, h4).warning {
+.content-inner .admonition :is(h3, h4).warning {
   background-color: var(--warningHeadingBackground);
   color: var(--warningHeading);
 }
-.content-inner section.admonition :is(h3, h4).warning::before {
+.content-inner .admonition :is(h3, h4).warning::before {
   content: var(--icon-error-warning);
   color: var(--warningHeading);
 }
 
-.content-inner section.admonition :is(h3, h4).error {
+.content-inner .admonition :is(h3, h4).error {
   background-color: var(--errorHeadingBackground);
   color: var(--errorHeading);
 }
-.content-inner section.admonition :is(h3, h4).error::before {
+.content-inner .admonition :is(h3, h4).error::before {
   content: var(--icon-error-warning);
   color: var(--errorHeading);
 }
 
-.content-inner section.admonition :is(h3, h4).info {
+.content-inner .admonition :is(h3, h4).info {
   background-color: var(--infoHeadingBackground);
   color: var(--infoHeading);
 }
-.content-inner section.admonition :is(h3, h4).info::before {
+.content-inner .admonition :is(h3, h4).info::before {
   content: var(--icon-information);
   color: var(--infoHeading);
 }
 
-.content-inner section.admonition :is(h3, h4).neutral {
+.content-inner .admonition :is(h3, h4).neutral {
   background-color: var(--neutralHeadingBackground);
   color: var(--neutralHeading);
 }
-.content-inner section.admonition :is(h3, h4).neutral::before {
+.content-inner .admonition :is(h3, h4).neutral::before {
   content: var(--icon-double-quotes-l);
   color: var(--neutralHeading);
 }
 
-.content-inner section.admonition :is(h3, h4).tip {
+.content-inner .admonition :is(h3, h4).tip {
   background-color: var(--tipHeadingBackground);
   color: var(--tipHeading);
 }
-.content-inner section.admonition :is(h3, h4).tip::before {
+.content-inner .admonition :is(h3, h4).tip::before {
   content: var(--icon-information);
   color: var(--tipHeading);
 }
 
-.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) code {
+.content-inner .admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) code {
   margin: 0 0.5ch;
 }
 
-.content-inner section.admonition:is(.warning, .error, .info, .neutral, .tip) code {
+.content-inner .admonition:is(.warning, .error, .info, .neutral, .tip) code {
   background-color: var(--admInlineCodeBackground);
   border: 1px solid var(--admInlineCodeBorder);
   color: var(--admInlineCodeColor);
 }
 
-.content-inner section.admonition:is(.warning, .error, .info, .neutral, .tip) pre code {
+.content-inner .admonition:is(.warning, .error, .info, .neutral, .tip) pre code {
   background-color: var(--admCodeBackground);
   border: 1px solid var(--admCodeBorder);
   color: var(--admCodeColor);
 }
 
-.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) :is(a, a:visited) {
+.content-inner .admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) :is(a, a:visited) {
   color: inherit;
   text-decoration-color: currentColor;
 }
 
 @media screen and (max-width: 768px) {
-  .content-inner section.admonition:is(.warning, .error, .info, .neutral, .tip) {
+  .content-inner .admonition:is(.warning, .error, .info, .neutral, .tip) {
     margin-left: calc(-1 * var(--content-gutter));
     margin-right: calc(-1 * var(--content-gutter));
     padding-left: var(--content-gutter);
@@ -116,7 +116,7 @@
     border-radius: 0;
   }
 
-  .content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
+  .content-inner .admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
     margin: 0 calc(-1 * var(--content-gutter));
   }
 }

--- a/assets/css/content/admonition.css
+++ b/assets/css/content/admonition.css
@@ -1,36 +1,36 @@
-.content-inner blockquote:is(.warning, .error, .info, .neutral, .tip) {
+.content-inner div.admonition:is(.warning, .error, .info, .neutral, .tip) {
   border-radius: 10px;
   border-left: 0;
 }
 
-.content-inner blockquote.warning {
+.content-inner div.admonition.warning {
   background-color: var(--warningBackground);
 }
 
-.content-inner blockquote.error {
+.content-inner div.admonition.error {
   background-color: var(--errorBackground);
 }
 
-.content-inner blockquote.info {
+.content-inner div.admonition.info {
   background-color: var(--infoBackground);
 }
 
-.content-inner blockquote.neutral {
+.content-inner div.admonition.neutral {
   background-color: var(--neutralBackground);
 }
 
-.content-inner blockquote.tip {
+.content-inner div.admonition.tip {
   background-color: var(--tipBackground);
 }
 
-.content-inner blockquote :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
+.content-inner div.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
   color: var(--contrast);
   margin: 0 -1.2rem;
   padding: .7rem 1.2rem .7rem 3.3rem;
   font-weight: 700;
   font-style: normal;
 }
-.content-inner blockquote :is(h3, h4):is(.warning, .error, .info, .neutral, .tip)::before {
+.content-inner div.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip)::before {
   color: var(--contrast);
   position: absolute;
   left: 1rem;
@@ -41,74 +41,74 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-.content-inner blockquote :is(h3, h4).warning {
+.content-inner div.admonition :is(h3, h4).warning {
   background-color: var(--warningHeadingBackground);
   color: var(--warningHeading);
 }
-.content-inner blockquote :is(h3, h4).warning::before {
+.content-inner div.admonition :is(h3, h4).warning::before {
   content: var(--icon-error-warning);
   color: var(--warningHeading);
 }
 
-.content-inner blockquote :is(h3, h4).error {
+.content-inner div.admonition :is(h3, h4).error {
   background-color: var(--errorHeadingBackground);
   color: var(--errorHeading);
 }
-.content-inner blockquote :is(h3, h4).error::before {
+.content-inner div.admonition :is(h3, h4).error::before {
   content: var(--icon-error-warning);
   color: var(--errorHeading);
 }
 
-.content-inner blockquote :is(h3, h4).info {
+.content-inner div.admonition :is(h3, h4).info {
   background-color: var(--infoHeadingBackground);
   color: var(--infoHeading);
 }
-.content-inner blockquote :is(h3, h4).info::before {
+.content-inner div.admonition :is(h3, h4).info::before {
   content: var(--icon-information);
   color: var(--infoHeading);
 }
 
-.content-inner blockquote :is(h3, h4).neutral {
+.content-inner div.admonition :is(h3, h4).neutral {
   background-color: var(--neutralHeadingBackground);
   color: var(--neutralHeading);
 }
-.content-inner blockquote :is(h3, h4).neutral::before {
+.content-inner div.admonition :is(h3, h4).neutral::before {
   content: var(--icon-double-quotes-l);
   color: var(--neutralHeading);
 }
 
-.content-inner blockquote :is(h3, h4).tip {
+.content-inner div.admonition :is(h3, h4).tip {
   background-color: var(--tipHeadingBackground);
   color: var(--tipHeading);
 }
-.content-inner blockquote :is(h3, h4).tip::before {
+.content-inner div.admonition :is(h3, h4).tip::before {
   content: var(--icon-information);
   color: var(--tipHeading);
 }
 
-.content-inner blockquote :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) code {
+.content-inner div.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) code {
   margin: 0 0.5ch;
 }
 
-.content-inner blockquote:is(.warning, .error, .info, .neutral, .tip) code {
+.content-inner div.admonition:is(.warning, .error, .info, .neutral, .tip) code {
   background-color: var(--admInlineCodeBackground);
   border: 1px solid var(--admInlineCodeBorder);
   color: var(--admInlineCodeColor);
 }
 
-.content-inner blockquote:is(.warning, .error, .info, .neutral, .tip) pre code {
+.content-inner div.admonition:is(.warning, .error, .info, .neutral, .tip) pre code {
   background-color: var(--admCodeBackground);
   border: 1px solid var(--admCodeBorder);
   color: var(--admCodeColor);
 }
 
-.content-inner blockquote :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) :is(a, a:visited) {
+.content-inner div.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) :is(a, a:visited) {
   color: inherit;
   text-decoration-color: currentColor;
 }
 
 @media screen and (max-width: 768px) {
-  .content-inner blockquote:is(.warning, .error, .info, .neutral, .tip) {
+  .content-inner div.admonition:is(.warning, .error, .info, .neutral, .tip) {
     margin-left: calc(-1 * var(--content-gutter));
     margin-right: calc(-1 * var(--content-gutter));
     padding-left: var(--content-gutter);
@@ -116,7 +116,7 @@
     border-radius: 0;
   }
 
-  .content-inner blockquote :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
+  .content-inner div.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
     margin: 0 calc(-1 * var(--content-gutter));
   }
 }

--- a/assets/css/content/epub-admonition.css
+++ b/assets/css/content/epub-admonition.css
@@ -34,30 +34,30 @@
   border-left-color: var(--tipHeadingBackground);
 }
 
-.content-inner section.admonition > :first-child {
+.content-inner section.admonition > .admonition-title {
   font-weight: bold;
   margin: 0px 10px 5px 0px;
   font-style: normal;
   font-weight: 700;
 }
 
-.content-inner section.admonition > :first-child.warning {
+.content-inner section.admonition > .admonition-title.warning {
   color: var(--warningHeadingBackground);
 }
-.content-inner section.admonition > :first-child.error {
+.content-inner section.admonition > .admonition-title.error {
   color: var(--errorHeadingBackground);
 }
-.content-inner section.admonition > :first-child.info {
+.content-inner section.admonition > .admonition-title.info {
   color: var(--infoHeadingBackground);
 }
-.content-inner section.admonition > :first-child.neutral {
+.content-inner section.admonition > .admonition-title.neutral {
   color: var(--neutralHeadingBackground);
 }
-.content-inner section.admonition > :first-child.tip {
+.content-inner section.admonition > .admonition-title.tip {
   color: var(--tipHeadingBackground);
 }
 
-.content-inner section.admonition > :first-child code {
+.content-inner section.admonition > .admonition-title code {
   margin: 0 0.5ch;
 }
 

--- a/assets/css/content/epub-admonition.css
+++ b/assets/css/content/epub-admonition.css
@@ -1,4 +1,4 @@
-.content-inner div.admonition:is(.warning, .error, .info, .neutral, .tip) {
+.content-inner section.admonition:is(.warning, .error, .info, .neutral, .tip) {
   border-left: solid 4px;
   color: var(--black);
   font-size: 0.9em;
@@ -9,68 +9,68 @@
   page-break-inside: avoid;
 }
 
-.content-inner div.admonition.warning {
+.content-inner section.admonition.warning {
   background-color: var(--warningBackground);
   border-left-color: var(--warningHeadingBackground);
 }
 
-.content-inner div.admonition.error {
+.content-inner section.admonition.error {
   background-color: var(--errorBackground);
   border-left-color: var(--errorHeadingBackground);
 }
 
-.content-inner div.admonition.info {
+.content-inner section.admonition.info {
   background-color: var(--infoBackground);
   border-left-color: var(--infoHeadingBackground);
 }
 
-.content-inner div.admonition.neutral {
+.content-inner section.admonition.neutral {
   background-color: var(--neutralBackground);
   border-left-color: var(--neutralHeadingBackground);
 }
 
-.content-inner div.admonition.tip {
+.content-inner section.admonition.tip {
   background-color: var(--tipBackground);
   border-left-color: var(--tipHeadingBackground);
 }
 
-.content-inner div.admonition :is(h3, h4) {
+.content-inner section.admonition :is(h3, h4) {
   font-weight: bold;
   margin: 0px 10px 5px 0px;
 }
 
-.content-inner div.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
+.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
   font-style: normal;
   font-weight: 700;
 }
 
-.content-inner div.admonition :is(h3, h4).warning {
+.content-inner section.admonition :is(h3, h4).warning {
   color: var(--warningHeadingBackground);
 }
-.content-inner div.admonition :is(h3, h4).error {
+.content-inner section.admonition :is(h3, h4).error {
   color: var(--errorHeadingBackground);
 }
-.content-inner div.admonition :is(h3, h4).info {
+.content-inner section.admonition :is(h3, h4).info {
   color: var(--infoHeadingBackground);
 }
-.content-inner div.admonition :is(h3, h4).neutral {
+.content-inner section.admonition :is(h3, h4).neutral {
   color: var(--neutralHeadingBackground);
 }
-.content-inner div.admonition :is(h3, h4).tip {
+.content-inner section.admonition :is(h3, h4).tip {
   color: var(--tipHeadingBackground);
 }
 
-.content-inner div.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) code {
+.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) code {
   margin: 0 0.5ch;
 }
 
-.content-inner div.admonition:is(.warning, .error, .info, .neutral, .tip) code {
+.content-inner section.admonition:is(.warning, .error, .info, .neutral, .tip) code {
   background-color: var(--admInlineCodeBackground);
   border: 1px solid var(--admInlineCodeBorder);
   color: var(--admInlineCodeColor);
 }
 
-.content-inner div.admonition:is(.warning, .error, .info, .neutral, .tip) pre code {
+.content-inner section.admonition:is(.warning, .error, .info, .neutral, .tip) pre code {
   background-color: var(--admCodeBackground);
   border: 1px solid var(--admCodeBorder);
   color: var(--admCodeColor);

--- a/assets/css/content/epub-admonition.css
+++ b/assets/css/content/epub-admonition.css
@@ -1,4 +1,4 @@
-.content-inner section.admonition:is(.warning, .error, .info, .neutral, .tip) {
+.content-inner .admonition:is(.warning, .error, .info, .neutral, .tip) {
   border-left: solid 4px;
   color: var(--black);
   font-size: 0.9em;
@@ -9,68 +9,68 @@
   page-break-inside: avoid;
 }
 
-.content-inner section.admonition.warning {
+.content-inner .admonition.warning {
   background-color: var(--warningBackground);
   border-left-color: var(--warningHeadingBackground);
 }
 
-.content-inner section.admonition.error {
+.content-inner .admonition.error {
   background-color: var(--errorBackground);
   border-left-color: var(--errorHeadingBackground);
 }
 
-.content-inner section.admonition.info {
+.content-inner .admonition.info {
   background-color: var(--infoBackground);
   border-left-color: var(--infoHeadingBackground);
 }
 
-.content-inner section.admonition.neutral {
+.content-inner .admonition.neutral {
   background-color: var(--neutralBackground);
   border-left-color: var(--neutralHeadingBackground);
 }
 
-.content-inner section.admonition.tip {
+.content-inner .admonition.tip {
   background-color: var(--tipBackground);
   border-left-color: var(--tipHeadingBackground);
 }
 
-.content-inner section.admonition :is(h3, h4) {
+.content-inner .admonition :is(h3, h4) {
   font-weight: bold;
   margin: 0px 10px 5px 0px;
 }
 
-.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
+.content-inner .admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
   font-style: normal;
   font-weight: 700;
 }
 
-.content-inner section.admonition :is(h3, h4).warning {
+.content-inner .admonition :is(h3, h4).warning {
   color: var(--warningHeadingBackground);
 }
-.content-inner section.admonition :is(h3, h4).error {
+.content-inner .admonition :is(h3, h4).error {
   color: var(--errorHeadingBackground);
 }
-.content-inner section.admonition :is(h3, h4).info {
+.content-inner .admonition :is(h3, h4).info {
   color: var(--infoHeadingBackground);
 }
-.content-inner section.admonition :is(h3, h4).neutral {
+.content-inner .admonition :is(h3, h4).neutral {
   color: var(--neutralHeadingBackground);
 }
-.content-inner section.admonition :is(h3, h4).tip {
+.content-inner .admonition :is(h3, h4).tip {
   color: var(--tipHeadingBackground);
 }
 
-.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) code {
+.content-inner .admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) code {
   margin: 0 0.5ch;
 }
 
-.content-inner section.admonition:is(.warning, .error, .info, .neutral, .tip) code {
+.content-inner .admonition:is(.warning, .error, .info, .neutral, .tip) code {
   background-color: var(--admInlineCodeBackground);
   border: 1px solid var(--admInlineCodeBorder);
   color: var(--admInlineCodeColor);
 }
 
-.content-inner section.admonition:is(.warning, .error, .info, .neutral, .tip) pre code {
+.content-inner .admonition:is(.warning, .error, .info, .neutral, .tip) pre code {
   background-color: var(--admCodeBackground);
   border: 1px solid var(--admCodeBorder);
   color: var(--admCodeColor);

--- a/assets/css/content/epub-admonition.css
+++ b/assets/css/content/epub-admonition.css
@@ -1,4 +1,4 @@
-.content-inner .admonition:is(.warning, .error, .info, .neutral, .tip) {
+.content-inner .admonition {
   border-left: solid 4px;
   color: var(--black);
   font-size: 0.9em;
@@ -64,13 +64,13 @@
   margin: 0 0.5ch;
 }
 
-.content-inner .admonition:is(.warning, .error, .info, .neutral, .tip) code {
+.content-inner .admonition code {
   background-color: var(--admInlineCodeBackground);
   border: 1px solid var(--admInlineCodeBorder);
   color: var(--admInlineCodeColor);
 }
 
-.content-inner .admonition:is(.warning, .error, .info, .neutral, .tip) pre code {
+.content-inner .admonition pre code {
   background-color: var(--admCodeBackground);
   border: 1px solid var(--admCodeBorder);
   color: var(--admCodeColor);

--- a/assets/css/content/epub-admonition.css
+++ b/assets/css/content/epub-admonition.css
@@ -1,4 +1,4 @@
-.content-inner .admonition {
+.content-inner section.admonition {
   border-left: solid 4px;
   color: var(--black);
   font-size: 0.9em;
@@ -9,68 +9,68 @@
   page-break-inside: avoid;
 }
 
-.content-inner .admonition.warning {
+.content-inner section.admonition.warning {
   background-color: var(--warningBackground);
   border-left-color: var(--warningHeadingBackground);
 }
 
-.content-inner .admonition.error {
+.content-inner section.admonition.error {
   background-color: var(--errorBackground);
   border-left-color: var(--errorHeadingBackground);
 }
 
-.content-inner .admonition.info {
+.content-inner section.admonition.info {
   background-color: var(--infoBackground);
   border-left-color: var(--infoHeadingBackground);
 }
 
-.content-inner .admonition.neutral {
+.content-inner section.admonition.neutral {
   background-color: var(--neutralBackground);
   border-left-color: var(--neutralHeadingBackground);
 }
 
-.content-inner .admonition.tip {
+.content-inner section.admonition.tip {
   background-color: var(--tipBackground);
   border-left-color: var(--tipHeadingBackground);
 }
 
-.content-inner .admonition :is(h3, h4) {
+.content-inner section.admonition :is(h3, h4) {
   font-weight: bold;
   margin: 0px 10px 5px 0px;
 }
 
-.content-inner .admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
+.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
   font-style: normal;
   font-weight: 700;
 }
 
-.content-inner .admonition :is(h3, h4).warning {
+.content-inner section.admonition :is(h3, h4).warning {
   color: var(--warningHeadingBackground);
 }
-.content-inner .admonition :is(h3, h4).error {
+.content-inner section.admonition :is(h3, h4).error {
   color: var(--errorHeadingBackground);
 }
-.content-inner .admonition :is(h3, h4).info {
+.content-inner section.admonition :is(h3, h4).info {
   color: var(--infoHeadingBackground);
 }
-.content-inner .admonition :is(h3, h4).neutral {
+.content-inner section.admonition :is(h3, h4).neutral {
   color: var(--neutralHeadingBackground);
 }
-.content-inner .admonition :is(h3, h4).tip {
+.content-inner section.admonition :is(h3, h4).tip {
   color: var(--tipHeadingBackground);
 }
 
-.content-inner .admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) code {
+.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) code {
   margin: 0 0.5ch;
 }
 
-.content-inner .admonition code {
+.content-inner section.admonition code {
   background-color: var(--admInlineCodeBackground);
   border: 1px solid var(--admInlineCodeBorder);
   color: var(--admInlineCodeColor);
 }
 
-.content-inner .admonition pre code {
+.content-inner section.admonition pre code {
   background-color: var(--admCodeBackground);
   border: 1px solid var(--admCodeBorder);
   color: var(--admCodeColor);

--- a/assets/css/content/epub-admonition.css
+++ b/assets/css/content/epub-admonition.css
@@ -34,33 +34,30 @@
   border-left-color: var(--tipHeadingBackground);
 }
 
-.content-inner section.admonition :is(h3, h4) {
+.content-inner section.admonition > :first-child {
   font-weight: bold;
   margin: 0px 10px 5px 0px;
-}
-
-.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
   font-style: normal;
   font-weight: 700;
 }
 
-.content-inner section.admonition :is(h3, h4).warning {
+.content-inner section.admonition > :first-child.warning {
   color: var(--warningHeadingBackground);
 }
-.content-inner section.admonition :is(h3, h4).error {
+.content-inner section.admonition > :first-child.error {
   color: var(--errorHeadingBackground);
 }
-.content-inner section.admonition :is(h3, h4).info {
+.content-inner section.admonition > :first-child.info {
   color: var(--infoHeadingBackground);
 }
-.content-inner section.admonition :is(h3, h4).neutral {
+.content-inner section.admonition > :first-child.neutral {
   color: var(--neutralHeadingBackground);
 }
-.content-inner section.admonition :is(h3, h4).tip {
+.content-inner section.admonition > :first-child.tip {
   color: var(--tipHeadingBackground);
 }
 
-.content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) code {
+.content-inner section.admonition > :first-child code {
   margin: 0 0.5ch;
 }
 

--- a/assets/css/content/epub-admonition.css
+++ b/assets/css/content/epub-admonition.css
@@ -1,4 +1,4 @@
-.content-inner blockquote:is(.warning, .error, .info, .neutral, .tip) {
+.content-inner div.admonition:is(.warning, .error, .info, .neutral, .tip) {
   border-left: solid 4px;
   color: var(--black);
   font-size: 0.9em;
@@ -9,68 +9,68 @@
   page-break-inside: avoid;
 }
 
-.content-inner blockquote.warning {
+.content-inner div.admonition.warning {
   background-color: var(--warningBackground);
   border-left-color: var(--warningHeadingBackground);
 }
 
-.content-inner blockquote.error {
+.content-inner div.admonition.error {
   background-color: var(--errorBackground);
   border-left-color: var(--errorHeadingBackground);
 }
 
-.content-inner blockquote.info {
+.content-inner div.admonition.info {
   background-color: var(--infoBackground);
   border-left-color: var(--infoHeadingBackground);
 }
 
-.content-inner blockquote.neutral {
+.content-inner div.admonition.neutral {
   background-color: var(--neutralBackground);
   border-left-color: var(--neutralHeadingBackground);
 }
 
-.content-inner blockquote.tip {
+.content-inner div.admonition.tip {
   background-color: var(--tipBackground);
   border-left-color: var(--tipHeadingBackground);
 }
 
-.content-inner blockquote :is(h3, h4) {
+.content-inner div.admonition :is(h3, h4) {
   font-weight: bold;
   margin: 0px 10px 5px 0px;
 }
 
-.content-inner blockquote :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
+.content-inner div.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
   font-style: normal;
   font-weight: 700;
 }
 
-.content-inner blockquote :is(h3, h4).warning {
+.content-inner div.admonition :is(h3, h4).warning {
   color: var(--warningHeadingBackground);
 }
-.content-inner blockquote :is(h3, h4).error {
+.content-inner div.admonition :is(h3, h4).error {
   color: var(--errorHeadingBackground);
 }
-.content-inner blockquote :is(h3, h4).info {
+.content-inner div.admonition :is(h3, h4).info {
   color: var(--infoHeadingBackground);
 }
-.content-inner blockquote :is(h3, h4).neutral {
+.content-inner div.admonition :is(h3, h4).neutral {
   color: var(--neutralHeadingBackground);
 }
-.content-inner blockquote :is(h3, h4).tip {
+.content-inner div.admonition :is(h3, h4).tip {
   color: var(--tipHeadingBackground);
 }
 
-.content-inner blockquote :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) code {
+.content-inner div.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) code {
   margin: 0 0.5ch;
 }
 
-.content-inner blockquote:is(.warning, .error, .info, .neutral, .tip) code {
+.content-inner div.admonition:is(.warning, .error, .info, .neutral, .tip) code {
   background-color: var(--admInlineCodeBackground);
   border: 1px solid var(--admInlineCodeBorder);
   color: var(--admInlineCodeColor);
 }
 
-.content-inner blockquote:is(.warning, .error, .info, .neutral, .tip) pre code {
+.content-inner div.admonition:is(.warning, .error, .info, .neutral, .tip) pre code {
   background-color: var(--admCodeBackground);
   border: 1px solid var(--admCodeBorder);
   color: var(--admCodeColor);

--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -97,7 +97,7 @@
   font-weight: normal;
 }
 
-.content-inner blockquote, .content-inner .admonition {
+.content-inner blockquote, .content-inner section.admonition {
   border-left: 3px solid var(--blockquoteBorder);
   position: relative;
   margin: 1.5625em 0;
@@ -106,7 +106,7 @@
   background-color: var(--blockquoteBackground);
   border-radius: var(--borderRadius);
 }
-.content-inner blockquote p:last-child, .content-inner .admonition p:last-child  {
+.content-inner blockquote p:last-child, .content-inner section.admonition p:last-child  {
   padding-bottom: 1em;
   margin-bottom: 0;
 }

--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -97,7 +97,7 @@
   font-weight: normal;
 }
 
-.content-inner blockquote, .content-inner div.admonition {
+.content-inner blockquote, .content-inner section.admonition {
   border-left: 3px solid var(--blockquoteBorder);
   position: relative;
   margin: 1.5625em 0;
@@ -106,7 +106,7 @@
   background-color: var(--blockquoteBackground);
   border-radius: var(--borderRadius);
 }
-.content-inner blockquote p:last-child {
+.content-inner blockquote p:last-child, .content-inner section.admonition p:last-child  {
   padding-bottom: 1em;
   margin-bottom: 0;
 }

--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -178,7 +178,7 @@
   }
 }
 
-.content-inner blockquote .section-heading i {
+.content-inner :is(blockquote, section.admonition) .section-heading i {
   display: none;
 }
 

--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -97,7 +97,7 @@
   font-weight: normal;
 }
 
-.content-inner blockquote, .content-inner section.admonition {
+.content-inner blockquote, .content-inner .admonition {
   border-left: 3px solid var(--blockquoteBorder);
   position: relative;
   margin: 1.5625em 0;
@@ -106,7 +106,7 @@
   background-color: var(--blockquoteBackground);
   border-radius: var(--borderRadius);
 }
-.content-inner blockquote p:last-child, .content-inner section.admonition p:last-child  {
+.content-inner blockquote p:last-child, .content-inner .admonition p:last-child  {
   padding-bottom: 1em;
   margin-bottom: 0;
 }

--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -97,7 +97,7 @@
   font-weight: normal;
 }
 
-.content-inner blockquote {
+.content-inner blockquote, .content-inner div.admonition {
   border-left: 3px solid var(--blockquoteBorder);
   position: relative;
   margin: 1.5625em 0;

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -56,7 +56,7 @@
     border: 2px solid var(--gray400);
   }
 
-  .content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
+  .content-inner section.admonition > :first-child {
     color: var(--textHeaders);
     border-bottom: 2px solid var(--gray400);
   }

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -52,11 +52,11 @@
     display: none;
   }
 
-  .content-inner section.admonition:is(.warning, .error, .info, .neutral, .tip) {
+  .content-inner .admonition:is(.warning, .error, .info, .neutral, .tip) {
     border: 2px solid var(--gray400);
   }
 
-  .content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
+  .content-inner .admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
     color: var(--textHeaders);
     border-bottom: 2px solid var(--gray400);
   }

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -56,7 +56,7 @@
     border: 2px solid var(--gray400);
   }
 
-  .content-inner section.admonition > :first-child {
+  .content-inner section.admonition > .admonition-title {
     color: var(--textHeaders);
     border-bottom: 2px solid var(--gray400);
   }

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -52,11 +52,11 @@
     display: none;
   }
 
-  .content-inner blockquote:is(.warning, .error, .info, .neutral, .tip) {
+  .content-inner section.admonition:is(.warning, .error, .info, .neutral, .tip) {
     border: 2px solid var(--gray400);
   }
 
-  .content-inner blockquote :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
+  .content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
     color: var(--textHeaders);
     border-bottom: 2px solid var(--gray400);
   }

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -52,11 +52,11 @@
     display: none;
   }
 
-  .content-inner .admonition {
+  .content-inner section.admonition {
     border: 2px solid var(--gray400);
   }
 
-  .content-inner .admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
+  .content-inner section.admonition :is(h3, h4):is(.warning, .error, .info, .neutral, .tip) {
     color: var(--textHeaders);
     border-bottom: 2px solid var(--gray400);
   }

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -52,7 +52,7 @@
     display: none;
   }
 
-  .content-inner .admonition:is(.warning, .error, .info, .neutral, .tip) {
+  .content-inner .admonition {
     border: 2px solid var(--gray400);
   }
 

--- a/assets/css/tabset.css
+++ b/assets/css/tabset.css
@@ -58,7 +58,8 @@
   }
 
   .tabset-panel pre,
-  .tabset-panel blockquote {
+  .tabset-panel blockquote,
+  .tabset-panel section.admonition {
     margin-left: calc(-1 * var(--tabsetPadding)) !important;
     margin-right: calc(-1 * var(--tabsetPadding)) !important;
   }

--- a/assets/css/tabset.css
+++ b/assets/css/tabset.css
@@ -59,7 +59,7 @@
 
   .tabset-panel pre,
   .tabset-panel blockquote,
-  .tabset-panel .admonition {
+  .tabset-panel section.admonition {
     margin-left: calc(-1 * var(--tabsetPadding)) !important;
     margin-right: calc(-1 * var(--tabsetPadding)) !important;
   }

--- a/assets/css/tabset.css
+++ b/assets/css/tabset.css
@@ -59,7 +59,7 @@
 
   .tabset-panel pre,
   .tabset-panel blockquote,
-  .tabset-panel section.admonition {
+  .tabset-panel .admonition {
     margin-left: calc(-1 * var(--tabsetPadding)) !important;
     margin-right: calc(-1 * var(--tabsetPadding)) !important;
   }

--- a/assets/js/content.js
+++ b/assets/js/content.js
@@ -16,7 +16,6 @@ export function initialize (isPreview) {
 
   setLivebookBadgeUrl()
   fixLinks()
-  fixBlockquotes()
 }
 
 /**
@@ -27,20 +26,6 @@ function fixLinks () {
     if (anchor.querySelector('code, img')) {
       anchor.classList.add('no-underline')
     }
-  })
-}
-
-/**
- * Add CSS classes to `blockquote` elements when those are used to
- * support admonition text blocks
- */
-export function fixBlockquotes () {
-  const classes = ['warning', 'info', 'error', 'neutral', 'tip']
-
-  classes.forEach(element => {
-    qsAll(`blockquote h3.${element}, blockquote h4.${element}`).forEach(header => {
-      header.closest('blockquote').classList.add(element)
-    })
   })
 }
 

--- a/assets/js/entry/epub.js
+++ b/assets/js/entry/epub.js
@@ -1,8 +1,6 @@
 import { onDocumentReady } from '../helpers'
-import { fixBlockquotes } from '../content'
 import { initialize as initMakeup } from '../makeup'
 
 onDocumentReady(() => {
   initMakeup()
-  fixBlockquotes()
 })

--- a/lib/ex_doc/markdown/earmark.ex
+++ b/lib/ex_doc/markdown/earmark.ex
@@ -84,7 +84,7 @@ defmodule ExDoc.Markdown.Earmark do
        when tag in ["h3", "h4"] do
     h_admonition =
       with {{"class", classes}, attrs} <- List.keytake(h_attrs, "class", 0),
-           class_list <- String.split(classes),
+           class_list <- String.split(classes, " "),
            adm_classes = [_ | _] <- Enum.filter(class_list, &(&1 in @admonition_classes)) do
         {"admonition " <> Enum.join(adm_classes, " "),
          [{"class", "admonition-title #{classes}"} | attrs]}

--- a/lib/ex_doc/markdown/earmark.ex
+++ b/lib/ex_doc/markdown/earmark.ex
@@ -78,8 +78,8 @@ defmodule ExDoc.Markdown.Earmark do
 
   # Convert admonition blockquotes to divs for screen reader accessibility
   defp fixup(
-         {"blockquote", blockquote_attrs, [{tag, h_attrs, _h_content, _h_meta} = h_elem | rest] = ast,
-          blockquote_meta}
+         {"blockquote", blockquote_attrs,
+          [{tag, h_attrs, _h_content, _h_meta} = h_elem | rest] = ast, blockquote_meta}
        )
        when tag in ["h3", "h4"] do
     h_admonition_classes =
@@ -97,13 +97,15 @@ defmodule ExDoc.Markdown.Earmark do
       end)
 
     if h_admonition_classes != "" do
+      admonition_classes = "admonition #{h_admonition_classes}"
+
       blockquote_attrs =
         case Enum.split_with(blockquote_attrs, &match?({"class", _}, &1)) do
           {[], attrs} ->
-            [{"class", h_admonition_classes}, {"role", "note"} | attrs]
+            [{"class", admonition_classes}, {"role", "note"} | attrs]
 
           {[{"class", classes}], attrs} ->
-            classes = String.trim_trailing(classes) <> " #{h_admonition_classes}"
+            classes = String.trim_trailing(classes) <> " #{admonition_classes}"
             [{"class", classes}, {"role", "note"} | attrs]
         end
 

--- a/lib/ex_doc/markdown/earmark.ex
+++ b/lib/ex_doc/markdown/earmark.ex
@@ -109,7 +109,7 @@ defmodule ExDoc.Markdown.Earmark do
             [{"class", classes}, {"role", "note"} | attrs]
         end
 
-      fixup({"div", blockquote_attrs, [h_elem | rest], blockquote_meta})
+      fixup({"section", blockquote_attrs, [h_elem | rest], blockquote_meta})
     else
       # regular blockquote, copied fixup/1 here to avoid infinite loop
       {:blockquote, Enum.map(blockquote_attrs, &fixup_attr/1), fixup(ast), blockquote_meta}

--- a/test/ex_doc/markdown/earmark_test.exs
+++ b/test/ex_doc/markdown/earmark_test.exs
@@ -80,12 +80,14 @@ defmodule ExDoc.Markdown.EarmarkTest do
       > #### Info {: .info .ignore}
       > This is info.
       """
+
       assert Markdown.to_ast(info, []) == [
-        {:div, [class: "info", role: "note"], [
-          {:h4, [class: "ignore info"], ["Info"], %{}},
-          {:p, [], ["This is info."], %{}}
-        ], %{}}
-      ]
+               {:div, [class: "info", role: "note"],
+                [
+                  {:h4, [class: "ignore info"], ["Info"], %{}},
+                  {:p, [], ["This is info."], %{}}
+                ], %{}}
+             ]
 
       not_admonition = """
       > ### H3 {: .xyz}
@@ -93,11 +95,12 @@ defmodule ExDoc.Markdown.EarmarkTest do
       """
 
       assert Markdown.to_ast(not_admonition, []) == [
-        {:blockquote, [], [
-          {:h3, [class: "xyz"], ["H3"], %{}},
-          {:p, [], ["This is NOT an admonition!"], %{}}
-        ], %{}}
-      ]
+               {:blockquote, [],
+                [
+                  {:h3, [class: "xyz"], ["H3"], %{}},
+                  {:p, [], ["This is NOT an admonition!"], %{}}
+                ], %{}}
+             ]
 
       warning_error = """
       > ### Warning! Error! {: .warning .error}
@@ -105,11 +108,12 @@ defmodule ExDoc.Markdown.EarmarkTest do
       """
 
       assert Markdown.to_ast(warning_error, []) == [
-        {:div, [class: "error warning", role: "note"], [
-          {:h3, [class: "error warning"], ["Warning! Error!"], %{}},
-          {:p, [], ["A warning and an error."], %{}}
-        ], %{}}
-      ]
+               {:div, [class: "error warning", role: "note"],
+                [
+                  {:h3, [class: "error warning"], ["Warning! Error!"], %{}},
+                  {:p, [], ["A warning and an error."], %{}}
+                ], %{}}
+             ]
     end
 
     test "keeps math syntax without interpreting math as markdown" do

--- a/test/ex_doc/markdown/earmark_test.exs
+++ b/test/ex_doc/markdown/earmark_test.exs
@@ -75,6 +75,43 @@ defmodule ExDoc.Markdown.EarmarkTest do
              ]
     end
 
+    test "converts blockquote admonitions to regular divs" do
+      info = """
+      > #### Info {: .info .ignore}
+      > This is info.
+      """
+      assert Markdown.to_ast(info, []) == [
+        {:div, [class: "info", role: "note"], [
+          {:h4, [class: "ignore info"], ["Info"], %{}},
+          {:p, [], ["This is info."], %{}}
+        ], %{}}
+      ]
+
+      not_admonition = """
+      > ### H3 {: .xyz}
+      > This is NOT an admonition!
+      """
+
+      assert Markdown.to_ast(not_admonition, []) == [
+        {:blockquote, [], [
+          {:h3, [class: "xyz"], ["H3"], %{}},
+          {:p, [], ["This is NOT an admonition!"], %{}}
+        ], %{}}
+      ]
+
+      warning_error = """
+      > ### Warning! Error! {: .warning .error}
+      > A warning and an error.
+      """
+
+      assert Markdown.to_ast(warning_error, []) == [
+        {:div, [class: "error warning", role: "note"], [
+          {:h3, [class: "error warning"], ["Warning! Error!"], %{}},
+          {:p, [], ["A warning and an error."], %{}}
+        ], %{}}
+      ]
+    end
+
     test "keeps math syntax without interpreting math as markdown" do
       assert Markdown.to_ast("Math $x *y* y$", []) == [
                {:p, [], ["Math ", "$x *y* y$"], %{}}

--- a/test/ex_doc/markdown/earmark_test.exs
+++ b/test/ex_doc/markdown/earmark_test.exs
@@ -82,7 +82,7 @@ defmodule ExDoc.Markdown.EarmarkTest do
       """
 
       assert Markdown.to_ast(info, []) == [
-               {:div, [class: "info", role: "note"],
+               {:div, [class: "admonition info", role: "note"],
                 [
                   {:h4, [class: "ignore info"], ["Info"], %{}},
                   {:p, [], ["This is info."], %{}}
@@ -108,7 +108,7 @@ defmodule ExDoc.Markdown.EarmarkTest do
       """
 
       assert Markdown.to_ast(warning_error, []) == [
-               {:div, [class: "error warning", role: "note"],
+               {:div, [class: "admonition error warning", role: "note"],
                 [
                   {:h3, [class: "error warning"], ["Warning! Error!"], %{}},
                   {:p, [], ["A warning and an error."], %{}}

--- a/test/ex_doc/markdown/earmark_test.exs
+++ b/test/ex_doc/markdown/earmark_test.exs
@@ -84,7 +84,7 @@ defmodule ExDoc.Markdown.EarmarkTest do
       assert Markdown.to_ast(info, []) == [
                {:section, [class: "admonition info", role: "note"],
                 [
-                  {:h4, [class: "ignore info"], ["Info"], %{}},
+                  {:h4, [class: "admonition-title ignore info"], ["Info"], %{}},
                   {:p, [], ["This is info."], %{}}
                 ], %{}}
              ]
@@ -110,7 +110,7 @@ defmodule ExDoc.Markdown.EarmarkTest do
       assert Markdown.to_ast(warning_error, []) == [
                {:section, [class: "admonition error warning", role: "note"],
                 [
-                  {:h3, [class: "error warning"], ["Warning! Error!"], %{}},
+                  {:h3, [class: "admonition-title error warning"], ["Warning! Error!"], %{}},
                   {:p, [], ["A warning and an error."], %{}}
                 ], %{}}
              ]

--- a/test/ex_doc/markdown/earmark_test.exs
+++ b/test/ex_doc/markdown/earmark_test.exs
@@ -75,20 +75,7 @@ defmodule ExDoc.Markdown.EarmarkTest do
              ]
     end
 
-    test "converts blockquote admonitions to regular divs" do
-      info = """
-      > #### Info {: .info .ignore}
-      > This is info.
-      """
-
-      assert Markdown.to_ast(info, []) == [
-               {:section, [class: "admonition info", role: "note"],
-                [
-                  {:h4, [class: "admonition-title ignore info"], ["Info"], %{}},
-                  {:p, [], ["This is info."], %{}}
-                ], %{}}
-             ]
-
+    test "leaves blockquotes with the wrong markup as is" do
       not_admonition = """
       > ### H3 {: .xyz}
       > This is NOT an admonition!
@@ -102,18 +89,80 @@ defmodule ExDoc.Markdown.EarmarkTest do
                 ], %{}}
              ]
 
+      no_h_tag_beginning = """
+      > {: .warning}
+      > #### Warning {: .warning}
+      > This blockquote didn't start with the h4 tag, so it wasn't converted.
+      """
+
+      assert Markdown.to_ast(no_h_tag_beginning, []) == [
+               {:blockquote, [],
+                [
+                  {:p, [], ["{: .warning}"], %{}},
+                  {:h4, [class: "warning"], ["Warning"], %{}},
+                  {:p, [],
+                   ["This blockquote didn't start with the h4 tag, so it wasn't converted."], %{}}
+                ], %{}}
+             ]
+    end
+
+    test "converts blockquotes with the appropriate markup to admonition sections" do
+      info = """
+      > #### Info {: .info .ignore}
+      > This is info.
+      """
+
+      assert [
+               {:section, section_attrs,
+                [
+                  {:h4, h_attrs, ["Info"], %{}},
+                  {:p, [], ["This is info."], %{}}
+                ], %{}}
+             ] = Markdown.to_ast(info, [])
+
+      assert section_attrs[:role] == "note"
+      assert section_attrs[:class] == "admonition info"
+
+      assert h_attrs[:class] == "admonition-title ignore info"
+
       warning_error = """
       > ### Warning! Error! {: .warning .error}
       > A warning and an error.
       """
 
-      assert Markdown.to_ast(warning_error, []) == [
-               {:section, [class: "admonition error warning", role: "note"],
+      assert [
+               {:section, section_attrs,
                 [
-                  {:h3, [class: "admonition-title error warning"], ["Warning! Error!"], %{}},
+                  {:h3, h_attrs, ["Warning! Error!"], %{}},
                   {:p, [], ["A warning and an error."], %{}}
                 ], %{}}
-             ]
+             ] = Markdown.to_ast(warning_error, [])
+
+      assert section_attrs[:role] == "note"
+      assert section_attrs[:class] == "admonition error warning"
+
+      assert h_attrs[:class] == "admonition-title error warning"
+
+      with_blockquote_level_attrs = """
+      > ### Eggs and baskets  {: .tip}
+      > Don't put all your eggs in one basket, especially if they're golden.
+      {: .egg-basket-bg #egg-basket-tip}
+      """
+
+      assert [
+               {:section, section_attrs,
+                [
+                  {:h3, h_attrs, ["Eggs and baskets"], %{}},
+                  {:p, [],
+                   ["Don't put all your eggs in one basket, especially if they're golden."], %{}}
+                ], %{}}
+             ] = Markdown.to_ast(with_blockquote_level_attrs, [])
+
+      assert section_attrs[:role] == "note"
+      assert section_attrs[:class] == "admonition tip egg-basket-bg"
+      assert section_attrs[:id] == "egg-basket-tip"
+
+      assert h_attrs[:class] == "admonition-title tip"
     end
 
     test "keeps math syntax without interpreting math as markdown" do

--- a/test/ex_doc/markdown/earmark_test.exs
+++ b/test/ex_doc/markdown/earmark_test.exs
@@ -82,7 +82,7 @@ defmodule ExDoc.Markdown.EarmarkTest do
       """
 
       assert Markdown.to_ast(info, []) == [
-               {:div, [class: "admonition info", role: "note"],
+               {:section, [class: "admonition info", role: "note"],
                 [
                   {:h4, [class: "ignore info"], ["Info"], %{}},
                   {:p, [], ["This is info."], %{}}
@@ -108,7 +108,7 @@ defmodule ExDoc.Markdown.EarmarkTest do
       """
 
       assert Markdown.to_ast(warning_error, []) == [
-               {:div, [class: "admonition error warning", role: "note"],
+               {:section, [class: "admonition error warning", role: "note"],
                 [
                   {:h3, [class: "error warning"], ["Warning! Error!"], %{}},
                   {:p, [], ["A warning and an error."], %{}}


### PR DESCRIPTION
Some screen readers will announce that an element is a blockquote. It could be potentially surprising to hear something announced as a blockquote despite the inner contents not being a quote.

References:
 - https://adrianroselli.com/2023/07/blockquotes-in-screen-readers.html#Example01
 - https://v5.chriskrycho.com/journal/psa-on-blockquotes/

Closes #1939 