### PR TITLE
Add gap between tabset tabs for improved spacing

### DIFF
--- a/assets/css/tabset.css
+++ b/assets/css/tabset.css
@@ -7,6 +7,7 @@
 .tabset-tablist {
   display: flex;
   overflow-x: auto;
+  gap: 10px;
 }
 
 .tabset-tab {


### PR DESCRIPTION
Introduce a gap between tabset tabs to enhance visual spacing and improve user experience.

![image](https://github.com/user-attachments/assets/a52fb4e2-84e9-4795-8baf-21694d4f937d)
