### PR TITLE
Refactor deprecated content styles and improve accessibility colors

### DIFF
--- a/assets/css/content/functions.css
+++ b/assets/css/content/functions.css
@@ -107,6 +107,8 @@
 
 .content-inner div.deprecated {
   display: block;
-  padding: 9px 15px;
+  padding: 1em;
   background-color: var(--fnDeprecated);
+  border-radius: var(--borderRadius);
+  margin: var(--baseLineHeight) 0;
 }

--- a/assets/css/custom-props/common.css
+++ b/assets/css/custom-props/common.css
@@ -40,8 +40,8 @@
   --coldGray-opacity-10: hsla(240, 5%, 46%, 10%);
   --coldGrayDark: hsl(240, 5%, 28%);
   --coldGrayDim: hsl(240, 5%, 18%);
-  --yellowLight: hsl(60, 100%, 81%);
-  --yellowDark: hsl(60, 100%, 43%, 62%);
+  --yellowLight: hsl(43, 100%, 95%);
+  --yellowDark: hsl(44, 100%, 15%);
   --yellow: hsl(60, 100%, 43%);
   --green-lightened-10: hsl(90, 100%, 45%);
   --green: hsl(90, 100%, 35%);


### PR DESCRIPTION
Refactor styles for deprecated content and update yellow color variables to enhance accessibility.

before
![image](https://github.com/user-attachments/assets/434f9eaa-9f80-47b7-8113-633a5c0ee249)

![image](https://github.com/user-attachments/assets/bf4a3ff5-9fe0-4b53-b929-8906e3e7d6c2)

after
![image](https://github.com/user-attachments/assets/6400bee1-de1c-4876-8ce3-907c5b0abff2)

![image](https://github.com/user-attachments/assets/8678a149-4d57-435b-a9d6-009a366a5169)


colors inspired by https://docusaurus.io/docs/markdown-features/admonitions