### PR TITLE
Fix font cascading behavior and clean up CSS by removing unused variables and redundant declarations

### DIFF
--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -1,5 +1,4 @@
 .content-inner {
-  font-family: var(--defaultFontFamily);
   font-size: 1em;
   line-height: 1.6875em;
   position: relative;

--- a/assets/css/content/summary.css
+++ b/assets/css/content/summary.css
@@ -21,7 +21,6 @@
 }
 
 .content-inner .summary .summary-row .summary-synopsis {
-  font-family: var(--defaultFontFamily);
   padding: 0 1.2em;
   margin: 0 0 0.5em;
 }

--- a/assets/css/copy-button.css
+++ b/assets/css/copy-button.css
@@ -20,7 +20,6 @@ pre .copy-button:focus {
   border: 1px solid var(--codeBorder);
   cursor: pointer;
   transition: var(--transition-all);
-  font-family: var(--defaultFontFamily);
   font-size: var(--text-sm);
   line-height: 24px;
   color: currentColor;

--- a/assets/css/custom-props/common.css
+++ b/assets/css/custom-props/common.css
@@ -6,6 +6,7 @@
   --navTabBorderWidth: 2px;
 
   /* Font Families */
+  /* modern-normalize.css handles the default font */
   --sansFontFamily: "Lato", ui-sans-serif, system-ui, sans-serif;
   --monoFontFamily: ui-monospace, monospace;
 

--- a/assets/css/custom-props/common.css
+++ b/assets/css/custom-props/common.css
@@ -12,7 +12,6 @@
   --monoFontFamily: ui-monospace, monospace;
 
   /* Typography */
-  --baseFontSize: 18px;
   --baseLineHeight: 1.5em;
 
   /* Colours */

--- a/assets/css/custom-props/common.css
+++ b/assets/css/custom-props/common.css
@@ -6,8 +6,6 @@
   --navTabBorderWidth: 2px;
 
   /* Font Families */
-  --defaultFontFamily: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif,
-    "Apple Color Emoji", "Segoe UI Emoji";
   --sansFontFamily: "Lato", ui-sans-serif, system-ui, sans-serif;
   --monoFontFamily: ui-monospace, monospace;
 

--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -12,7 +12,6 @@ body {
   background-color: var(--background);
   color: var(--textBody);
   font-size: var(--text-base);
-  font-family: var(--sansFontFamily);
   line-height: 1.6875em;
 }
 


### PR DESCRIPTION
Eliminate unused variables and redundant font family declarations to streamline the CSS files.

this pr introduces no visual changes but fixes font hierarchy because sansFontFamily which is meant for titles and the sidebar was being applied on the entire site and this fixes that so now we have proper font cascading behavior where the default font is actually the default

normalize already sets things globally https://github.com/sindresorhus/modern-normalize/blob/ba66c6fe35c7ae33954120c73e69d57de4249a0b/modern-normalize.css#L26