### PR TITLE
Enhance sidebar styles for overflow and text display

### DIFF
--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -132,6 +132,8 @@
   display: flex;
   margin: 0;
   padding: 4px 4px 0 4px;
+  overflow: auto;
+  scrollbar-width: thin;
 }
 
 .sidebar .sidebar-list-nav :is(li, li button) {
@@ -139,6 +141,7 @@
   letter-spacing: 0.02em;
   font-size: 14px;
   color: var(--sidebarMuted);
+  white-space: nowrap;
 }
 
 .sidebar .sidebar-list-nav li {


### PR DESCRIPTION
Improve sidebar styles to handle overflow better and ensure text displays correctly without wrapping.

before
![image](https://github.com/user-attachments/assets/405b3252-7105-48d3-aa70-724acb0be5e2)

after
![image](https://github.com/user-attachments/assets/436e29c5-ac3f-409d-bda9-6f418ddb02df)
