### PR TITLE
Adjust margin-top for icon action in detail header

### DIFF
--- a/assets/css/content/functions.css
+++ b/assets/css/content/functions.css
@@ -58,7 +58,7 @@
 }
 
 .content-inner .detail-header .icon-action {
-  margin-top: 3px;
+  margin-top: 0px;
 }
 
 .content-inner .specs pre {

--- a/assets/css/content/functions.css
+++ b/assets/css/content/functions.css
@@ -57,10 +57,6 @@
   }
 }
 
-.content-inner .detail-header .icon-action {
-  margin-top: 0px;
-}
-
 .content-inner .specs pre {
   font-family: var(--monoFontFamily);
   font-size: 0.9em;


### PR DESCRIPTION
Modify the margin-top for the icon action in the detail header to improve layout consistency.

before
![image](https://github.com/user-attachments/assets/324ee262-ce68-48e1-9559-eca30482cbd1)

after
![image](https://github.com/user-attachments/assets/d9257c9f-c2e5-4059-a189-d79432ae7bed)
