### PR TITLE
Compile inline HTML with esbuild

### DIFF
--- a/assets/build/build.js
+++ b/assets/build/build.js
@@ -26,6 +26,7 @@ const formatters = [
     formatter: 'html',
     outdir: path.resolve('../formatters/html/dist'),
     entryPoints: [
+      'js/entry/html_inline.js',
       'js/entry/html.js',
       'css/entry/html-elixir.css',
       'css/entry/html-erlang.css'

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -1,0 +1,3 @@
+// Constants separated to allow importing into html_inline.js without
+// bringing in other code.
+export const SETTINGS_KEY = 'ex_doc:settings'

--- a/assets/js/entry/html_inline.js
+++ b/assets/js/entry/html_inline.js
@@ -1,0 +1,18 @@
+// CAREFUL
+// This file is inlined into each HTML document.
+// Only code that must be executed ASAP belongs here.
+// Imports should only bring in inlinable constants.
+// Check compiled output to make sure no unnecessary code is imported.
+import { SETTINGS_KEY } from '../constants'
+
+// Immediately apply night mode preference to avoid a flash effect
+try {
+  const {theme} = JSON.parse(localStorage.getItem(SETTINGS_KEY) || '{}')
+
+  if (theme === 'dark' ||
+     ((theme === 'system' || theme == null) &&
+       window.matchMedia('(prefers-color-scheme: dark)').matches)
+  ) {
+    document.body.classList.add('dark')
+  }
+} catch (error) { }

--- a/assets/js/settings-store.js
+++ b/assets/js/settings-store.js
@@ -1,4 +1,4 @@
-const SETTINGS_KEY = 'ex_doc:settings'
+import { SETTINGS_KEY } from './constants'
 
 const DEFAULT_SETTINGS = {
   // Whether to show tooltips on function/module links

--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -192,19 +192,27 @@ defmodule ExDoc.Formatter.HTML.Templates do
   defp sidebar_type(:livemd), do: "extras"
   defp sidebar_type(:extra), do: "extras"
 
-  def asset_rev(output, pattern) do
+  defp resolve_asset(output, pattern) do
     output = Path.expand(output)
 
-    output
-    |> Path.join(pattern)
-    |> Path.wildcard()
-    |> relative_asset(output, pattern)
+    matches =
+      output
+      |> Path.join(pattern)
+      |> Path.wildcard()
+
+    case matches do
+      [] -> raise("could not find matching #{output}/#{pattern}")
+      [asset | _] -> asset
+    end
   end
 
-  defp relative_asset([], output, pattern),
-    do: raise("could not find matching #{output}/#{pattern}")
+  def asset_rev(output, pattern) do
+    resolve_asset(output, pattern) |> Path.relative_to(output)
+  end
 
-  defp relative_asset([h | _], output, _pattern), do: Path.relative_to(h, output)
+  def asset_inline(output, pattern) do
+    resolve_asset(output, pattern) |> File.read!()
+  end
 
   # TODO: Move link_headings and friends to html.ex or even to autolinking code,
   # so content is built with it upfront instead of added at the template level.

--- a/lib/ex_doc/formatter/html/templates/head_template.eex
+++ b/lib/ex_doc/formatter/html/templates/head_template.eex
@@ -23,16 +23,4 @@
     <%= before_closing_head_tag(config, :html) %>
   </head>
   <body class="sidebar-closed">
-    <script>
-      <% # Immediately apply night mode preference to avoid a flash effect %>
-      try {
-        var settings = JSON.parse(localStorage.getItem('ex_doc:settings') || '{}');
-
-        if (settings.theme === 'dark' ||
-           ((settings.theme === 'system' || settings.theme == null) &&
-             window.matchMedia('(prefers-color-scheme: dark)').matches)
-           ) {
-          document.body.classList.add('dark')
-        }
-      } catch (error) { }
-    </script>
+    <script><%= asset_inline config.output, "dist/html_inline-*.js" %></script>


### PR DESCRIPTION
* Compile inline HTML with esbuild, allowing minification and sharing of constants
* Add `asset_inline` helper to `templates.ex`
* Refactor asset resolving

## Before
```html
  <body class="sidebar-closed">
    <script>

      try {
        var settings = JSON.parse(localStorage.getItem('ex_doc:settings') || '{}');

        if (settings.theme === 'dark' ||
           ((settings.theme === 'system' || settings.theme == null) &&
             window.matchMedia('(prefers-color-scheme: dark)').matches)
           ) {
          document.body.classList.add('dark')
        }
      } catch (error) { }
    </script>
```

## After
```html
  <body class="sidebar-closed">
    <script>(()=>{var t="ex_doc:settings";try{let{theme:e}=JSON.parse(localStorage.getItem(t)||"{}");(e==="dark"||(e==="system"||e==null)&&window.matchMedia("(prefers-color-scheme: dark)").matches)&&document.body.classList.add("dark")}catch{}})();
</script>
```

Tests are passing locally