### PR TITLE
Autocomplete suggestion focus outline

### DIFF
--- a/assets/css/autocomplete.css
+++ b/assets/css/autocomplete.css
@@ -141,6 +141,10 @@
   background-color: var(--autocompleteHover);
 }
 
+.autocomplete-suggestion.selected {
+  box-shadow: inset 0 0 0 1px var(--searchBarFocusColor);
+}
+
 .autocomplete-suggestion:not(.selected) .autocomplete-preview-indicator {
   display: none;
 }


### PR DESCRIPTION
Give autocomplete suggestion a visible focus outline to differentiate from hovered suggestion.

I got confused when searching with keyboard and my mouse was hovered over the suggestions.

Before:
![image](https://github.com/user-attachments/assets/813451bc-f661-4500-8725-4a34207cd72a)

After:
![image](https://github.com/user-attachments/assets/52397da3-ed69-4ed8-9c99-7ec7aed8d9b1)
