### PR TITLE
Refactor table wrap for improved text handling

### DIFF
--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -144,6 +144,7 @@
   font-family: var(--sansFontFamily);
   font-weight: 700;
   padding-bottom: 0.5em;
+  white-space: nowrap;
 }
 
 .content-inner thead tr {
@@ -168,7 +169,6 @@
   padding-left: 1em;
   line-height: 2em;
   vertical-align: top;
-  white-space: nowrap;
 }
 
 .content-inner .section-heading {


### PR DESCRIPTION
Only allow td wrapping to avoid headers overflowing because of long td cells and having to horizontally scroll to see the rest of the headers.

before
![image](https://github.com/user-attachments/assets/21d0d919-41a4-411c-a494-0f234acfa396)

after
![image](https://github.com/user-attachments/assets/e77cb95c-9efd-4b0d-a967-1ef69e9313d7)
