### PR TITLE
Update mix.exs for EarmarkParser 1.4.42

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule ExDoc.Mixfile do
 
   defp deps do
     [
-      {:earmark_parser, "~> 1.4.39"},
+      {:earmark_parser, "~> 1.4.42"},
       {:makeup_elixir, "~> 0.14 or ~> 1.0"},
       {:makeup_erlang, "~> 0.1 or ~> 1.0"},
       # Add other makeup lexers as optional for the executable


### PR DESCRIPTION
This is the first version without warnings in Elixir 1.18.0

No other changes to the behavior.