### PR TITLE
Add word-wrap to inline code to fix overflow

### DIFF
--- a/assets/css/content/code.css
+++ b/assets/css/content/code.css
@@ -20,6 +20,7 @@
 
 .content-inner code.inline {
   border-radius: 4px;
+  word-wrap: break-word;
 }
 
 .content-inner pre {


### PR DESCRIPTION
Improves the readability of inline code by adding word-wrap functionality.

before
![image](https://github.com/user-attachments/assets/7b56d124-d2df-47f1-866f-f26f87fc294c)

after
![image](https://github.com/user-attachments/assets/2830bed2-a9a4-4f64-a60a-58b8f1c1b7e8)
