### PR TITLE
Use system monospace font

### DIFF
--- a/assets/css/_html.css
+++ b/assets/css/_html.css
@@ -1,6 +1,5 @@
 @import "@fontsource/lato/400.css";
 @import "@fontsource/lato/700.css";
-@import "@fontsource-variable/inconsolata";
 
 @import "custom-props/common.css";
 @import "custom-props/theme-light.css";

--- a/assets/css/custom-props/common.css
+++ b/assets/css/custom-props/common.css
@@ -9,7 +9,7 @@
   --defaultFontFamily: -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji";
   --sansFontFamily: "Lato", sans-serif;
-  --monoFontFamily: "Inconsolata Variable", Menlo, Courier, monospace;
+  --monoFontFamily: monospace;
 
   /* Typography */
   --baseFontSize: 18px;

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -6,11 +6,7 @@
     "": {
       "name": "ex_doc",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@fontsource-variable/inconsolata": "^5.1.1"
-      },
       "devDependencies": {
-        "@fontsource/inconsolata": "^4.5.9",
         "@fontsource/lato": "^4.5.10",
         "@swup/a11y-plugin": "^5.0.0",
         "@swup/progress-plugin": "^3.2.0",
@@ -422,18 +418,6 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
-    },
-    "node_modules/@fontsource-variable/inconsolata": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/inconsolata/-/inconsolata-5.1.1.tgz",
-      "integrity": "sha512-zwPcyf5/9sw0xO4hKPhdmMPBmx7zYzRGjHsdh0U2Mxf44pYdCoxZgbPw4JNIUCbMnMY8u2tE6W+6kv1cHiRO4g==",
-      "license": "OFL-1.1"
-    },
-    "node_modules/@fontsource/inconsolata": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/@fontsource/inconsolata/-/inconsolata-4.5.9.tgz",
-      "integrity": "sha512-hj+IIYvbmA0pxoIbjQVkPkEq28moTuD0d4c+s3HU58Gossh24NH6ExttgU/ImJGDngxxGKfmbuZeAJhxUQWdyw==",
-      "dev": true
     },
     "node_modules/@fontsource/lato": {
       "version": "4.5.10",
@@ -4799,17 +4783,6 @@
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       }
-    },
-    "@fontsource-variable/inconsolata": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/inconsolata/-/inconsolata-5.1.1.tgz",
-      "integrity": "sha512-zwPcyf5/9sw0xO4hKPhdmMPBmx7zYzRGjHsdh0U2Mxf44pYdCoxZgbPw4JNIUCbMnMY8u2tE6W+6kv1cHiRO4g=="
-    },
-    "@fontsource/inconsolata": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/@fontsource/inconsolata/-/inconsolata-4.5.9.tgz",
-      "integrity": "sha512-hj+IIYvbmA0pxoIbjQVkPkEq28moTuD0d4c+s3HU58Gossh24NH6ExttgU/ImJGDngxxGKfmbuZeAJhxUQWdyw==",
-      "dev": true
     },
     "@fontsource/lato": {
       "version": "4.5.10",

--- a/assets/package.json
+++ b/assets/package.json
@@ -27,7 +27,6 @@
   "homepage": "https://github.com/elixir-lang/ex_doc#readme",
   "browserslist": "last 2 versions",
   "devDependencies": {
-    "@fontsource-variable/inconsolata": "^5.1.1",
     "@fontsource/lato": "^4.5.10",
     "@swup/a11y-plugin": "^5.0.0",
     "@swup/progress-plugin": "^3.2.0",


### PR DESCRIPTION
Eliminate the Inconsolata font dependency and adjust styles to use the system monospace font instead. This streamlines the font usage in the project and reduces page load times.