### PR TITLE
Add warning for stale version of documentation

### DIFF
--- a/assets/css/custom-props/common.css
+++ b/assets/css/custom-props/common.css
@@ -52,6 +52,8 @@
   --black: hsl(0, 0%, 0%);
   --black-opacity-10: hsla(0, 0%, 0%, 10%);
   --black-opacity-50: hsla(0, 0%, 0%, 50%);
+  --orangeDark: hsl(30, 90%, 40%);
+  --orangeLight: hsl(30, 80%, 50%);
 }
 
 @media screen and (max-width: 768px) {

--- a/assets/css/custom-props/theme-dark.css
+++ b/assets/css/custom-props/theme-dark.css
@@ -80,6 +80,7 @@ body.dark {
   --sidebarHover:                var(--white);
   --sidebarScrollbarThumb:       var(--coldGray);
   --sidebarScrollbarTrack:       var(--sidebarBackground);
+  --sidebarStaleVersion:         var(--orangeDark);
   --sidebarSubheadings:          var(--gray400);
   --sidebarItem:                 var(--gray200);
   --sidebarInactiveItemBorder:   var(--gray400);

--- a/assets/css/custom-props/theme-dark.css
+++ b/assets/css/custom-props/theme-dark.css
@@ -80,7 +80,7 @@ body.dark {
   --sidebarHover:                var(--white);
   --sidebarScrollbarThumb:       var(--coldGray);
   --sidebarScrollbarTrack:       var(--sidebarBackground);
-  --sidebarStaleVersion:         var(--orangeDark);
+  --sidebarStaleVersion:         var(--orangeLight);
   --sidebarSubheadings:          var(--gray400);
   --sidebarItem:                 var(--gray200);
   --sidebarInactiveItemBorder:   var(--gray400);

--- a/assets/css/custom-props/theme-light.css
+++ b/assets/css/custom-props/theme-light.css
@@ -80,6 +80,7 @@
   --sidebarHover:                var(--black);
   --sidebarScrollbarThumb:       var(--coldGrayLight);
   --sidebarScrollbarTrack:       var(--sidebarBackground);
+  --sidebarStaleVersion:         var(--orangeLight);
   --sidebarSubheadings:          var(--black);
   --sidebarItem:                 var(--black);
   --sidebarInactiveItemBorder:   var(--gray500);

--- a/assets/css/custom-props/theme-light.css
+++ b/assets/css/custom-props/theme-light.css
@@ -80,7 +80,7 @@
   --sidebarHover:                var(--black);
   --sidebarScrollbarThumb:       var(--coldGrayLight);
   --sidebarScrollbarTrack:       var(--sidebarBackground);
-  --sidebarStaleVersion:         var(--orangeLight);
+  --sidebarStaleVersion:         var(--orangeDark);
   --sidebarSubheadings:          var(--black);
   --sidebarItem:                 var(--black);
   --sidebarInactiveItemBorder:   var(--gray500);

--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -109,6 +109,22 @@
   display: none;
 }
 
+.sidebar .sidebar-staleVersion {
+    display: inline;
+}
+
+.sidebar .sidebar-staleVersion > a {
+    color: var(--sidebarStaleVersion);
+    font-weight: 400;
+}
+
+.sidebar .sidebar-staleIcon {
+    font-size: 18px;
+    position: relative;
+    top: 3px;
+    line-height: 0;
+}
+
 .sidebar .sidebar-list-nav {
   display: flex;
   margin: 0;

--- a/assets/js/handlebars/templates/versions-dropdown.handlebars
+++ b/assets/js/handlebars/templates/versions-dropdown.handlebars
@@ -10,4 +10,12 @@
       {{/each}}
     </select>
   </label>
+  {{#if latestVersion}}
+    <div class="sidebar-staleVersion">
+      <a href="{{latestVersion}}" title="This version of package is not the latest version">
+        <i class="ri-alert-line sidebar-staleIcon" aria-hidden="true"></i>
+        <span>Go to latest</span>
+      </a>
+    </div>
+  {{/if}}
 </form>

--- a/assets/js/sidebar/sidebar-version-select.js
+++ b/assets/js/sidebar/sidebar-version-select.js
@@ -26,10 +26,30 @@ if (!isEmbedded) {
       isCurrentVersion: node.version === currentVersion
     }))
 
-    versionsContainer.innerHTML = versionsDropdownTemplate({ nodes })
+    const latestVersionNode = versionNodes.find(node => node.latest)
+    const latestVersion = latestVersionNode?.version !== currentVersion ? latestVersionNode?.url : null
 
-    qs(VERSIONS_DROPDOWN_SELECTOR).addEventListener('change', handleVersionSelected)
+    versionsContainer.innerHTML = versionsDropdownTemplate({ nodes, latestVersion})
+
+    const select = qs(VERSIONS_DROPDOWN_SELECTOR)
+    select.addEventListener('change', handleVersionSelected)
+    adjustWidth(select)
   }
+}
+
+// Function to adjust the width of the select element
+function adjustWidth (select) {
+  // Create a temporary element to measure the width
+  const temp = document.createElement('span')
+  temp.style.visibility = 'hidden'
+  temp.style.position = 'absolute'
+  temp.style.whiteSpace = 'nowrap'
+  temp.style.font = window.getComputedStyle(select).font
+  temp.textContent = select.options[select.selectedIndex].text
+
+  document.body.appendChild(temp)
+  select.style.width = `${temp.offsetWidth + 20}px`
+  document.body.removeChild(temp)
 }
 
 function handleVersionSelected (event) {


### PR DESCRIPTION
Continuation of #1918 *(could not push to the same branch since I'm not a maintainer)*

---

Based on feedback in #1918 here is the revised version of warning color and icon added when an outdated version is detected.

@halostatue I tried yellow but I could not make it work on Light mode. It would end-up look green-ish when lightness was reduced.

### Screenshots

<img width="314" alt="Screenshot 2025-01-08 at 2 30 25 PM" src="https://github.com/user-attachments/assets/ecfb3120-b23b-4fc9-9189-f90c5f498208" />
<img width="315" alt="Screenshot 2025-01-08 at 2 30 37 PM" src="https://github.com/user-attachments/assets/93881085-d62e-4d52-a65e-3aec54230a6f" />
<img width="375" alt="Screenshot 2025-01-08 at 2 30 45 PM" src="https://github.com/user-attachments/assets/f4227dfe-53a8-42dc-8e3f-ac51cf389133" />


**NOTE**: Initially I wanted to put the icon after the version, but the `<select>` HTML element width is set to the largest possible item. This will create an unwanted padding that looks ugly in projects which have versions like `1.2.3-RC0`.