### PR TITLE
Remove uppercase transformation from sidebar tab items for accessibility reasons

### DIFF
--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -137,7 +137,6 @@
 }
 
 .sidebar .sidebar-list-nav :is(li, li button) {
-  text-transform: uppercase;
   letter-spacing: 0.02em;
   font-size: 14px;
   color: var(--sidebarMuted);


### PR DESCRIPTION
Improved readability by removing the uppercase transformation from sidebar list items.

this solution even saves horizontal space

Important for accessibility

research:
https://www.a11y-101.com/design/capitalisation

https://accessibility.huit.harvard.edu/design-readability
> Avoid using all caps. Readability is reduced with all caps because all words have a uniform rectangular shape, meaning readers can't identify words by their shape.

tldr: The best thing to do is to avoid uppercase letters

before
![image](https://github.com/user-attachments/assets/029bc398-8460-4adb-a262-26f7b6bebe84)

after
![image](https://github.com/user-attachments/assets/0bc98a35-f259-4045-a007-abebe8fc2d69)
