### PR TITLE
Make table responsive with block display and overflow properties

### DIFF
--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -135,6 +135,8 @@
 .content-inner table {
   margin: 2em 0;
   border-collapse: collapse;
+  display: block;
+  overflow: auto;
 }
 
 .content-inner th {


### PR DESCRIPTION
Adding block display and overflow properties to the table improves responsiveness and enhances the user experience on smaller screens.

bug
![image](https://github.com/user-attachments/assets/cd31564e-a81b-435b-9950-dcb81ab591ab)
