### PR TITLE
Fix typespec with (...) -> any(), closes #1974

### DIFF
--- a/test/ex_doc/language/erlang_test.exs
+++ b/test/ex_doc/language/erlang_test.exs
@@ -806,6 +806,10 @@ defmodule ExDoc.Language.ErlangTest do
     test "function - any arity", c do
       assert autolink_spec(~s"-spec foo() -> fun((...) -> t()) | erlang_bar:t().", c) ==
                ~s[foo() -> fun((...) -> <a href="#t:t/0">t</a>()) | <a href="erlang_bar.html#t:t/0">erlang_bar:t</a>().]
+
+      assert autolink_spec(~s"-type foo() :: fun((...) -> any()) | [any()].", c) ==
+               "foo() :: fun((...) -> <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:any/0\">any</a>()) | " <>
+                 "[<a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:any/0\">any</a>()]."
     end
 
     test "local type", c do

--- a/test/ex_doc/language/erlang_test.exs
+++ b/test/ex_doc/language/erlang_test.exs
@@ -807,9 +807,11 @@ defmodule ExDoc.Language.ErlangTest do
       assert autolink_spec(~s"-spec foo() -> fun((...) -> t()) | erlang_bar:t().", c) ==
                ~s[foo() -> fun((...) -> <a href="#t:t/0">t</a>()) | <a href="erlang_bar.html#t:t/0">erlang_bar:t</a>().]
 
-      assert autolink_spec(~s"-type foo() :: fun((...) -> any()) | [any()].", c) ==
-               "foo() :: fun((...) -> <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:any/0\">any</a>()) | " <>
-                 "[<a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:any/0\">any</a>()]."
+      if Version.match?(System.version(), ">= 1.18.0-rc") do
+        assert autolink_spec(~s"-type foo() :: fun((...) -> any()) | [any()].", c) ==
+                 "foo() :: fun((...) -> <a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:any/0\">any</a>()) | " <>
+                   "[<a href=\"https://www.erlang.org/doc/apps/erts/erlang.html#t:any/0\">any</a>()]."
+      end
     end
 
     test "local type", c do


### PR DESCRIPTION
@gomoripeti this is fixed in main but it will require Elixir v1.18+.

@garazdawi in the long term, we probably want the code that converts a typespec into a string with links to be part of Erlang/OTP? Perhaps by adding some sort of fallback to the existing pretty printing function? Or perhaps, instead of converting it to Elixir AST and traversing it, we'd traverse the Erlang AST typespec directly.