### PR TITLE
First attempt at supporting encrypted debug_info

### DIFF
--- a/lib/ex_doc/config.ex
+++ b/lib/ex_doc/config.ex
@@ -125,7 +125,12 @@ defmodule ExDoc.Config do
       end)
 
     {debug_info_key, options} = Keyword.pop(options, :debug_info_key)
-    {debug_info_fn, options} = Keyword.pop(options, :debug_info_fn)
+
+    {debug_info_fn, options} =
+      case Keyword.pop(options, :debug_info_fn) do
+        {nil, options} -> Keyword.pop(options, :debug_info_fun)
+        {debug_info_fn, options} -> {debug_info_fn, options}
+      end
 
     debug_info_fn =
       cond do

--- a/lib/ex_doc/config.ex
+++ b/lib/ex_doc/config.ex
@@ -23,7 +23,6 @@ defmodule ExDoc.Config do
             cover: nil,
             deps: [],
             debug_info_fn: nil,
-            debug_info_key: nil,
             extra_section: nil,
             extras: [],
             filter_modules: &__MODULE__.filter_modules/2,
@@ -52,6 +51,10 @@ defmodule ExDoc.Config do
             title: nil,
             version: nil
 
+  @typep debug_info_fn_arg :: :init | :clear | {:debug_info, atom(), module(), :file.filename()}
+  @typep debug_info_fn :: (debug_info_fn_arg ->
+                             :ok | {:ok, (debug_info_fn_arg -> term())} | {:error, term()})
+
   @type t :: %__MODULE__{
           annotations_for_docs: (map() -> list()),
           api_reference: boolean(),
@@ -64,8 +67,7 @@ defmodule ExDoc.Config do
           canonical: nil | String.t(),
           cover: nil | Path.t(),
           deps: [{ebin_path :: String.t(), doc_url :: String.t()}],
-          debug_info_fn: nil | :beam_lib.crypto_fun(),
-          debug_info_key: nil | String.t() | charlist(),
+          debug_info_fn: nil | debug_info_fn(),
           extra_section: nil | String.t(),
           extras: list(),
           filter_modules: (module, map -> boolean),

--- a/lib/ex_doc/language/erlang.ex
+++ b/lib/ex_doc/language/erlang.ex
@@ -23,7 +23,11 @@ defmodule ExDoc.Language.Erlang do
               title: binary,
               type: :behaviour | :module
             }
-  def module_data(module, docs_chunk, _config) do
+  def module_data(module, docs_chunk, config) do
+    if debug_info_fn = config.debug_info_fn do
+      :beam_lib.crypto_key_fun(debug_info_fn)
+    end
+
     if abst_code = Source.get_abstract_code(module) do
       id = Atom.to_string(module)
       source_basedir = Source.fetch_basedir!(abst_code, module)

--- a/lib/ex_doc/language/erlang.ex
+++ b/lib/ex_doc/language/erlang.ex
@@ -23,11 +23,7 @@ defmodule ExDoc.Language.Erlang do
               title: binary,
               type: :behaviour | :module
             }
-  def module_data(module, docs_chunk, config) do
-    if debug_info_fn = config.debug_info_fn do
-      :beam_lib.crypto_key_fun(debug_info_fn)
-    end
-
+  def module_data(module, docs_chunk, _config) do
     if abst_code = Source.get_abstract_code(module) do
       id = Atom.to_string(module)
       source_basedir = Source.fetch_basedir!(abst_code, module)

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -80,7 +80,7 @@ defmodule ExDoc.Retriever do
   end
 
   defp get_module(module, config) do
-    with {:docs_v1, _, language, _, _, _metadata, _} = docs_chunk <- docs_chunk(module),
+    with {:docs_v1, _, language, _, _, _metadata, _} = docs_chunk <- docs_chunk(module, config),
          {:ok, language} <- ExDoc.Language.get(language, module),
          %{} = module_data <- language.module_data(module, docs_chunk, config) do
       {:ok, generate_node(module, module_data, config)}
@@ -90,7 +90,11 @@ defmodule ExDoc.Retriever do
     end
   end
 
-  defp docs_chunk(module) do
+  defp docs_chunk(module, config) do
+    if debug_info_fn = config.debug_info_fn do
+      :beam_lib.crypto_key_fun(debug_info_fn)
+    end
+
     result = Code.fetch_docs(module)
     Refs.insert_from_chunk(module, result)
 

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -92,7 +92,7 @@ defmodule ExDoc.Retriever do
 
   defp docs_chunk(module, config) do
     if debug_info_fn = config.debug_info_fn do
-      :beam_lib.crypto_key_fun(debug_info_fn)
+      set_crypto_key_fn(debug_info_fn)
     end
 
     result = Code.fetch_docs(module)
@@ -499,5 +499,18 @@ defmodule ExDoc.Retriever do
 
   defp source_link(source, line) do
     Utils.source_url_pattern(source.url, source.path |> Path.relative_to(File.cwd!()), line)
+  end
+
+  @doc false
+  def set_crypto_key_fn(crypto_key_fn) do
+    :beam_lib.clear_crypto_key_fun()
+
+    case :beam_lib.crypto_key_fun(crypto_key_fn) do
+      {:error, reason} ->
+        raise Error, "failed to set crypto_key_fun: #{inspect(reason)}"
+
+      other ->
+        other
+    end
   end
 end

--- a/test/ex_doc/retriever_test.exs
+++ b/test/ex_doc/retriever_test.exs
@@ -307,4 +307,14 @@ defmodule ExDoc.RetrieverTest do
     %{docs: [%{signature: signature}]} = module_node
     assert signature == "callback_name(arg1, integer, %Date{}, term, t)"
   end
+
+  test "set_crypto_key_fn/1 raises if it receives an error" do
+    assert_raise(
+      Retriever.Error,
+      "failed to set crypto_key_fun: :badfun",
+      fn ->
+        Retriever.set_crypto_key_fn(fn _ -> {:error, :badfun} end)
+      end
+    )
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -58,6 +58,15 @@ defmodule TestHelper do
 
     beam_docs = docstrings(docs, context)
 
+    # not to be confused with the regular :debug_info opt
+    debug_info_opts =
+      Enum.filter(opts, fn
+        {:debug_info, _debug_info} -> true
+        {:debug_info_key, _debug_info_key} -> true
+        :encrypt_debug_info -> true
+        _ -> false
+      end)
+
     {:ok, module} =
       :compile.file(
         String.to_charlist(src_path),
@@ -65,7 +74,7 @@ defmodule TestHelper do
           :return_errors,
           :debug_info,
           outdir: String.to_charlist(ebin_dir)
-        ] ++ beam_docs
+        ] ++ beam_docs ++ debug_info_opts
       )
 
     true = Code.prepend_path(ebin_dir)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -70,11 +70,8 @@ defmodule TestHelper do
     {:ok, module} =
       :compile.file(
         String.to_charlist(src_path),
-        [
-          :return_errors,
-          :debug_info,
-          outdir: String.to_charlist(ebin_dir)
-        ] ++ beam_docs ++ debug_info_opts
+        [:return_errors, :debug_info, outdir: String.to_charlist(ebin_dir)] ++
+          beam_docs ++ debug_info_opts
       )
 
     true = Code.prepend_path(ebin_dir)


### PR DESCRIPTION
Would close #1928 

A few things need to be resolved before this can be changed from a draft:

1. There are two places where calling `:beam_lib.crypto_key_fun/1` would make sense: the `Retriever` module or in the individual language modules. Based on a cursory glance of the Elixir compiler, it doesn't look like `{:debug_info_key, ...}` is supported as an option. This was the original intent behind calling `:beam_lib.crypto_key_fun/1` in the Erlang language module. However, either this option really is supported by the Elixir compiler or could be in the future. This is where it might make sense to put it in the `Retriever` module instead. This draft does it both ways for now.
2. Surfacing `debug_info_key`/`debug_info_fn` to the user. I've added these to `ExDoc.Config`.  But I'm unsure of the best course of action for CLI options. Supporting just the key in the options and then allowing the user to define a function in a custom `config.exs` breaks the existing order of things (*i.e.* being able to set the same config options with command line switches as with a config file) since something like `--debug_info_fn "fn ..."` isn't user friendly. Maybe only `debug_info_key` should be supported for now?
3. Finally, I was considering adding `debug_info_fun` as a synonym so that Erlang users don't have to worry about translating `fun` to `fn`. 

*(note to self: the test needs to test for the rest of the docs in the erlang module)*