### PR TITLE
Improve content headings

### DIFF
--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -39,7 +39,8 @@
 
 .content-inner h2 {
   font-size: 1.6em;
-  margin: 1em 0 0.5em;
+  padding-top: 1em;
+  margin-bottom: 0.5em;
   font-weight: 700;
 }
 
@@ -154,6 +155,11 @@
   display: grid;
   grid-template: 1fr / 1fr;
 }
+@media screen and (max-width: 768px) {
+  .content-inner .section-heading {
+    --icon-spacing: 2px;
+  }
+}
 
 .content-inner .section-heading > :is(.hover-link, .text) {
   grid-row: 1;
@@ -166,32 +172,19 @@
 
 .content-inner .section-heading i {
   font-size: var(--icon-size);
+  color: var(--mainLight);
   margin-top: 0.1em;
   margin-left: calc(-1 * (var(--icon-size) + var(--icon-spacing)));
-  padding-right: var(--icon-spacing); /* Avoids gap in hover area */
-  opacity: 0;
-}
-
-@media screen and (max-width: 768px) {
-  .content-inner .section-heading i {
-    margin-left: calc(-1 * (var(--icon-size)));
-  }
+  padding-right: var(--icon-spacing);
+  opacity: 0.3;
 }
 
 .content-inner :is(blockquote, section.admonition) .section-heading i {
   display: none;
 }
 
-.content-inner .section-heading .hover-link:is(:hover, :focus) i {
+.content-inner .section-heading:is(:hover, :focus, :target) i {
   opacity: 1;
-}
-
-/* Allow section link to be hovered and used “through” text */
-.content-inner .section-heading .text {
-  pointer-events: none;
-}
-.content-inner .section-heading .text a {
-  pointer-events: all;
 }
 
 .content-inner .app-vsn {

--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -176,7 +176,7 @@
   margin-top: 0.1em;
   margin-left: calc(-1 * (var(--icon-size) + var(--icon-spacing)));
   padding-right: var(--icon-spacing);
-  opacity: 0.3;
+  opacity: 0;
 }
 
 .content-inner :is(blockquote, section.admonition) .section-heading i {


### PR DESCRIPTION
https://github.com/user-attachments/assets/dedb197e-fb52-44b9-9fa3-3e5626f314fe

> [!IMPORTANT]
> @josevalim, if you'd prefer the hover links to remain invisible until the heading is hovered/focussed, let me know and I'll revert that change.

Allows selection of heading text. Also makes hover link always (slightly) visible for discoverability.

Also improves:

- hover link colour
- hover link icon spacing
- heading spacing

Fixes #1969