### PR TITLE
Add main scrollbar dark mode support and improve scrollbar styles

### DIFF
--- a/assets/css/autocomplete.css
+++ b/assets/css/autocomplete.css
@@ -114,6 +114,7 @@
   white-space: normal;
   overflow-x: hidden;
   overscroll-behavior-y: contain;
+  scrollbar-width: thin;
 }
 
 .autocomplete-suggestions.previewing:has(.selected) {
@@ -232,26 +233,6 @@
 
 .autocomplete-suggestions a {
   text-decoration: none !important;
-}
-
-/* Style the scrollbar track (the area behind the thumb) */
-.autocomplete-suggestions::-webkit-scrollbar {
-  width: 5px;
-  /* Set the width of the scrollbar */
-  border-radius: 7px;
-  /* Add rounded corners to the thumb */
-  flex-shrink: 0;
-}
-
-/* Style the scrollbar thumb (the draggable part) */
-.autocomplete-suggestions::-webkit-scrollbar-thumb {
-  background-color: var(--autocompleteScrollbarThumb);
-  border-radius: 7px;
-}
-
-/* Style the scrollbar track on hover */
-.autocomplete-suggestions::-webkit-scrollbar-track {
-  background-color: var(--autocompleteScrollbarTrack);
 }
 
 @media screen and (hover: none) {

--- a/assets/css/content/cheatsheet.css
+++ b/assets/css/content/cheatsheet.css
@@ -114,11 +114,6 @@
   padding: var(--vertical-space) var(--horizontal-space);
 }
 
-.page-cheatmd .content-inner pre code::-webkit-scrollbar {
-  width: 0.4rem;
-  height: 0.6rem;
-}
-
 .page-cheatmd .content-inner .h2 pre {
   margin: 0;
 }

--- a/assets/css/content/code.css
+++ b/assets/css/content/code.css
@@ -27,24 +27,7 @@
   overflow-x: auto;
   white-space: inherit;
   padding: .5em 1em;
-}
-
-.content-inner pre code::-webkit-scrollbar {
-  width: .4rem;
-  height: .4rem;
-}
-
-.content-inner pre code::-webkit-scrollbar-thumb {
-  border-radius: .25rem;
-  background-color: var(--codeScrollThumb);
-}
-
-.content-inner pre code::-webkit-scrollbar-track {
-  background-color: var(--codeScrollBackground);
-}
-
-.content-inner pre code::-webkit-scrollbar-corner {
-  background-color: var(--codeScrollBackground);
+  scrollbar-width: thin;
 }
 
 .content-inner pre code.output {

--- a/assets/css/custom-props/theme-dark.css
+++ b/assets/css/custom-props/theme-dark.css
@@ -103,3 +103,7 @@ body.dark {
   --autocompleteLabelBack:       var(--gray600);
   --autocompleteLabelFont:       rgba(255, 255, 255, 0.8);
 }
+
+:root:has(body.dark) {
+  color-scheme: dark;
+}

--- a/assets/css/custom-props/theme-dark.css
+++ b/assets/css/custom-props/theme-dark.css
@@ -78,8 +78,6 @@ body.dark {
   --sidebarHeader:               var(--gray700);
   --sidebarMuted:                var(--gray300);
   --sidebarHover:                var(--white);
-  --sidebarScrollbarThumb:       var(--coldGray);
-  --sidebarScrollbarTrack:       var(--sidebarBackground);
   --sidebarStaleVersion:         var(--orangeLight);
   --sidebarSubheadings:          var(--gray400);
   --sidebarItem:                 var(--gray200);
@@ -98,8 +96,6 @@ body.dark {
   --suggestionBorder:            var(--gray600);
   --autocompleteResults:         var(--gray200);
   --autocompleteResultsBold:     var(--gray100);
-  --autocompleteScrollbarThumb:   var(--gray600);
-  --autocompleteScrollbarTrack:   var(--gray850);
   --autocompleteLabelBack:       var(--gray600);
   --autocompleteLabelFont:       rgba(255, 255, 255, 0.8);
 }

--- a/assets/css/custom-props/theme-light.css
+++ b/assets/css/custom-props/theme-light.css
@@ -78,8 +78,6 @@
   --sidebarHeader:               var(--gray100);
   --sidebarMuted:                var(--gray800);
   --sidebarHover:                var(--black);
-  --sidebarScrollbarThumb:       var(--coldGrayLight);
-  --sidebarScrollbarTrack:       var(--sidebarBackground);
   --sidebarStaleVersion:         var(--orangeDark);
   --sidebarSubheadings:          var(--black);
   --sidebarItem:                 var(--black);
@@ -99,8 +97,6 @@
   --suggestionBorder:            var(--gray200);
   --autocompleteResults:         var(--gray600);
   --autocompleteResultsBold:     var(--gray800);
-  --autocompleteScrollbarThumb:   var(--gray200);
-  --autocompleteScrollbarTrack:   var(--gray50);
   --autocompleteLabelBack:       var(--gray100);
   --autocompleteLabelFont:       var(--gray600);
 }

--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -8,6 +8,10 @@
   background-color: var(--sidebarBackground);
   color: var(--sidebarAccentMain);
   overflow: hidden;
+
+  & .sidebar-tabpanel {
+    scrollbar-width: thin;
+  }
 }
 
 :root:not(.apple-os) .sidebar {

--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -8,10 +8,6 @@
   background-color: var(--sidebarBackground);
   color: var(--sidebarAccentMain);
   overflow: hidden;
-
-  & .sidebar-tabpanel {
-    scrollbar-width: thin;
-  }
 }
 
 :root:not(.apple-os) .sidebar {

--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -9,7 +9,7 @@
   color: var(--sidebarAccentMain);
   overflow: hidden;
 
-  .sidebar-tabpanel {
+  & .sidebar-tabpanel {
     scrollbar-width: thin;
   }
 }

--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -8,7 +8,10 @@
   background-color: var(--sidebarBackground);
   color: var(--sidebarAccentMain);
   overflow: hidden;
-  scrollbar-color: var(--sidebarScrollbarThumb) var(--sidebarScrollbarTrack);
+
+  .sidebar-tabpanel {
+    scrollbar-width: thin;
+  }
 }
 
 :root:not(.apple-os) .sidebar {
@@ -356,20 +359,6 @@
 .sidebar .full-list ul ul a[aria-selected] {
   color: var(--sidebarActiveItem);
   border-color: var(--sidebarLanguageAccentBar);
-}
-
-.sidebar ::-webkit-scrollbar {
-  width: 14px;
-}
-
-::-webkit-scrollbar-track {
-  background-color: var(--sidebarBackground);
-}
-
-.sidebar ::-webkit-scrollbar-thumb {
-  background-color: var(--sidebarScrollbarThumb);
-  border-radius: 10px;
-  border: 3px solid var(--sidebarBackground);
 }
 
 .sidebar-button {


### PR DESCRIPTION
Introduce support for dark mode in the main scrollbar and enhance scrollbar styles to use native styles as much as possible for better contrast and more predictable scrollbars adhering more to user expectations.

![image](https://github.com/user-attachments/assets/4d457bb0-3951-4755-b861-9d24effe78dc)

![image](https://github.com/user-attachments/assets/7f93fdeb-ba01-4f7f-be3c-622bdf07e589)

