### PR TITLE
Copy symbolic links in the assets as actual files

### DIFF
--- a/lib/ex_doc/formatter/html.ex
+++ b/lib/ex_doc/formatter/html.ex
@@ -306,7 +306,7 @@ defmodule ExDoc.Formatter.HTML do
 
         is_binary(dir_or_files) and File.dir?(dir_or_files) ->
           dir_or_files
-          |> File.cp_r!(target_dir)
+          |> File.cp_r!(target_dir, dereference_symlinks: true)
           |> Enum.map(&Path.relative_to(&1, output))
 
         is_binary(dir_or_files) ->

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -203,8 +203,7 @@ defmodule ExDoc.Formatter.HTML.Templates do
   end
 
   def module_summary(module_node) do
-    entries =
-      docs_groups(module_node.docs_groups, module_node.docs ++ module_node.typespecs)
+    entries = docs_groups(module_node.docs_groups, module_node.docs ++ module_node.typespecs)
 
     Enum.reject(entries, fn {_type, nodes} -> nodes == [] end)
   end

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -247,8 +247,7 @@ defmodule ExDoc.Retriever do
         metadata
       )
 
-    source_url =
-      source_link(function_data[:source_file], source, function_data.source_line)
+    source_url = source_link(function_data[:source_file], source, function_data.source_line)
 
     annotations =
       annotations_for_docs.(metadata) ++
@@ -260,8 +259,7 @@ defmodule ExDoc.Retriever do
       (source_doc && doc_ast(content_type, source_doc, file: doc_file, line: doc_line + 1)) ||
         function_data.doc_fallback.()
 
-    group =
-      GroupMatcher.match_function(groups_for_docs, metadata)
+    group = GroupMatcher.match_function(groups_for_docs, metadata)
 
     %ExDoc.FunctionNode{
       id: nil_or_name(name, arity),
@@ -325,8 +323,7 @@ defmodule ExDoc.Retriever do
     doc_file = anno_file(anno, source)
     doc_line = anno_line(anno)
 
-    source_url =
-      source_link(callback_data[:source_file], source, callback_data.source_line)
+    source_url = source_link(callback_data[:source_file], source, callback_data.source_line)
 
     metadata =
       Map.merge(
@@ -393,8 +390,7 @@ defmodule ExDoc.Retriever do
         metadata
       )
 
-    source_url =
-      source_link(type_data[:source_file], source, type_data.source_line)
+    source_url = source_link(type_data[:source_file], source, type_data.source_line)
 
     signature = signature(type_data.signature)
 

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -816,4 +816,24 @@ defmodule ExDoc.Formatter.HTMLTest do
   after
     File.rm_rf!("test/tmp/html_assets")
   end
+
+  test "symbolic links in the assets should be resolved and copied as actual files",
+       %{tmp_dir: tmp_dir} = context do
+    File.mkdir_p!("test/tmp/html_assets/hello")
+    File.touch!("test/tmp/html_assets/hello/world")
+
+    File.ln_s("world", "test/tmp/html_assets/hello/symlink_world")
+
+    generate_docs(
+      doc_config(context,
+        assets: %{"test/tmp/html_assets" => "assets"}
+      )
+    )
+
+    assert File.regular?(tmp_dir <> "/html/assets/hello/world")
+    assert File.exists?(tmp_dir <> "/html/assets/hello/symlink_world")
+    assert File.read_link(tmp_dir <> "/html/assets/hello/symlink_world") == {:error, :einval}
+  after
+    File.rm_rf!("test/tmp/html_assets")
+  end
 end


### PR DESCRIPTION
### Summary

This PR addresses issue [#1966](https://github.com/elixir-lang/ex_doc/issues/1966) by modifying the asset copying function to handle symbolic links correctly.

### Details

The commit [f4a46cb](https://github.com/elixir-lang/ex_doc/commit/f4a46cb0f8f11fbc9d8863a797b10afff1eefa31) changed the asset copying function from `File.copy/3` to `File.cp_r!/3`, which altered the handling of symbolic links.

To resolve this, we add the option `dereference_symlinks: true` to `File.cp_r!/3` as advised by José Valim.

### Additional Changes

- Ran `mix fix` to address linting issues present on the current `main` branch. If necessary, I can create a separate PR or revert this commit based on reviewer feedback.

### Testing

- Passed `mix lint`
- Passed `mix test`
- Run `mix build` and check some pages in `doc/index.html`
- Confirmed that all assets are actual files in the reproduced repository [antikythera](https://github.com/access-company/antikythera)

Please review and let me know if any further changes are needed.