### PR TITLE
Update content width for improved accessibility

### DIFF
--- a/assets/css/custom-props/common.css
+++ b/assets/css/custom-props/common.css
@@ -1,6 +1,6 @@
 :root {
   /* Layout & Whitespace */
-  --content-width: 949px;
+  --content-width: 70em;
   --content-gutter: 60px;
   --borderRadius: 8px;
   --navTabBorderWidth: 4px;


### PR DESCRIPTION
Adjust the content width variable to enhance the responsiveness of the layout.

w3 recommends `70em` which is a nice balance between showing the max amount of content (reduce scrolling) without compromising readability

https://www.w3.org/WAI/tutorials/page-structure/styling/#line-length

before
![image](https://github.com/user-attachments/assets/1c76e9b4-40bf-4101-a840-e50e58d52854)

after
![image](https://github.com/user-attachments/assets/98f9a8da-3050-4131-8ce1-fb4377ff331a)
