### PR TITLE
Fix code action icon position in top heading

### DIFF
--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -33,7 +33,6 @@
   font-weight: normal;
 }
 .content-inner .heading-with-actions.top-heading .icon-action {
-  padding-top: 1.5rem;
   font-size: 1.2rem;
 }
 

--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -11,7 +11,7 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
-  align-items: start;
+  align-items: center;
   gap: 6px;
 }
 .content-inner .heading-with-actions > *:not(h1) {


### PR DESCRIPTION
Eliminate unnecessary top padding from the action icon to improve alignment in the top heading.

before
![image](https://github.com/user-attachments/assets/7e081263-d38d-4296-914c-632e949b6da9)

after
![image](https://github.com/user-attachments/assets/c38f168e-fecd-445b-8e4b-3bf314674041)
