### PR TITLE
Remove italic font style from summary synopsis for improved readability

### DIFF
--- a/assets/css/content/summary.css
+++ b/assets/css/content/summary.css
@@ -26,7 +26,6 @@
 
 .content-inner .summary .summary-row .summary-synopsis {
   font-family: var(--defaultFontFamily);
-  font-style: italic;
   padding: 0 1.2em;
   margin: 0 0 0.5em;
 }

--- a/assets/css/content/summary.css
+++ b/assets/css/content/summary.css
@@ -11,7 +11,6 @@
 .content-inner .summary span.deprecated {
   color: var(--darkDeprecated);
   font-weight: normal;
-  font-style: italic;
 }
 
 .content-inner .summary .summary-row .summary-signature {


### PR DESCRIPTION
Eliminate the italic font style in the summary synopsis to enhance text clarity and readability

research https://ux.stackexchange.com/a/62752

before
![image](https://github.com/user-attachments/assets/8a2dee35-37cb-4aab-9c56-d5dda9d99cf0)

after
![image](https://github.com/user-attachments/assets/6284ca41-6f00-4365-96ca-67ae5b3299e2)
