### PR TITLE
Document using .erlang.crypt with ExDoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       MIX_ENV: test
+      CI: true
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     * Improve warning when referencing type from a private module
     * Rename "Search HexDocs package" modal to "Go to package docs". Support built-in Erlang/OTP
       apps.
+    * Document how to use `.erlang.crypt` with ExDoc
 
   * Bug fixes
     * Switch anchor `title` to `aria-label`

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -200,6 +200,14 @@ defmodule Mix.Tasks.Docs do
       where path is either an relative path from the cwd, or an absolute path. The function
       must return the full URI as it should be placed in the documentation.
 
+  ## Encrypted debug info
+
+  If a module is compiled with [encrypted debug info](`:compile.file/2`), ExDoc will not be able to
+  extract its documentation without preparation. ExDoc supports using `.erlang.crypt` to decrypt
+  debug information. Consult the
+  [`.erlang.crypt` section in the `:beam_lib` documentation](`m::beam_lib#module-erlang-crypt`)
+  for more information.
+
   ## Groups
 
   ExDoc content can be organized in groups. This is done via the `:groups_for_extras`

--- a/test/fixtures/.erlang.crypt
+++ b/test/fixtures/.erlang.crypt
@@ -1,0 +1,2 @@
+[{debug_info, des3_cbc, debug_info_mod, "SECRET"},
+ {debug_info, des3_cbc, [], "PASSWORD"}].


### PR DESCRIPTION
Closes #1928.

- Update documentation
- Update test helper so that debug info options are forwarded to the compiler
- Add basic tests
- Update changelog
- Use "CI" environment variable to skip the encrypted debug info test