### PR TITLE
Edoc still includes private functions so need to remove them

### DIFF
--- a/lib/ex_doc/language/erlang.ex
+++ b/lib/ex_doc/language/erlang.ex
@@ -62,7 +62,10 @@ defmodule ExDoc.Language.Erlang do
   def function_data(entry, module_data) do
     {{kind, name, arity}, _anno, _signature, doc_content, metadata} = entry
 
-    if kind == :function and doc_content != :hidden do
+    # Edoc on Erlang/OTP24.1+ includes private functions in
+    # the chunk, so we manually yank them out.
+    if kind == :function and doc_content != :hidden and
+         function_exported?(module_data.module, name, arity) do
       function_data(name, arity, doc_content, module_data, metadata)
     else
       :skip

--- a/test/ex_doc/retriever/erlang_test.exs
+++ b/test/ex_doc/retriever/erlang_test.exs
@@ -376,7 +376,7 @@ defmodule ExDoc.Retriever.ErlangTest do
       %% @doc
       %% mod docs.
       -module(mod).
-      -export([function1/0, function2/0]).
+      -export([function1/0, function2/0, hidden_function/0]).
 
       %% @doc
       %% function1/0 docs.
@@ -386,6 +386,13 @@ defmodule ExDoc.Retriever.ErlangTest do
       %% @doc
       %% function2/0 docs.
       function2() -> ok.
+
+      %% @doc hidden function docs.
+      %% @private
+      hidden_function() -> local_function().
+
+      %% @doc hidden function docs.
+      local_function() -> local_function().
       """)
 
       {[mod], []} = Retriever.docs_from_modules([:mod], %ExDoc.Config{})


### PR DESCRIPTION
In cf49545 the pruning of edoc function was removed which causes more functions than there should be to be part of the generated docs.

This commit restores the old behaviour and adds a testcase.