### PR TITLE
Remove italic font style from footer and summary sections

### DIFF
--- a/assets/css/content/footer.css
+++ b/assets/css/content/footer.css
@@ -1,7 +1,6 @@
 .content-inner .footer {
   margin: 4em auto 1em;
   text-align: center;
-  font-style: italic;
   font-size: 14px;
 }
 
@@ -18,7 +17,6 @@
   background-color: transparent;
   border: 0;
   cursor: pointer;
-  font-style: italic;
   padding: 0 4px;
 }
 

--- a/assets/css/content/summary.css
+++ b/assets/css/content/summary.css
@@ -10,7 +10,6 @@
 .content-inner .summary span.deprecated {
   color: var(--darkDeprecated);
   font-weight: normal;
-  font-style: italic;
 }
 
 .content-inner .summary .summary-row .summary-signature {
@@ -25,7 +24,6 @@
 
 .content-inner .summary .summary-row .summary-synopsis {
   font-family: var(--defaultFontFamily);
-  font-style: italic;
   padding: 0 1.2em;
   margin: 0 0 0.5em;
 }


### PR DESCRIPTION
Remove the italic font style from the footer and summary sections to enhance readability.
many people struggle to read italics and there's no point in using them here anyway

before
![image](https://github.com/user-attachments/assets/48d62e69-5656-424a-a5bb-3a6b433b2825)

after
![image](https://github.com/user-attachments/assets/98b00bdf-16d5-4ffc-8e7e-8c69e64db227)

before
![image](https://github.com/user-attachments/assets/25ba9e15-05fb-47c8-90c2-70ad56a77415)

after
![image](https://github.com/user-attachments/assets/b5504db6-5b82-441a-b2a6-eec72899d733)
