### PR TITLE
Remove uppercase transformation from table headers and add nowrap to content cells

### DIFF
--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -140,7 +140,6 @@
 .content-inner th {
   text-align: left;
   font-family: var(--sansFontFamily);
-  text-transform: uppercase;
   font-weight: 700;
   padding-bottom: 0.5em;
 }
@@ -167,6 +166,7 @@
   padding-left: 1em;
   line-height: 2em;
   vertical-align: top;
+  white-space: nowrap;
 }
 
 .content-inner .section-heading {


### PR DESCRIPTION
Eliminate uppercase transformation for better readability and ensure content cells handle text without wrapping.

I couldn't find where the italic`em` is being applied so i can get rid of it

before
![image](https://github.com/user-attachments/assets/dc780186-cd4f-46d4-9318-a9ab8733f1ff)

after
![image](https://github.com/user-attachments/assets/3143d93f-d4ea-4666-b181-af1c37bb96cd)
