### PR TITLE
Use system font for consistency, improved readability, and faster loading times

### DIFF
--- a/assets/css/_html.css
+++ b/assets/css/_html.css
@@ -1,3 +1,6 @@
+@import "@fontsource-variable/inter";
+@import "@fontsource-variable/vazirmatn";
+
 @import "custom-props/common.css";
 @import "custom-props/theme-light.css";
 @import "custom-props/theme-dark.css";

--- a/assets/css/_html.css
+++ b/assets/css/_html.css
@@ -1,5 +1,6 @@
 @import "@fontsource-variable/inter";
 @import "@fontsource-variable/vazirmatn";
+@import "@fontsource-variable/open-sans";
 
 @import "custom-props/common.css";
 @import "custom-props/theme-light.css";

--- a/assets/css/_html.css
+++ b/assets/css/_html.css
@@ -1,8 +1,3 @@
-@import "@fontsource/lato/300.css";
-@import "@fontsource/lato/400.css";
-@import "@fontsource/lato/700.css";
-@import "@fontsource-variable/inconsolata";
-
 @import "custom-props/common.css";
 @import "custom-props/theme-light.css";
 @import "custom-props/theme-dark.css";

--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -233,7 +233,8 @@
   font-family: var(--monoFontFamily);
   font-style: normal;
   line-height: 24px;
-  font-weight: 400;
+  font-weight: normal;
+  font-size: 0.875rem
 }
 
 @media screen and (max-width: 768px) {

--- a/assets/css/custom-props/common.css
+++ b/assets/css/custom-props/common.css
@@ -6,10 +6,9 @@
   --navTabBorderWidth: 2px;
 
   /* Font Families */
-  --defaultFontFamily: -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif,
-    "Apple Color Emoji", "Segoe UI Emoji";
-  --sansFontFamily: "Lato", sans-serif;
-  --monoFontFamily: "Inconsolata Variable", Menlo, Courier, monospace;
+  --defaultFontFamily: system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  --sansFontFamily: var(--defaultFontFamily);
+  --monoFontFamily: monospace, monospace;
 
   /* Typography */
   --baseFontSize: 18px;

--- a/assets/css/custom-props/common.css
+++ b/assets/css/custom-props/common.css
@@ -6,7 +6,7 @@
   --navTabBorderWidth: 2px;
 
   /* Font Families */
-  --defaultFontFamily: system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  --defaultFontFamily: "Inter Variable", system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   --sansFontFamily: var(--defaultFontFamily);
   --monoFontFamily: monospace, monospace;
 

--- a/assets/css/custom-props/common.css
+++ b/assets/css/custom-props/common.css
@@ -6,7 +6,7 @@
   --navTabBorderWidth: 2px;
 
   /* Font Families */
-  --defaultFontFamily: "Inter Variable", system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  --defaultFontFamily: "Open Sans Variable", system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   --sansFontFamily: var(--defaultFontFamily);
   --monoFontFamily: monospace, monospace;
 

--- a/assets/css/custom-props/common.css
+++ b/assets/css/custom-props/common.css
@@ -11,8 +11,8 @@
   --monoFontFamily: monospace, monospace;
 
   /* Typography */
-  --baseFontSize: 18px;
-  --baseLineHeight: 1.5em;
+  --baseFontSize: 1rem;
+  --baseLineHeight: 1.5rem;
 
   /* Colours */
   --gray25: hsl(207, 43%, 98%);

--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -234,7 +234,7 @@
 
 .sidebar .full-list a {
   margin-right: 30px;
-  padding: 5px 0 5px 12px;
+  padding: 6px 0 6px 12px;
   border-left: var(--navTabBorderWidth) solid transparent;
   color: var(--sidebarItem);
 }

--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -3,7 +3,7 @@
   --sidebarLineHeight: 20px;
   font-family: var(--sansFontFamily);
   font-size: var(--sidebarFontSize);
-  font-weight: 300;
+  font-weight: normal;
   line-height: var(--sidebarLineHeight);
   background-color: var(--sidebarBackground);
   color: var(--sidebarAccentMain);
@@ -12,10 +12,6 @@
   & .sidebar-tabpanel {
     scrollbar-width: thin;
   }
-}
-
-:root:not(.apple-os) .sidebar {
-  font-weight: 400; /* Non-Apple OSes render small light type too thinly */
 }
 
 .sidebar ul {

--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -146,7 +146,6 @@
 }
 
 .sidebar .sidebar-list-nav :is(li, li button) {
-  text-transform: uppercase;
   letter-spacing: 0.02em;
   font-size: 14px;
   color: var(--sidebarMuted);
@@ -216,7 +215,6 @@
 }
 
 .sidebar .full-list li.group {
-  text-transform: uppercase;
   font-weight: bold;
   font-size: 0.8em;
   margin: 1.5em 0 0;

--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -234,7 +234,7 @@
 
 .sidebar .full-list a {
   margin-right: 30px;
-  padding: 3px 0 3px 12px;
+  padding: 5px 0 5px 12px;
   border-left: var(--navTabBorderWidth) solid transparent;
   color: var(--sidebarItem);
 }
@@ -327,7 +327,6 @@
 
 .sidebar .full-list ul a {
   padding-left: 15px;
-  height: 24px;
 }
 
 .sidebar .full-list ul button {

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -7,6 +7,8 @@
       "name": "ex_doc",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@fontsource-variable/inter": "^5.1.1",
+        "@fontsource-variable/vazirmatn": "^5.1.1",
         "@swup/a11y-plugin": "^5.0.0",
         "@swup/progress-plugin": "^3.2.0",
         "esbuild": "^0.16.16",
@@ -417,6 +419,20 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.1.1.tgz",
+      "integrity": "sha512-OpXFTmiH6tHkYijMvQTycFKBLK4X+SRV6tet1m4YOUH7SzIIlMqDja+ocDtiCA72UthBH/vF+3ZtlMr2rN/wIw==",
+      "dev": true,
+      "license": "OFL-1.1"
+    },
+    "node_modules/@fontsource-variable/vazirmatn": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/vazirmatn/-/vazirmatn-5.1.1.tgz",
+      "integrity": "sha512-Tugc1E5yFSvD/DLuCJ3qZjjLggzz1VNuAGfzU4l29IEHp9GfgRdHEiukEAWcAnQ1UnsSXfjUnhMmJiixOYR2CA==",
+      "dev": true,
+      "license": "OFL-1.1"
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -4776,6 +4792,18 @@
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       }
+    },
+    "@fontsource-variable/inter": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.1.1.tgz",
+      "integrity": "sha512-OpXFTmiH6tHkYijMvQTycFKBLK4X+SRV6tet1m4YOUH7SzIIlMqDja+ocDtiCA72UthBH/vF+3ZtlMr2rN/wIw==",
+      "dev": true
+    },
+    "@fontsource-variable/vazirmatn": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/vazirmatn/-/vazirmatn-5.1.1.tgz",
+      "integrity": "sha512-Tugc1E5yFSvD/DLuCJ3qZjjLggzz1VNuAGfzU4l29IEHp9GfgRdHEiukEAWcAnQ1UnsSXfjUnhMmJiixOYR2CA==",
+      "dev": true
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -6,12 +6,7 @@
     "": {
       "name": "ex_doc",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@fontsource-variable/inconsolata": "^5.1.1"
-      },
       "devDependencies": {
-        "@fontsource/inconsolata": "^4.5.9",
-        "@fontsource/lato": "^4.5.10",
         "@swup/a11y-plugin": "^5.0.0",
         "@swup/progress-plugin": "^3.2.0",
         "esbuild": "^0.16.16",
@@ -422,24 +417,6 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
-    },
-    "node_modules/@fontsource-variable/inconsolata": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/inconsolata/-/inconsolata-5.1.1.tgz",
-      "integrity": "sha512-zwPcyf5/9sw0xO4hKPhdmMPBmx7zYzRGjHsdh0U2Mxf44pYdCoxZgbPw4JNIUCbMnMY8u2tE6W+6kv1cHiRO4g==",
-      "license": "OFL-1.1"
-    },
-    "node_modules/@fontsource/inconsolata": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/@fontsource/inconsolata/-/inconsolata-4.5.9.tgz",
-      "integrity": "sha512-hj+IIYvbmA0pxoIbjQVkPkEq28moTuD0d4c+s3HU58Gossh24NH6ExttgU/ImJGDngxxGKfmbuZeAJhxUQWdyw==",
-      "dev": true
-    },
-    "node_modules/@fontsource/lato": {
-      "version": "4.5.10",
-      "resolved": "https://registry.npmjs.org/@fontsource/lato/-/lato-4.5.10.tgz",
-      "integrity": "sha512-2hYR6r661Cq9B8zugtu6yxuOKqrVhAgfOSaPSq8XoxbC4ebsl0KOTy/vPoP+9U7JuQVLfrmikirW4a9Z0nDUug==",
-      "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -4799,23 +4776,6 @@
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       }
-    },
-    "@fontsource-variable/inconsolata": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/inconsolata/-/inconsolata-5.1.1.tgz",
-      "integrity": "sha512-zwPcyf5/9sw0xO4hKPhdmMPBmx7zYzRGjHsdh0U2Mxf44pYdCoxZgbPw4JNIUCbMnMY8u2tE6W+6kv1cHiRO4g=="
-    },
-    "@fontsource/inconsolata": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/@fontsource/inconsolata/-/inconsolata-4.5.9.tgz",
-      "integrity": "sha512-hj+IIYvbmA0pxoIbjQVkPkEq28moTuD0d4c+s3HU58Gossh24NH6ExttgU/ImJGDngxxGKfmbuZeAJhxUQWdyw==",
-      "dev": true
-    },
-    "@fontsource/lato": {
-      "version": "4.5.10",
-      "resolved": "https://registry.npmjs.org/@fontsource/lato/-/lato-4.5.10.tgz",
-      "integrity": "sha512-2hYR6r661Cq9B8zugtu6yxuOKqrVhAgfOSaPSq8XoxbC4ebsl0KOTy/vPoP+9U7JuQVLfrmikirW4a9Z0nDUug==",
-      "dev": true
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -6,6 +6,9 @@
     "": {
       "name": "ex_doc",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@fontsource-variable/open-sans": "^5.1.1"
+      },
       "devDependencies": {
         "@fontsource-variable/inter": "^5.1.1",
         "@fontsource-variable/vazirmatn": "^5.1.1",
@@ -425,6 +428,12 @@
       "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.1.1.tgz",
       "integrity": "sha512-OpXFTmiH6tHkYijMvQTycFKBLK4X+SRV6tet1m4YOUH7SzIIlMqDja+ocDtiCA72UthBH/vF+3ZtlMr2rN/wIw==",
       "dev": true,
+      "license": "OFL-1.1"
+    },
+    "node_modules/@fontsource-variable/open-sans": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/open-sans/-/open-sans-5.1.1.tgz",
+      "integrity": "sha512-5YCCAAt6t8b9T1UehgGuD0z1mZ8orrygrWC8PrA7hAIDdyQRZXYmT6A+9qG7hnhFRHR3KTSIcvBodO0EsRxZrA==",
       "license": "OFL-1.1"
     },
     "node_modules/@fontsource-variable/vazirmatn": {
@@ -4798,6 +4807,11 @@
       "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.1.1.tgz",
       "integrity": "sha512-OpXFTmiH6tHkYijMvQTycFKBLK4X+SRV6tet1m4YOUH7SzIIlMqDja+ocDtiCA72UthBH/vF+3ZtlMr2rN/wIw==",
       "dev": true
+    },
+    "@fontsource-variable/open-sans": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/open-sans/-/open-sans-5.1.1.tgz",
+      "integrity": "sha512-5YCCAAt6t8b9T1UehgGuD0z1mZ8orrygrWC8PrA7hAIDdyQRZXYmT6A+9qG7hnhFRHR3KTSIcvBodO0EsRxZrA=="
     },
     "@fontsource-variable/vazirmatn": {
       "version": "5.1.1",

--- a/assets/package.json
+++ b/assets/package.json
@@ -27,6 +27,8 @@
   "homepage": "https://github.com/elixir-lang/ex_doc#readme",
   "browserslist": "last 2 versions",
   "devDependencies": {
+    "@fontsource-variable/inter": "^5.1.1",
+    "@fontsource-variable/vazirmatn": "^5.1.1",
     "@swup/a11y-plugin": "^5.0.0",
     "@swup/progress-plugin": "^3.2.0",
     "esbuild": "^0.16.16",
@@ -47,8 +49,9 @@
     "lunr": "^2.3.8",
     "mocha": "^10.2.0",
     "normalize.css": "^8.0.1",
-    "swup": "^4.8.1",
-    "@fontsource-variable/inter": "^5.1.1",
-    "@fontsource-variable/vazirmatn": "^5.1.1"
+    "swup": "^4.8.1"
+  },
+  "dependencies": {
+    "@fontsource-variable/open-sans": "^5.1.1"
   }
 }

--- a/assets/package.json
+++ b/assets/package.json
@@ -47,6 +47,8 @@
     "lunr": "^2.3.8",
     "mocha": "^10.2.0",
     "normalize.css": "^8.0.1",
-    "swup": "^4.8.1"
+    "swup": "^4.8.1",
+    "@fontsource-variable/inter": "^5.1.1",
+    "@fontsource-variable/vazirmatn": "^5.1.1"
   }
 }

--- a/assets/package.json
+++ b/assets/package.json
@@ -27,8 +27,6 @@
   "homepage": "https://github.com/elixir-lang/ex_doc#readme",
   "browserslist": "last 2 versions",
   "devDependencies": {
-    "@fontsource-variable/inconsolata": "^5.1.1",
-    "@fontsource/lato": "^4.5.10",
     "@swup/a11y-plugin": "^5.0.0",
     "@swup/progress-plugin": "^3.2.0",
     "esbuild": "^0.16.16",


### PR DESCRIPTION
Standardize font weights and sizes across components to enhance readability and maintain consistency in typography.

[Docusaurus](https://docusaurus.io/) relies on system fonts and it looks pertty good and loads very quickly

looks great and consistent with all systems i've tested on (macos, window, ubuntu) tbh

if we get rid of these third party fonts then this saves 70.2kB from Lato

and 34.3kB from Inconsolata

look at how much time is wasted fetching these separate resources

![image](https://github.com/user-attachments/assets/6e153ce4-5c6a-4cc0-b01d-d9883cae5a4a)

![image](https://github.com/user-attachments/assets/ac2b8d7b-8920-474a-9357-635a3821e476)
