### PR TITLE
Warn when trying to reference types in hidden modules

### DIFF
--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -511,6 +511,18 @@ defmodule ExDoc.Autolink do
              (config.language != ExDoc.Language.Erlang or kind == :function) ->
         nil
 
+      {:regular_link, :hidden, :hidden}
+      when not same_module? ->
+        if warn? do
+          maybe_warn(config, ref, :hidden, %{
+            original_text: original_text,
+            module_visibility: :hidden,
+            same_module?: false
+          })
+        end
+
+        nil
+
       {_mode, _module_visibility, visibility} ->
         if warn? do
           maybe_warn(config, ref, visibility, %{original_text: original_text})
@@ -581,6 +593,19 @@ defmodule ExDoc.Autolink do
          %{file_path: _file_path, original_text: original_text}
        ) do
     message = "documentation references file \"#{original_text}\" but it does not exist"
+
+    warn(config, message)
+  end
+
+  defp warn(
+         config,
+         {:type, module, _name, _arity},
+         :hidden,
+         %{original_text: original_text, module_visibility: :hidden, same_module?: false}
+       ) do
+    message =
+      "documentation references type \"#{original_text}\" but the module " <>
+        "#{inspect(module)} is #{format_visibility(:hidden, :module)}"
 
     warn(config, message)
   end

--- a/test/ex_doc/language/elixir_test.exs
+++ b/test/ex_doc/language/elixir_test.exs
@@ -500,7 +500,9 @@ defmodule ExDoc.Language.ElixirTest do
     ExDoc.Refs.insert([
       {{:module, AutolinkTest.Foo}, :public},
       {{:function, AutolinkTest.Foo, :bar, 1}, :hidden},
-      {{:type, AutolinkTest.Foo, :bad, 0}, :hidden}
+      {{:type, AutolinkTest.Foo, :bad, 0}, :hidden},
+      {{:module, AutoLinkTest.Hidden}, :hidden},
+      {{:type, AutoLinkTest.Hidden, :my_type, 0}, :hidden}
     ])
 
     opts = [
@@ -518,6 +520,12 @@ defmodule ExDoc.Language.ElixirTest do
     assert_received {:warn, message, metadata}
     assert message =~ ~s|references function "AutolinkTest.Foo.bar/1" but it is hidden|
     assert metadata == [file: "foo.ex", line: 2]
+
+    assert warn(fn ->
+             assert autolink_doc("`t:AutoLinkTest.Hidden.my_type/0`", opts) ==
+                      ~s|<code class="inline">t:AutoLinkTest.Hidden.my_type/0</code>|
+           end) =~
+             ~s|documentation references type "t:AutoLinkTest.Hidden.my_type/0" but the module AutoLinkTest.Hidden is hidden|
 
     assert warn(fn ->
              assert autolink_doc("`t:AutolinkTest.Foo.bad/0`", opts) ==


### PR DESCRIPTION
Closes #1932
When a module is hidden, its types will also be hidden. We check for two conditions and warn the user if both are met:
 - The module defining the type is hidden
 - The type itself is hidden If the type is undefined, the standard warning is displayed instead

It does not seem possible to do this check for Erlang modules.