### PR TITLE
Remove remaining swup:page:view listeners

### DIFF
--- a/assets/js/sidebar/sidebar-list.js
+++ b/assets/js/sidebar/sidebar-list.js
@@ -1,6 +1,8 @@
 import { el, getCurrentPageSidebarType, qs, qsAll } from '../helpers'
 import { getSidebarNodes } from '../globals'
 
+// Sidebar list is only rendered when needed.
+// Mobile users may never see the sidebar.
 let init = false
 export function initialize () {
   if (init) return
@@ -88,15 +90,15 @@ export function initialize () {
     }))
   })
 
-  window.addEventListener('hashchange', markCurrentHashInSidebar)
-
-  // We listen to swup:page:view event because we need to trigger
-  // markCurrentHashInSidebar() before scollNodeListToCurrentCategory.
-  window.addEventListener('swup:page:view', markCurrentHashInSidebar)
+  // Update new sidebar list with current hash.
   markCurrentHashInSidebar()
 
   // Triggers layout, defer.
   requestAnimationFrame(scrollNodeListToCurrentCategory)
+
+  // Keep updated with future changes.
+  window.addEventListener('hashchange', markCurrentHashInSidebar)
+  window.addEventListener('exdoc:loaded', markCurrentHashInSidebar)
 }
 
 /**

--- a/assets/js/swup.js
+++ b/assets/js/swup.js
@@ -3,9 +3,14 @@ import SwupA11yPlugin from '@swup/a11y-plugin'
 import SwupProgressPlugin from '@swup/progress-plugin'
 import { isEmbedded } from './globals'
 
-window.addEventListener('DOMContentLoaded', () => {
+// Emit exdoc:loaded each time content loads:
+// - on initial page load (DOMContentLoaded)
+// - on subsequent SWUP page loads (page:view)
+const emitExdocLoaded = () => {
   window.dispatchEvent(new Event('exdoc:loaded'))
-})
+}
+
+window.addEventListener('DOMContentLoaded', emitExdocLoaded)
 
 if (!isEmbedded && window.location.protocol !== 'file:') {
   new Swup({
@@ -17,10 +22,9 @@ if (!isEmbedded && window.location.protocol !== 'file:') {
             path === window.location.pathname + '.html'
     },
     linkSelector: 'a[href]:not([href^="/"]):not([href^="http"])',
+    hooks: {
+      'page:view': emitExdocLoaded
+    },
     plugins: [new SwupA11yPlugin(), new SwupProgressPlugin({delay: 500})]
-  })
-
-  window.addEventListener('swup:page:view', () => {
-    window.dispatchEvent(new Event('exdoc:loaded'))
   })
 }


### PR DESCRIPTION
Re: https://github.com/elixir-lang/ex_doc/pull/2069#discussion_r1929493618

The sidebar-list is lazy-rendered so will always be called after the first `exdoc:loaded` event.

I re-arranged a few lines and added some comments to make it more obvious that it's not the standard `exdoc:loaded` -> `init()` pattern.