### PR TITLE
Refactor monospace font sizes to use CSS variables for consistency

### DIFF
--- a/assets/css/content/code.css
+++ b/assets/css/content/code.css
@@ -52,7 +52,7 @@
   top: -16px;
   left: 12px;
   padding: 2px 4px;
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-family: var(--monoFontFamily);
   line-height: 1;
   color: var(--textHeaders);

--- a/assets/css/content/functions.css
+++ b/assets/css/content/functions.css
@@ -27,7 +27,7 @@
 
 .content-inner .detail-header .signature {
   font-family: var(--monoFontFamily);
-  font-size: 14px;
+  font-size: var(--text-sm);
   font-weight: 700;
 }
 
@@ -59,7 +59,7 @@
 
 .content-inner .specs pre {
   font-family: var(--monoFontFamily);
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-style: normal;
   line-height: 24px;
   white-space: pre-wrap;

--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -231,7 +231,7 @@
   font-style: normal;
   line-height: 24px;
   font-weight: 400;
-  font-size: 13px;
+  font-size: var(--text-sm);
 }
 
 @media screen and (max-width: 768px) {

--- a/assets/css/content/summary.css
+++ b/assets/css/content/summary.css
@@ -11,7 +11,7 @@
 
 .content-inner .summary .summary-row .summary-signature {
   font-family: var(--monoFontFamily);
-  font-size: 13px;
+  font-size: var(--text-sm);
   font-weight: 700;
 }
 

--- a/assets/css/custom-props/common.css
+++ b/assets/css/custom-props/common.css
@@ -55,7 +55,8 @@
   --orangeDark: hsl(30, 90%, 40%);
   --orangeLight: hsl(30, 80%, 50%);
 
-  --text-sm: 0.875rem;
+  --text-sm: 0.875rem; /* 14px */
+  --text-xs: 0.75rem; /* 12px */
 
   --transition-duration: 150ms;
   --transition-timing: cubic-bezier(0.4, 0, 0.2, 1);

--- a/assets/css/custom-props/common.css
+++ b/assets/css/custom-props/common.css
@@ -55,6 +55,8 @@
   --orangeDark: hsl(30, 90%, 40%);
   --orangeLight: hsl(30, 80%, 50%);
 
+  --text-sm: 0.875rem;
+
   --transition-duration: 150ms;
   --transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
 


### PR DESCRIPTION
Replace hardcoded font sizes with CSS variables to ensure consistency across the application. Introduce a new variable for small text size.

I've also noticed monospace text became too small in some places when @josevalim tried to compensate for the larger system monospace font rendering in https://github.com/elixir-lang/ex_doc/commit/70acb0d5a97976f2456dfa8b05ef404f6d78b539#diff-ff486ec25148e539aaaedfe186ecf1c05b629ff7fe07e5c26040a65eb4193bc0 so this brings the font sizes back to a normal level consistent with the rest of the website, going below 14px is bad for legibility

`0.875rem` is equivalent to 14px https://v3.tailwindcss.com/docs/font-size

result

![image](https://github.com/user-attachments/assets/1285b113-9650-42cf-8d2a-5622d24bb03a)

![image](https://github.com/user-attachments/assets/5f322da8-6363-44be-a998-2d1a18452fec)
