### PR TITLE
Ensure top heading action icon is to right when width allows

### DIFF
--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -41,7 +41,7 @@
     gap: 32px;
     align-items: flex-start;
     .icon-action {
-      padding-top: 1.7rem; /* vertically aligned with first line of heading x-height */
+      padding-top: 1.7rem; /* vertically align with x-height of first line of heading */
     }
   }
 }

--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -34,6 +34,17 @@
 .content-inner .heading-with-actions.top-heading .icon-action {
   font-size: 1.2rem;
 }
+/* When content is wide enough, ensure action icon is to the right of, not below, heading */
+@container content (width > 600px) {
+  .content-inner .heading-with-actions.top-heading {
+    flex-wrap: nowrap;
+    gap: 32px;
+    align-items: flex-start;
+    .icon-action {
+      padding-top: 1.7rem; /* vertically aligned with first line of heading x-height */
+    }
+  }
+}
 
 .content-inner .top-heading {
   padding-top: 1rem;

--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -59,6 +59,7 @@ body {
 }
 
 .content .content-inner {
+  container: content / inline-size;
   max-width: var(--content-width);
   min-height: 100%;
   margin: 0 auto;


### PR DESCRIPTION
Only `top-heading` headings are affected, and only when content is wider than 600px.

Callback/function headings have not been changed; they continue to always wrap so as to prioritise text display.

A container has been registered in the layout styles, meaning that we can easily conditionally apply styles based on the content width irrespective of whether or not the sidebar is shown.

https://github.com/user-attachments/assets/59fd72b6-de59-472c-9a64-753d18ea8778

