### PR TITLE
Replace normalize.css with modern-normalize for improved styling consistency

### DIFF
--- a/assets/css/_html.css
+++ b/assets/css/_html.css
@@ -5,7 +5,7 @@
 @import "custom-props/theme-light.css";
 @import "custom-props/theme-dark.css";
 
-@import "normalize.css/normalize.css";
+@import 'modern-normalize/modern-normalize.css';
 
 @import "icons.css";
 @import "layout.css";

--- a/assets/css/_html.css
+++ b/assets/css/_html.css
@@ -5,7 +5,7 @@
 @import "custom-props/theme-light.css";
 @import "custom-props/theme-dark.css";
 
-@import 'modern-normalize/modern-normalize.css';
+@import "modern-normalize/modern-normalize.css";
 
 @import "icons.css";
 @import "layout.css";

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -28,7 +28,7 @@
         "lodash.throttle": "^4.1.1",
         "lunr": "^2.3.8",
         "mocha": "^10.2.0",
-        "normalize.css": "^8.0.1",
+        "modern-normalize": "^3.0.1",
         "swup": "^4.8.1"
       },
       "engines": {
@@ -2948,6 +2948,19 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/modern-normalize": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/modern-normalize/-/modern-normalize-3.0.1.tgz",
+      "integrity": "sha512-VqlMdYi59Uch6fnUPxnpijWUQe+TW6zeWCvyr6Mb7JibheHzSuAAoJi2c71ZwIaWKpECpGpYHoaaBp6rBRr+/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -3001,12 +3014,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/normalize.css": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
-      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==",
-      "dev": true
     },
     "node_modules/object-assign": {
       "version": "4.1.1",

--- a/assets/package.json
+++ b/assets/package.json
@@ -48,7 +48,7 @@
     "lodash.throttle": "^4.1.1",
     "lunr": "^2.3.8",
     "mocha": "^10.2.0",
-    "normalize.css": "^8.0.1",
+    "modern-normalize": "^3.0.1",
     "swup": "^4.8.1"
   }
 }


### PR DESCRIPTION
Switch to modern-normalize for better cross-browser consistency in styling and remove the deprecated normalize.css.

tailwind uses modern-normalize https://v3.tailwindcss.com/docs/preflight

normalize.css hasn't been updated in 6 years

i've done some testing and everything looks the same as before