### PR TITLE
Add background color to option elements for improved visibility

### DIFF
--- a/assets/css/custom-props/common.css
+++ b/assets/css/custom-props/common.css
@@ -76,3 +76,7 @@
     --content-gutter: 20px;
   }
 }
+
+option {
+  background-color: var(--sidebarBackground);
+}


### PR DESCRIPTION
Improved visibility of option elements by adding a background color. this is because select transparency doesn't apply to option elements so it defaults to white which breaks in dark mode

before
![image](https://github.com/user-attachments/assets/a9fb50c2-cdcc-4d1b-8fb5-de845641a7b9)

after
![image](https://github.com/user-attachments/assets/25834547-6b67-4558-8ed2-1dc7d7f2ae84)
