### PR TITLE
allow searching for atoms inside backticks

### DIFF
--- a/assets/js/search-page.js
+++ b/assets/js/search-page.js
@@ -196,7 +196,7 @@ function docTokenFunction (token) {
     tokens.push(token.clone().update(() => toSplitWords))
   } else if (toSplitWords.startsWith(':')) {
     // allow searching for atoms without `:`
-    toSplitWords = toSplitWords.slice(1)
+    toSplitWords = toSplitWords.substring(1)
     tokens.push(token.clone().update(() => toSplitWords))
   }
 

--- a/assets/js/search-page.js
+++ b/assets/js/search-page.js
@@ -161,6 +161,18 @@ function docTokenFunction (token) {
   const namespaceRegex = /\:|\./
   let toSplitWords = token.toString()
 
+  // clean up leading and trailing backticks
+  if (toSplitWords.startsWith('`') && toSplitWords.endsWith('`')) {
+    toSplitWords = toSplitWords.slice(1, -1)
+    tokens.push(token.clone().update(() => toSplitWords))
+  }
+
+  // allow searching for atoms without `:`
+  if (toSplitWords.startsWith(':')) {
+    toSplitWords = toSplitWords.slice(1)
+    tokens.push(token.clone().update(() => toSplitWords))
+  }
+
   if (arityRegex.test(toSplitWords)) {
     const withoutArity = token
       .toString()

--- a/assets/js/search-page.js
+++ b/assets/js/search-page.js
@@ -167,12 +167,6 @@ function docTokenFunction (token) {
     tokens.push(token.clone().update(() => toSplitWords))
   }
 
-  // allow searching for atoms without `:`
-  if (toSplitWords.startsWith(':')) {
-    toSplitWords = toSplitWords.slice(1)
-    tokens.push(token.clone().update(() => toSplitWords))
-  }
-
   if (arityRegex.test(toSplitWords)) {
     const withoutArity = token
       .toString()
@@ -199,6 +193,10 @@ function docTokenFunction (token) {
     // If we have a module attribute, such as @foo_bar,
     // also make it searchable as foo_bar
     toSplitWords = toSplitWords.substring(1)
+    tokens.push(token.clone().update(() => toSplitWords))
+  } else if (toSplitWords.startsWith(':')) {
+    // allow searching for atoms without `:`
+    toSplitWords = toSplitWords.slice(1)
     tokens.push(token.clone().update(() => toSplitWords))
   }
 


### PR DESCRIPTION
In the LV repo you were not able to search for atoms inside backticks, for example when searching for "validate_attrs" the corresponding option of the `Phoenix.Component.slot/3` macro could not be found:

![image](https://github.com/user-attachments/assets/2585c6fd-2377-4f69-9897-0004c0e5d83e)

This commit fixes this by stripping the backticks from tokens and also removing trailing colons. I'm not familiar with the ex_doc codebase at all, so this may very well NOT be the way to properly fix, so please double check.

After this change:

![image](https://github.com/user-attachments/assets/3ad092fb-f4e3-4c2c-b481-31db8d597948)

cc @josevalim 