### PR TITLE
Refactor border-radius styles to use CSS variable for consistency

### DIFF
--- a/assets/css/autocomplete.css
+++ b/assets/css/autocomplete.css
@@ -107,7 +107,7 @@
 
 .autocomplete-suggestions {
   background-color: var(--autocompleteBackground);
-  border-radius: 8px;
+  border-radius: var(--borderRadius);
   box-shadow: 0px 15px 99px 0px var(--autocompleteBorder);
   overflow-y: auto;
   max-height: 450px;
@@ -168,7 +168,7 @@
   align-items: center;
   text-decoration: none;
   border: 1px solid var(--suggestionBorder);
-  border-radius: 8px;
+  border-radius: var(--borderRadius);
   transition: color .3s ease-in-out;
   background-color: var(--autocompletePreview);
   cursor: pointer;

--- a/assets/css/content/admonition.css
+++ b/assets/css/content/admonition.css
@@ -1,5 +1,5 @@
 .content-inner section.admonition {
-  border-radius: 10px;
+  border-radius: var(--borderRadius);
   border-left: 0;
 }
 

--- a/assets/css/content/code.css
+++ b/assets/css/content/code.css
@@ -18,6 +18,10 @@
   text-transform: none;
 }
 
+.content-inner code.inline {
+  border-radius: 4px;
+}
+
 .content-inner pre {
   margin: var(--baseLineHeight) 0;
 }

--- a/assets/css/content/code.css
+++ b/assets/css/content/code.css
@@ -12,7 +12,7 @@
 .content-inner code {
   background-color: var(--codeBackground);
   vertical-align: baseline;
-  border-radius: 2px;
+  border-radius: var(--borderRadius);
   padding: .1em .2em;
   border: 1px solid var(--codeBorder);
   text-transform: none;
@@ -26,7 +26,7 @@
   display: block;
   overflow-x: auto;
   white-space: inherit;
-  padding: .5em 1em;
+  padding: 1em;
   scrollbar-width: thin;
 }
 

--- a/assets/css/copy-button.css
+++ b/assets/css/copy-button.css
@@ -14,7 +14,9 @@ pre .copy-button:focus {
   top: 5px;
   right: 5px;
   padding: 4px;
-  background-color: var(--codeBackground);
+  background-color: transparent;
+  backdrop-filter: blur(2px);
+  border-radius: var(--borderRadius);
   border: none;
   cursor: pointer;
   transition: all 150ms;

--- a/assets/css/copy-button.css
+++ b/assets/css/copy-button.css
@@ -15,7 +15,7 @@ pre .copy-button:focus {
   right: 5px;
   padding: 4px;
   background-color: transparent;
-  backdrop-filter: blur(2px);
+  backdrop-filter: blur(4px);
   border-radius: var(--borderRadius);
   border: none;
   cursor: pointer;

--- a/assets/css/custom-props/common.css
+++ b/assets/css/custom-props/common.css
@@ -2,7 +2,7 @@
   /* Layout & Whitespace */
   --content-width: 949px;
   --content-gutter: 60px;
-  --borderRadius: 4px;
+  --borderRadius: 8px;
   --navTabBorderWidth: 4px;
 
   /* Font Families */

--- a/assets/css/search-bar.css
+++ b/assets/css/search-bar.css
@@ -17,7 +17,7 @@
 
 .search-bar {
   border: 1px solid var(--searchBarBorder);
-  border-radius: 8px;
+  border-radius: var(--borderRadius);
   height: 48px;
   position: relative;
   width: 100%;
@@ -26,7 +26,7 @@
 .top-search .search-bar .search-input {
   background-color: var(--searchSearch);
   border: 1px solid transparent;
-  border-radius: 8px;
+  border-radius: var(--borderRadius);
   color: var(--searchAccentMain);
   position: relative;
   height: 46px;

--- a/assets/css/settings.css
+++ b/assets/css/settings.css
@@ -14,7 +14,7 @@
   background-color: var(--settingsInputBackground);
   color: var(--settingsInput);
   border: 1px solid var(--settingsInputBorder);
-  border-radius: 8px;
+  border-radius: var(--borderRadius);
   transition: border-color 150ms;
 }
 #settings-modal-content .input:focus {

--- a/assets/css/toast.css
+++ b/assets/css/toast.css
@@ -9,7 +9,7 @@
   padding: .7rem 1.2rem;
   text-align: center;
   font-weight: 700;
-  border-radius: 10px;
+  border-radius: var(--borderRadius);
   border: 1px solid var(--codeBorder);
   background-color: var(--codeBackground);
   color: var(--textBody);

--- a/assets/css/tooltips.css
+++ b/assets/css/tooltips.css
@@ -29,6 +29,8 @@ as it has absolute positioning, so doesn't impact the layout and click events pa
 
 .tooltip .tooltip-body {
   border: 1px solid var(--codeBorder);
+  border-radius: var(--borderRadius);
+  overflow: auto;
 }
 
 .tooltip .tooltip-body .signature {


### PR DESCRIPTION
I noticed border radius inconsistencies so i addressed them via a single variable.
Update border-radius styles across various components to utilize a CSS variable, ensuring consistency in design. Adjust the variable value for improved appearance.

![image](https://github.com/user-attachments/assets/8804e570-41a4-40c7-a254-3d362a33f5a7)

![image](https://github.com/user-attachments/assets/c0645269-fcd6-400b-b438-e4228702ddc0)

![image](https://github.com/user-attachments/assets/dc22917c-b35f-4682-a14f-0c0e9ed38e40)
