### PR TITLE
Page load improvements

### DIFF
--- a/assets/README.md
+++ b/assets/README.md
@@ -22,7 +22,7 @@ $ npm run --prefix assets build
 
 Build a complete production bundle, including JavaScript and CSS.
 
-(Note that this is not required to be manually run when generating docs: if you run `mix build` at the `ExDoc` root after changing your assets, the assets will be recompiled, `mix compile --force` will be invoked, and fresh docs with your changes will be generated.)
+(Note that this is not required to be manually run when generating docs: if you run `mix build` at the `ExDoc` root after changing your assets, the assets will be recompiled and fresh docs with your changes will be generated.)
 
 ### `build:watch`
 

--- a/assets/build/build.js
+++ b/assets/build/build.js
@@ -76,7 +76,6 @@ Promise.all(formatters.map(async ({formatter, ...options}) => {
           build.onEnd(async result => {
             if (result.errors.length) return
             console.log(`${formatter} assets built`)
-            await exec('mix compile --force', {cwd: '../'})
             await exec(`mix docs --formatter ${formatter}`, {cwd: '../'})
             console.log(`${formatter} docs built`)
           })

--- a/assets/css/content/code.css
+++ b/assets/css/content/code.css
@@ -1,11 +1,11 @@
-.content-inner :is(a.no-underline, pre a) {
+.content-inner.content-inner :is(a:has(code, img), pre a) {
   color: var(--linksNoUnderline);
   text-shadow: none;
   text-decoration: none;
   background-image: none;
 }
 
-.content-inner :is(a.no-underline, pre a):is(:visited, :active, :focus, :hover) {
+.content-inner.content-inner :is(a:has(code, img), pre a):is(:visited, :active, :focus, :hover) {
   color: var(--linksNoUnderlineVisited);
 }
 

--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -11,7 +11,7 @@
   scrollbar-color: var(--sidebarScrollbarThumb) var(--sidebarScrollbarTrack);
 }
 
-.non-apple-os .sidebar {
+:root:not(.apple-os) .sidebar {
   font-weight: 400; /* Non-Apple OSes render small light type too thinly */
 }
 
@@ -318,7 +318,7 @@
   color: var(--sidebarAccentMain);
 }
 
-.non-apple-os .sidebar .full-list ul li {
+:root:not(.apple-os) .sidebar .full-list ul li {
   font-weight: 400; /* Non-Apple OSes render small light type too thinly */
 }
 

--- a/assets/js/content.js
+++ b/assets/js/content.js
@@ -1,72 +1,21 @@
-import { qs, qsAll } from './helpers'
+import { qsAll } from './helpers'
 import { settingsStore } from './settings-store'
-
-const CONTENT_SELECTOR = '.content'
-const CONTENT_INNER_SELECTOR = '.content-inner'
-const LIVEBOOK_BADGE_ANCHOR_SELECTOR = '.livebook-badge'
-
-/**
- * Runs some general modifiers on the documentation content.
- */
-export function initialize (isPreview) {
-  // Disabled on autocomplete preview because it moves the focus to inner iframe
-  if (!isPreview) {
-    fixSpacebar()
-  }
-
-  setLivebookBadgeUrl()
-  fixLinks()
-}
-
-/**
- * Removes underline from links that have nested code or images.
- */
-function fixLinks () {
-  qs(CONTENT_SELECTOR).querySelectorAll('a').forEach(anchor => {
-    if (anchor.querySelector('code, img')) {
-      anchor.classList.add('no-underline')
-    }
-  })
-}
-
-/**
- * Focuses the content element.
- *
- * This is required so that the space bar (and similar key bindings)
- * work as soon as you visit a module's documentation. Without this,
- * the user would be forced to first click on the content element
- * before these keybindings worked.
- */
-function fixSpacebar () {
-  qs(CONTENT_INNER_SELECTOR).setAttribute('tabindex', -1)
-  qs(CONTENT_INNER_SELECTOR).focus()
-}
 
 /**
  * Updates "Run in Livebook" badges to link to a notebook
  * corresponding to the current documentation page.
  */
-function setLivebookBadgeUrl () {
-  const path = window.location.pathname
-  const notebookPath = path.replace(/(\.html)?$/, '.livemd')
-  const notebookUrl = new URL(notebookPath, window.location.href).toString()
+export function initialize () {
+  const notebookPath = window.location.pathname.replace(/(\.html)?$/, '.livemd')
+  const notebookUrl = encodeURIComponent(new URL(notebookPath, window.location.href).toString())
 
-  settingsStore.getAndSubscribe(settings => {
-    const targetUrl =
-      settings.livebookUrl
-        ? getLivebookImportUrl(settings.livebookUrl, notebookUrl)
-        : getLivebookDevRunUrl(notebookUrl)
+  settingsStore.getAndSubscribe(({livebookUrl}) => {
+    const targetUrl = livebookUrl
+      ? `${livebookUrl}/import?url=${notebookUrl}`
+      : `https://livebook.dev/run?url=${notebookUrl}`
 
-    for (const anchor of qsAll(LIVEBOOK_BADGE_ANCHOR_SELECTOR)) {
+    for (const anchor of qsAll('.livebook-badge')) {
       anchor.href = targetUrl
     }
   })
-}
-
-function getLivebookDevRunUrl (notebookUrl) {
-  return `https://livebook.dev/run?url=${encodeURIComponent(notebookUrl)}`
-}
-
-function getLivebookImportUrl (livebookUrl, notebookUrl) {
-  return `${livebookUrl}/import?url=${encodeURIComponent(notebookUrl)}`
 }

--- a/assets/js/copy-button.js
+++ b/assets/js/copy-button.js
@@ -1,6 +1,8 @@
 import { qsAll } from './helpers'
 
-const BUTTON = '<button class="copy-button"><svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="currentColor"><path d="M0 0h24v24H0z" fill="none"/><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg><span class="sr-only">copy</span><span aria-live="polite"></span></button>'
+const template = document.createElement('div')
+template.innerHTML = '<button class="copy-button"><svg role="img" aria-label="copy" viewBox="0 0 24 24" fill="currentColor"><path d="M0 0h24v24H0z" fill="none"/><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg><span aria-live="polite"></span></button>'
+const buttonTemplate = template.firstChild
 
 /**
  * Initializes copy buttons.
@@ -15,19 +17,17 @@ export function initialize () {
  * Find pre tags, add copy buttons, copy <code> content on click.
  */
 function addCopyButtons () {
-  Array.from(qsAll('pre'))
-    .filter(pre => pre.firstElementChild && pre.firstElementChild.tagName === 'CODE')
-    .forEach(pre => pre.insertAdjacentHTML('beforeend', BUTTON))
+  qsAll('pre:has(> code:first-child):not(:has(.copy-button))').forEach(pre => {
+    const button = buttonTemplate.cloneNode(true)
+    pre.appendChild(button)
 
-  Array.from(qsAll('.copy-button')).forEach(button => {
     let timeout
     button.addEventListener('click', () => {
       const ariaLiveContent = button.querySelector('[aria-live]')
-      timeout && clearTimeout(timeout)
+      clearTimeout(timeout)
 
       const text =
-        Array.from(button.parentElement.querySelector('code').childNodes)
-          .filter(elem => !(elem.tagName === 'SPAN' && elem.classList.contains('unselectable')))
+        Array.from(pre.querySelectorAll('code > *:not(.unselectable)'))
           .map(elem => elem.textContent)
           .join('')
 

--- a/assets/js/entry/html.js
+++ b/assets/js/entry/html.js
@@ -16,7 +16,6 @@ import { initialize as initTooltips } from '../tooltips/tooltips'
 import { initialize as initHintsPage } from '../tooltips/hint-page'
 import { initialize as initCopyButton } from '../copy-button'
 import { initialize as initSettings } from '../settings'
-import { initialize as initStyling } from '../styling'
 import { initialize as initPreview} from '../preview'
 
 import Swup from 'swup'
@@ -30,10 +29,9 @@ onDocumentReady(() => {
   const isHint = params.has('hint')
 
   initTheme()
-  initStyling()
 
   initTabsets()
-  initContent(isPreview)
+  initContent()
   initMakeup()
   initTooltips()
   initCopyButton()
@@ -55,7 +53,7 @@ onDocumentReady(() => {
         hooks: {
           'page:view': () => {
             initTabsets()
-            initContent(false)
+            initContent()
             initMakeup()
             initTooltips()
             initCopyButton()

--- a/assets/js/entry/inline_html.js
+++ b/assets/js/entry/inline_html.js
@@ -28,3 +28,7 @@ const sidebarWidth = sessionStorage.getItem(SIDEBAR_WIDTH_KEY)
 if (sidebarWidth) {
   document.body.style.setProperty('--sidebarWidth', `${sidebarWidth}px`)
 }
+
+// Set OS class.
+const isAppleOS = /(Macintosh|iPhone|iPad|iPod)/.test(window.navigator.userAgent)
+document.documentElement.classList.toggle('apple-os', isAppleOS)

--- a/assets/js/handlebars/templates/tooltip-layout.handlebars
+++ b/assets/js/handlebars/templates/tooltip-layout.handlebars
@@ -1,3 +1,0 @@
-<div class="tooltip">
-  <div class="tooltip-body"></div>
-</div>

--- a/assets/js/helpers.js
+++ b/assets/js/helpers.js
@@ -1,12 +1,12 @@
 /**
  * A shorthand for `document.querySelector`.
- * @type {Function}
+ * @type {typeof document.querySelector}
  */
 export const qs = document.querySelector.bind(document)
 
 /**
  * A shorthand for `document.querySelectorAll`.
- * @type {Function}
+ * @type {typeof document.querySelectorAll}
  */
 export const qsAll = document.querySelectorAll.bind(document)
 
@@ -218,5 +218,6 @@ export function getProjectNameAndVersion () {
  * @return {Boolean}
  */
 export function isAppleOS () {
-  return /(Macintosh|iPhone|iPad|iPod)/.test(window.navigator.userAgent)
+  // Set in inline_html.js
+  return document.documentElement.classList.contains('apple-os')
 }

--- a/assets/js/makeup.js
+++ b/assets/js/makeup.js
@@ -6,30 +6,20 @@ const HIGHLIGHT_CLASS = 'hll'
  * Sets up dynamic behaviour for code blocks processed with *makeup*.
  */
 export function initialize () {
-  initializeDelimitersHighlighting()
-}
-
-// Hovering over a delimiter (bracket, parenthesis, do/end)
-// highlights the relevant pair of delimiters.
-function initializeDelimitersHighlighting () {
-  const delimiters = qsAll('[data-group-id]')
-
-  delimiters.forEach(delimiter => {
-    const groupId = delimiter.getAttribute('data-group-id')
-
-    delimiter.addEventListener('mouseenter', event => {
-      toggleDelimitersHighlight(groupId, true)
-    })
-
-    delimiter.addEventListener('mouseleave', event => {
-      toggleDelimitersHighlight(groupId, false)
-    })
+  // Hovering over a delimiter (bracket, parenthesis, do/end)
+  // highlights the relevant pair of delimiters.
+  qsAll('[data-group-id]').forEach(delimiter => {
+    delimiter.addEventListener('mouseenter', toggleDelimitersHighlight)
+    delimiter.addEventListener('mouseleave', toggleDelimitersHighlight)
   })
 }
 
-function toggleDelimitersHighlight (groupId, force) {
-  const delimiters = qsAll(`[data-group-id="${groupId}"]`)
-  delimiters.forEach(delimiter => {
+/** @param {MouseEvent} event */
+function toggleDelimitersHighlight (event) {
+  const element = event.currentTarget
+  const force = event.type === 'mouseenter'
+  const groupId = element.getAttribute('data-group-id')
+  element.parentElement.querySelectorAll(`[data-group-id="${groupId}"]`).forEach(delimiter => {
     delimiter.classList.toggle(HIGHLIGHT_CLASS, force)
   })
 }

--- a/assets/js/search-bar.js
+++ b/assets/js/search-bar.js
@@ -172,23 +172,22 @@ function hideAutocomplete () {
   hideAutocompleteList()
 }
 
-let lastScroll = window.scrollY
-const scrollThreshold = 70 // Threshold beyond which search bar may be hidden
-const scrollConsideredIntentional = -2 // Pixels (negative sign) considered to indicate intent
+let lastScroll
+const scrollIntentThreshold = 2
 
 window.addEventListener('scroll', function () {
   const currentScroll = window.scrollY
 
-  // Remove when at the top
-  if (currentScroll === 0) {
-    document.body.classList.remove('scroll-sticky')
-  } else if (lastScroll - currentScroll < scrollConsideredIntentional && currentScroll > scrollThreshold) {
-    // Scrolling down and past the threshold
-    document.body.classList.remove('scroll-sticky')
-  } else if (lastScroll - currentScroll > Math.abs(scrollConsideredIntentional)) {
-    // Scrolling up
-    document.body.classList.add('scroll-sticky')
+  if (lastScroll !== undefined) {
+    const diff = currentScroll - lastScroll
+    if (currentScroll === 0 || diff > scrollIntentThreshold) {
+      // Remove when at the top or scrolling down.
+      document.body.classList.remove('scroll-sticky')
+    } else if (currentScroll > 0 && -diff > scrollIntentThreshold) {
+      // Add when scrolling up.
+      document.body.classList.add('scroll-sticky')
+    }
   }
 
-  lastScroll = currentScroll <= 0 ? 0 : currentScroll
+  lastScroll = Math.max(0, currentScroll)
 }, false)

--- a/assets/js/styling.js
+++ b/assets/js/styling.js
@@ -1,6 +1,0 @@
-import { isAppleOS } from './helpers'
-
-export function initialize () {
-  const osClass = isAppleOS() ? 'apple-os' : 'non-apple-os'
-  document.documentElement.classList.add(osClass)
-}

--- a/assets/js/tooltips/tooltips.js
+++ b/assets/js/tooltips/tooltips.js
@@ -1,11 +1,12 @@
 import { qs, qsAll } from '../helpers'
 import { settingsStore } from '../settings-store'
 import { cancelHintFetchingIfAny, getHint, HINT_KIND, isValidHintHref } from './hints'
-import tooltipLayoutTemplate from '../handlebars/templates/tooltip-layout.handlebars'
 import tooltipBodyTemplate from '../handlebars/templates/tooltip-body.handlebars'
 
+const TOOLTIP_HTML = '<div class="tooltip"><div class="tooltip-body"></div></div>'
+
 // Elements that can activate the tooltip.
-const TOOLTIP_ACTIVATORS_SELECTOR = '.content a'
+const TOOLTIP_ACTIVATORS_SELECTOR = '.content a:not([data-no-tooltip])'
 // Tooltip root element.
 const TOOLTIP_SELECTOR = '.tooltip'
 // Tooltip content element.
@@ -22,7 +23,8 @@ const SPACING_BASE = 10
 // The minimum space needed between the bottom of the page and the bottom edge of the tooltip.
 const MIN_BOTTOM_SPACING = SPACING_BASE * 4
 // The minimum required viewport size to show tooltips.
-const MIN_WINDOW_SIZE = { height: 450, width: 768 }
+const MIN_WIDTH = 768
+const MIN_HEIGHT = 450
 // The minimum time mouse cursor must stay on link for the tooltip to be loaded.
 // This prevents from triggering tooltips by accident while scrolling and moving the cursor around.
 const HOVER_DELAY_MS = 100
@@ -38,26 +40,13 @@ const state = {
  * Initializes tooltips handling.
  */
 export function initialize () {
-  renderTooltipLayout()
-  addEventListeners()
-}
+  qs(CONTENT_INNER_SELECTOR).insertAdjacentHTML('beforeend', TOOLTIP_HTML)
 
-function renderTooltipLayout () {
-  const tooltipLayoutHtml = tooltipLayoutTemplate()
-  qs(CONTENT_INNER_SELECTOR).insertAdjacentHTML('beforeend', tooltipLayoutHtml)
-}
-
-function addEventListeners () {
   qsAll(TOOLTIP_ACTIVATORS_SELECTOR).forEach(element => {
     if (!linkElementEligibleForTooltip(element)) { return }
 
-    element.addEventListener('mouseenter', event => {
-      handleHoverStart(element)
-    })
-
-    element.addEventListener('mouseleave', event => {
-      handleHoverEnd(element)
-    })
+    element.addEventListener('mouseenter', handleHoverStart)
+    element.addEventListener('mouseleave', handleHoverEnd)
   })
 }
 
@@ -66,9 +55,6 @@ function addEventListeners () {
  * link element, or if it should just be ignored up-front.
  */
 function linkElementEligibleForTooltip (linkElement) {
-  // Skip tooltips on the permalink icon (the on-hover one next to the function name).
-  if (linkElement.getAttribute('data-no-tooltip') !== null) { return false }
-
   // Skip link to the module page we are already on.
   if (isHrefToSelf(linkElement.href)) { return false }
 
@@ -88,25 +74,23 @@ function isHrefToSelf (href) {
   return currentPage === targetPage
 }
 
-function handleHoverStart (element) {
-  if (!shouldShowTooltips()) { return }
+/** @param {MouseEvent} event */
+function handleHoverStart (event) {
+  if (
+    window.innerWidth < MIN_WIDTH ||
+    window.innerHeight < MIN_HEIGHT ||
+    !settingsStore.get().tooltips
+  ) { return }
+
+  const element = event.currentTarget
 
   state.currentLinkElement = element
 
   state.hoverDelayTimeout = setTimeout(() => {
     getHint(element.href)
-      .then(hint => {
-        renderTooltip(hint)
-        animateTooltipIn()
-      })
+      .then(renderTooltip)
       .catch(() => {})
   }, HOVER_DELAY_MS)
-}
-
-function shouldShowTooltips () {
-  const windowToSmall = (window.innerWidth < MIN_WINDOW_SIZE.width || window.innerHeight < MIN_WINDOW_SIZE.height)
-
-  return tooltipsEnabled() && !windowToSmall
 }
 
 function renderTooltip (hint) {
@@ -118,25 +102,18 @@ function renderTooltip (hint) {
   qs(TOOLTIP_BODY_SELECTOR).innerHTML = tooltipBodyHtml
 
   updateTooltipPosition()
+
+  // Animate tooltip in.
+  qs(TOOLTIP_SELECTOR).classList.add(TOOLTIP_SHOWN_CLASS)
 }
 
-function animateTooltipIn () {
-  const tooltipElement = qs(TOOLTIP_SELECTOR)
-  tooltipElement.classList.add(TOOLTIP_SHOWN_CLASS)
-}
-
-function handleHoverEnd (element) {
-  if (!tooltipsEnabled()) { return }
+function handleHoverEnd () {
+  if (!state.currentLinkElement) { return }
 
   clearTimeout(state.hoverDelayTimeout)
   cancelHintFetchingIfAny()
   state.currentLinkElement = null
-  animateTooltipOut()
-}
-
-function animateTooltipOut () {
-  const tooltipElement = qs(TOOLTIP_SELECTOR)
-  tooltipElement.classList.remove(TOOLTIP_SHOWN_CLASS)
+  qs(TOOLTIP_SELECTOR).classList.remove(TOOLTIP_SHOWN_CLASS)
 }
 
 /**
@@ -191,8 +168,4 @@ function getRelativeBoundingRect (elementRect, containerRect) {
     width: elementRect.width,
     height: elementRect.height
   }
-}
-
-function tooltipsEnabled () {
-  return settingsStore.get().tooltips
 }


### PR DESCRIPTION
Minor performance improvements and refactoring.

* remove `mix compile --force` from asset build watch script
* styling
  * set `apple-os` class in `inline_html.js`
  * remove `non-apple-os` class, replace with `:not(.apple-os)` selector
  * update `isAppleOs()` helper to query this class for source of truth
* content
  * replace `fixLinks()` & `.no-underline` with CSS-only `:has(code, img)` selector
  * remove `fixSpacebar()`, there is no need to focus content to enable keybinds
  * inline and refactor `setLivebookBadgeUrl()` - the only remaining code
* copy-button
  * optimise button HTML, remove unneeded attrs, replace `span.sr-only` with appropriate attrs on svg
  * replace `.insertAdjacentHTML()` with `.cloneNode()` (only parses HTML once)
  * implement array filters in query selectors
* makeup
  * inline many things
  * implement mouseenter/leave callbacks in single function, no need for closures
  * only search parent for matching delimiters
* search-bar
  * remove reading of `window.scrollY` on init, this forces layout and is not required
  * refactor logic
  * remove `scrollThreshold` of 70 px, looking at git history and PR comments, this is no longer needed
* tooltips
  * inline HTML, no need for handlebars
  * inline a few functions
  * move filter logic into query selectors
  * remove need for closures in event handlers

Performance improvement is so minor, I can't record it reliably. JS is 0.8kb smaller.