### PR TITLE
Improve the font clarity of sidebar tab button styles for better accessibility

### DIFF
--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -3,7 +3,6 @@
   --sidebarLineHeight: 20px;
   font-family: var(--sansFontFamily);
   font-size: var(--sidebarFontSize);
-  font-weight: 300;
   line-height: var(--sidebarLineHeight);
   background-color: var(--sidebarBackground);
   color: var(--sidebarAccentMain);
@@ -12,10 +11,6 @@
   & .sidebar-tabpanel {
     scrollbar-width: thin;
   }
-}
-
-:root:not(.apple-os) .sidebar {
-  font-weight: 400; /* Non-Apple OSes render small light type too thinly */
 }
 
 .sidebar ul {

--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -3,6 +3,7 @@
   --sidebarLineHeight: 20px;
   font-family: var(--sansFontFamily);
   font-size: var(--sidebarFontSize);
+  font-weight: 500;
   line-height: var(--sidebarLineHeight);
   background-color: var(--sidebarBackground);
   color: var(--sidebarAccentMain);
@@ -148,6 +149,7 @@
   -webkit-appearance: none;
   text-align: inherit;
   color: inherit;
+  font-weight: inherit;
   cursor: pointer;
   display: inline-block;
   line-height: 27px;

--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -153,7 +153,6 @@
   -webkit-appearance: none;
   text-align: inherit;
   color: inherit;
-  font-weight: inherit;
   cursor: pointer;
   display: inline-block;
   line-height: 27px;


### PR DESCRIPTION
Removing the inherited font-weight from sidebar button styles improves the visual clarity and overall appearance of the sidebar.

this is an improvement in terms of accessibility as the font can be too thin to read on screens without good contrast levels and pixelating.

research:
https://accessibility.psu.edu/legibility/lightweight/

https://www.digitala11y.com/choosing-accessible-fonts-enhancing-readability-and-inclusivity/#:~:text=Font%20Weight,-Let's%20start%20with&text=But%20be%20cautious%3A%20overly%20bold,fonts%20can%20be%20problematic%20too.

![image](https://github.com/user-attachments/assets/30739939-b56e-4d51-a1d5-5e26f5603822)


![image](https://github.com/user-attachments/assets/b065f406-d39d-46cf-9ec2-92135b0ca48a)

![image](https://github.com/user-attachments/assets/19491a8a-eb81-4d0f-9f0c-52e6b9d49b8d)

![image](https://github.com/user-attachments/assets/c78018ad-a888-4893-aaf8-89a0a3e7a959)

fix applied to tabs
![image](https://github.com/user-attachments/assets/83958ae3-da0e-4f32-9ef8-94fba499aa1f)

fix applied to everything
![image](https://github.com/user-attachments/assets/6738f462-3faf-40ba-8f96-9b1235cfb0b7)


tldr: avoid light weight fonts as much as possible