### PR TITLE
Improve tabset corners; rework border-radius across styles

### DIFF
--- a/assets/css/autocomplete.css
+++ b/assets/css/autocomplete.css
@@ -107,7 +107,7 @@
 
 .autocomplete-suggestions {
   background-color: var(--autocompleteBackground);
-  border-radius: var(--borderRadiusMiddle);
+  border-radius: var(--borderRadius-base);
   box-shadow: 0px 15px 99px 0px var(--autocompleteBorder);
   overflow-y: auto;
   max-height: 450px;
@@ -167,7 +167,7 @@
   align-items: center;
   text-decoration: none;
   border: 1px solid var(--suggestionBorder);
-  border-radius: var(--borderRadiusMiddle);
+  border-radius: var(--borderRadius-base);
   transition: var(--transition-colors);
   background-color: var(--autocompletePreview);
   cursor: pointer;

--- a/assets/css/autocomplete.css
+++ b/assets/css/autocomplete.css
@@ -107,7 +107,7 @@
 
 .autocomplete-suggestions {
   background-color: var(--autocompleteBackground);
-  border-radius: var(--borderRadius);
+  border-radius: var(--borderRadiusOuter);
   box-shadow: 0px 15px 99px 0px var(--autocompleteBorder);
   overflow-y: auto;
   max-height: 450px;
@@ -167,7 +167,7 @@
   align-items: center;
   text-decoration: none;
   border: 1px solid var(--suggestionBorder);
-  border-radius: var(--borderRadius);
+  border-radius: var(--borderRadiusOuter);
   transition: var(--transition-colors);
   background-color: var(--autocompletePreview);
   cursor: pointer;

--- a/assets/css/autocomplete.css
+++ b/assets/css/autocomplete.css
@@ -107,7 +107,7 @@
 
 .autocomplete-suggestions {
   background-color: var(--autocompleteBackground);
-  border-radius: var(--borderRadiusOuter);
+  border-radius: var(--borderRadiusMiddle);
   box-shadow: 0px 15px 99px 0px var(--autocompleteBorder);
   overflow-y: auto;
   max-height: 450px;
@@ -167,7 +167,7 @@
   align-items: center;
   text-decoration: none;
   border: 1px solid var(--suggestionBorder);
-  border-radius: var(--borderRadiusOuter);
+  border-radius: var(--borderRadiusMiddle);
   transition: var(--transition-colors);
   background-color: var(--autocompletePreview);
   cursor: pointer;

--- a/assets/css/content/admonition.css
+++ b/assets/css/content/admonition.css
@@ -1,5 +1,5 @@
 .content-inner section.admonition {
-  border-radius: var(--borderRadiusInner);
+  border-radius: var(--borderRadiusMiddle);
   border-left: 0;
 }
 

--- a/assets/css/content/admonition.css
+++ b/assets/css/content/admonition.css
@@ -1,5 +1,5 @@
 .content-inner section.admonition {
-  border-radius: var(--borderRadiusMiddle);
+  border-radius: var(--borderRadius-base);
   border-left: 0;
 }
 

--- a/assets/css/content/admonition.css
+++ b/assets/css/content/admonition.css
@@ -1,5 +1,5 @@
 .content-inner section.admonition {
-  border-radius: var(--borderRadius);
+  border-radius: var(--borderRadiusInner);
   border-left: 0;
 }
 

--- a/assets/css/content/bottom-actions.css
+++ b/assets/css/content/bottom-actions.css
@@ -13,7 +13,7 @@
   display: flex;
   text-decoration: none;
   flex-direction: column;
-  border-radius: var(--borderRadiusInner);
+  border-radius: var(--borderRadius-sm);
   border: 1px solid var(--bottomActionsBtnBorder);
   padding: 12px 16px;
   min-width: 150px;

--- a/assets/css/content/bottom-actions.css
+++ b/assets/css/content/bottom-actions.css
@@ -13,7 +13,7 @@
   display: flex;
   text-decoration: none;
   flex-direction: column;
-  border-radius: var(--borderRadiusOuter);
+  border-radius: var(--borderRadiusInner);
   border: 1px solid var(--bottomActionsBtnBorder);
   padding: 12px 16px;
   min-width: 150px;

--- a/assets/css/content/bottom-actions.css
+++ b/assets/css/content/bottom-actions.css
@@ -13,7 +13,7 @@
   display: flex;
   text-decoration: none;
   flex-direction: column;
-  border-radius: var(--borderRadius);
+  border-radius: var(--borderRadiusOuter);
   border: 1px solid var(--bottomActionsBtnBorder);
   padding: 12px 16px;
   min-width: 150px;

--- a/assets/css/content/cheatsheet.css
+++ b/assets/css/content/cheatsheet.css
@@ -97,7 +97,7 @@
 
 .page-cheatmd .content-inner .h2 p > code {
   color: #eb5757;
-  border-radius: var(--borderRadiusOuter);
+  border-radius: var(--borderRadiusInner);
   padding: 0.2em 0.4em;
 }
 
@@ -156,7 +156,7 @@
 
 .page-cheatmd .content-inner .h2 td code {
   color: #eb5757;
-  border-radius: var(--borderRadiusOuter);
+  border-radius: var(--borderRadiusInner);
   padding: 0.2em 0.4em;
 }
 
@@ -195,7 +195,7 @@
 
 .page-cheatmd .content-inner .h2 li > code {
   color: #eb5757;
-  border-radius: var(--borderRadiusOuter);
+  border-radius: var(--borderRadiusInner);
   padding: 0.2em 0.4em;
 }
 

--- a/assets/css/content/cheatsheet.css
+++ b/assets/css/content/cheatsheet.css
@@ -97,7 +97,7 @@
 
 .page-cheatmd .content-inner .h2 p > code {
   color: #eb5757;
-  border-radius: var(--borderRadius);
+  border-radius: var(--borderRadiusOuter);
   padding: 0.2em 0.4em;
 }
 
@@ -156,7 +156,7 @@
 
 .page-cheatmd .content-inner .h2 td code {
   color: #eb5757;
-  border-radius: var(--borderRadius);
+  border-radius: var(--borderRadiusOuter);
   padding: 0.2em 0.4em;
 }
 
@@ -195,7 +195,7 @@
 
 .page-cheatmd .content-inner .h2 li > code {
   color: #eb5757;
-  border-radius: var(--borderRadius);
+  border-radius: var(--borderRadiusOuter);
   padding: 0.2em 0.4em;
 }
 

--- a/assets/css/content/cheatsheet.css
+++ b/assets/css/content/cheatsheet.css
@@ -97,7 +97,7 @@
 
 .page-cheatmd .content-inner .h2 p > code {
   color: #eb5757;
-  border-radius: var(--borderRadiusInner);
+  border-radius: var(--borderRadius-sm);
   padding: 0.2em 0.4em;
 }
 
@@ -156,7 +156,7 @@
 
 .page-cheatmd .content-inner .h2 td code {
   color: #eb5757;
-  border-radius: var(--borderRadiusInner);
+  border-radius: var(--borderRadius-sm);
   padding: 0.2em 0.4em;
 }
 
@@ -195,7 +195,7 @@
 
 .page-cheatmd .content-inner .h2 li > code {
   color: #eb5757;
-  border-radius: var(--borderRadiusInner);
+  border-radius: var(--borderRadius-sm);
   padding: 0.2em 0.4em;
 }
 

--- a/assets/css/content/code.css
+++ b/assets/css/content/code.css
@@ -12,14 +12,14 @@
 .content-inner code {
   background-color: var(--codeBackground);
   vertical-align: baseline;
-  border-radius: var(--borderRadius);
+  border-radius: var(--borderRadiusInner);
   padding: .1em .2em;
   border: 1px solid var(--codeBorder);
   text-transform: none;
 }
 
 .content-inner code.inline {
-  border-radius: 4px;
+  border-radius: var(--borderRadiusInner);
   word-wrap: break-word;
 }
 

--- a/assets/css/content/code.css
+++ b/assets/css/content/code.css
@@ -12,14 +12,14 @@
 .content-inner code {
   background-color: var(--codeBackground);
   vertical-align: baseline;
-  border-radius: var(--borderRadiusInner);
+  border-radius: var(--borderRadius-sm);
   padding: .1em .2em;
   border: 1px solid var(--codeBorder);
   text-transform: none;
 }
 
 .content-inner code.inline {
-  border-radius: var(--borderRadiusInner);
+  border-radius: var(--borderRadius-sm);
   word-wrap: break-word;
 }
 

--- a/assets/css/content/functions.css
+++ b/assets/css/content/functions.css
@@ -105,6 +105,6 @@
   display: block;
   padding: 1em;
   background-color: var(--fnDeprecated);
-  border-radius: var(--borderRadiusOuter);
+  border-radius: var(--borderRadiusInner);
   margin: var(--baseLineHeight) 0;
 }

--- a/assets/css/content/functions.css
+++ b/assets/css/content/functions.css
@@ -20,7 +20,6 @@
   padding: 0.5em 0.85em 0.5em 1em;
   background-color: var(--textDetailBackground);
   border-left: 3px solid var(--textDetailAccent);
-  border-radius: var(--borderRadiusInner);
   font-size: 1em;
   font-family: var(--monoFontFamily);
   position: relative;

--- a/assets/css/content/functions.css
+++ b/assets/css/content/functions.css
@@ -20,6 +20,7 @@
   padding: 0.5em 0.85em 0.5em 1em;
   background-color: var(--textDetailBackground);
   border-left: 3px solid var(--textDetailAccent);
+  border-radius: var(--borderRadiusInner);
   font-size: 1em;
   font-family: var(--monoFontFamily);
   position: relative;
@@ -105,6 +106,6 @@
   display: block;
   padding: 1em;
   background-color: var(--fnDeprecated);
-  border-radius: var(--borderRadius);
+  border-radius: var(--borderRadiusOuter);
   margin: var(--baseLineHeight) 0;
 }

--- a/assets/css/content/functions.css
+++ b/assets/css/content/functions.css
@@ -105,6 +105,6 @@
   display: block;
   padding: 1em;
   background-color: var(--fnDeprecated);
-  border-radius: var(--borderRadiusInner);
+  border-radius: var(--borderRadius-sm);
   margin: var(--baseLineHeight) 0;
 }

--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -121,7 +121,7 @@
   padding: 0 1.2rem;
   overflow: auto;
   background-color: var(--blockquoteBackground);
-  border-radius: var(--borderRadiusMiddle);
+  border-radius: var(--borderRadius-base);
 }
 .content-inner blockquote p:last-child, .content-inner section.admonition p:last-child  {
   padding-bottom: 1em;

--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -121,7 +121,7 @@
   padding: 0 1.2rem;
   overflow: auto;
   background-color: var(--blockquoteBackground);
-  border-radius: var(--borderRadius);
+  border-radius: var(--borderRadiusOuter);
 }
 .content-inner blockquote p:last-child, .content-inner section.admonition p:last-child  {
   padding-bottom: 1em;

--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -121,7 +121,7 @@
   padding: 0 1.2rem;
   overflow: auto;
   background-color: var(--blockquoteBackground);
-  border-radius: var(--borderRadiusOuter);
+  border-radius: var(--borderRadiusMiddle);
 }
 .content-inner blockquote p:last-child, .content-inner section.admonition p:last-child  {
   padding-bottom: 1em;

--- a/assets/css/copy-button.css
+++ b/assets/css/copy-button.css
@@ -16,7 +16,7 @@ pre .copy-button:focus {
   padding: 8px;
   background-color: transparent;
   backdrop-filter: blur(8px);
-  border-radius: var(--borderRadiusOuter);
+  border-radius: var(--borderRadiusInner);
   border: 1px solid var(--codeBorder);
   cursor: pointer;
   transition: var(--transition-all);

--- a/assets/css/copy-button.css
+++ b/assets/css/copy-button.css
@@ -16,7 +16,7 @@ pre .copy-button:focus {
   padding: 8px;
   background-color: transparent;
   backdrop-filter: blur(8px);
-  border-radius: var(--borderRadius);
+  border-radius: var(--borderRadiusOuter);
   border: 1px solid var(--codeBorder);
   cursor: pointer;
   transition: var(--transition-all);

--- a/assets/css/copy-button.css
+++ b/assets/css/copy-button.css
@@ -16,7 +16,7 @@ pre .copy-button:focus {
   padding: 8px;
   background-color: transparent;
   backdrop-filter: blur(8px);
-  border-radius: var(--borderRadiusInner);
+  border-radius: var(--borderRadius-sm);
   border: 1px solid var(--codeBorder);
   cursor: pointer;
   transition: var(--transition-all);

--- a/assets/css/custom-props/common.css
+++ b/assets/css/custom-props/common.css
@@ -2,7 +2,8 @@
   /* Layout & Whitespace */
   --content-width: 949px;
   --content-gutter: 60px;
-  --borderRadiusOuter: 12px;
+  --borderRadiusOuter: 14px;
+  --borderRadiusMiddle: 8px;
   --borderRadiusInner: 3px;
   --navTabBorderWidth: 2px;
 

--- a/assets/css/custom-props/common.css
+++ b/assets/css/custom-props/common.css
@@ -2,7 +2,8 @@
   /* Layout & Whitespace */
   --content-width: 949px;
   --content-gutter: 60px;
-  --borderRadius: 8px;
+  --borderRadiusOuter: 12px;
+  --borderRadiusInner: 3px;
   --navTabBorderWidth: 2px;
 
   /* Font Families */
@@ -58,7 +59,7 @@
   --text-base: 1rem; /* 16px */
   --text-lg: 1.125rem; /* 18px */
   --text-xl: 1.25rem; /* 20px */
-  
+
   --transition-duration: 150ms;
   --transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
 

--- a/assets/css/custom-props/common.css
+++ b/assets/css/custom-props/common.css
@@ -2,9 +2,9 @@
   /* Layout & Whitespace */
   --content-width: 949px;
   --content-gutter: 60px;
-  --borderRadiusOuter: 14px;
-  --borderRadiusMiddle: 8px;
-  --borderRadiusInner: 3px;
+  --borderRadius-lg: 14px;
+  --borderRadius-base: 8px;
+  --borderRadius-sm: 3px;
   --navTabBorderWidth: 2px;
 
   /* Font Families */

--- a/assets/css/keyboard-shortcuts.css
+++ b/assets/css/keyboard-shortcuts.css
@@ -22,7 +22,7 @@
 #keyboard-shortcuts-content kbd > kbd {
   background-color: var(--settingsInputBorder);
   color: var(--contrast);
-  border-radius: var(--borderRadiusInner);
+  border-radius: var(--borderRadius-sm);
   font-family: inherit;
   font-weight: bold;
   display: inline-block;

--- a/assets/css/keyboard-shortcuts.css
+++ b/assets/css/keyboard-shortcuts.css
@@ -22,7 +22,7 @@
 #keyboard-shortcuts-content kbd > kbd {
   background-color: var(--settingsInputBorder);
   color: var(--contrast);
-  border-radius: var(--borderRadius);
+  border-radius: var(--borderRadiusOuter);
   font-family: inherit;
   font-weight: bold;
   display: inline-block;

--- a/assets/css/keyboard-shortcuts.css
+++ b/assets/css/keyboard-shortcuts.css
@@ -22,7 +22,7 @@
 #keyboard-shortcuts-content kbd > kbd {
   background-color: var(--settingsInputBorder);
   color: var(--contrast);
-  border-radius: var(--borderRadiusOuter);
+  border-radius: var(--borderRadiusInner);
   font-family: inherit;
   font-weight: bold;
   display: inline-block;

--- a/assets/css/modal.css
+++ b/assets/css/modal.css
@@ -27,7 +27,7 @@
   margin: 75px auto 0 auto;
   max-width: 500px;
   background-color: var(--modalBackground);
-  border-radius: var(--borderRadius);
+  border-radius: var(--borderRadiusOuter);
   box-shadow: 2px 2px 8px rgba(0, 0, 0, .2);
   padding: 25px 35px 35px;
 }

--- a/assets/css/modal.css
+++ b/assets/css/modal.css
@@ -27,7 +27,7 @@
   margin: 75px auto 0 auto;
   max-width: 500px;
   background-color: var(--modalBackground);
-  border-radius: var(--borderRadiusInner);
+  border-radius: var(--borderRadius-sm);
   box-shadow: 2px 2px 8px rgba(0, 0, 0, .2);
   padding: 25px 35px 35px;
 }

--- a/assets/css/modal.css
+++ b/assets/css/modal.css
@@ -27,7 +27,7 @@
   margin: 75px auto 0 auto;
   max-width: 500px;
   background-color: var(--modalBackground);
-  border-radius: var(--borderRadiusOuter);
+  border-radius: var(--borderRadiusInner);
   box-shadow: 2px 2px 8px rgba(0, 0, 0, .2);
   padding: 25px 35px 35px;
 }

--- a/assets/css/search-bar.css
+++ b/assets/css/search-bar.css
@@ -17,7 +17,7 @@
 
 .search-bar {
   border: 1px solid var(--searchBarBorder);
-  border-radius: var(--borderRadiusOuter);
+  border-radius: var(--borderRadiusMiddle);
   height: 48px;
   position: relative;
   width: 100%;
@@ -26,7 +26,7 @@
 .top-search .search-bar .search-input {
   background-color: var(--searchSearch);
   border: 1px solid transparent;
-  border-radius: var(--borderRadiusOuter);
+  border-radius: var(--borderRadiusMiddle);
   color: var(--searchAccentMain);
   position: relative;
   height: 46px;
@@ -42,7 +42,7 @@
 
 .top-search .search-bar .search-input:focus {
   border: 1px solid var(--searchBarFocusColor);
-  border-radius: 7px;
+  border-radius: calc(var(--borderRadiusMiddle) - 1px);
   position: relative;
   box-shadow: 0px 4px 20px 0px var(--searchBarBorderColor) inset;
 }

--- a/assets/css/search-bar.css
+++ b/assets/css/search-bar.css
@@ -17,7 +17,7 @@
 
 .search-bar {
   border: 1px solid var(--searchBarBorder);
-  border-radius: var(--borderRadiusMiddle);
+  border-radius: var(--borderRadius-base);
   height: 48px;
   position: relative;
   width: 100%;
@@ -26,7 +26,7 @@
 .top-search .search-bar .search-input {
   background-color: var(--searchSearch);
   border: 1px solid transparent;
-  border-radius: var(--borderRadiusMiddle);
+  border-radius: var(--borderRadius-base);
   color: var(--searchAccentMain);
   position: relative;
   height: 46px;
@@ -42,7 +42,7 @@
 
 .top-search .search-bar .search-input:focus {
   border: 1px solid var(--searchBarFocusColor);
-  border-radius: calc(var(--borderRadiusMiddle) - 1px);
+  border-radius: calc(var(--borderRadius-base) - 1px);
   position: relative;
   box-shadow: 0px 4px 20px 0px var(--searchBarBorderColor) inset;
 }

--- a/assets/css/search-bar.css
+++ b/assets/css/search-bar.css
@@ -17,7 +17,7 @@
 
 .search-bar {
   border: 1px solid var(--searchBarBorder);
-  border-radius: var(--borderRadius);
+  border-radius: var(--borderRadiusOuter);
   height: 48px;
   position: relative;
   width: 100%;
@@ -26,7 +26,7 @@
 .top-search .search-bar .search-input {
   background-color: var(--searchSearch);
   border: 1px solid transparent;
-  border-radius: var(--borderRadius);
+  border-radius: var(--borderRadiusOuter);
   color: var(--searchAccentMain);
   position: relative;
   height: 46px;

--- a/assets/css/settings.css
+++ b/assets/css/settings.css
@@ -14,7 +14,7 @@
   background-color: var(--settingsInputBackground);
   color: var(--settingsInput);
   border: 1px solid var(--settingsInputBorder);
-  border-radius: var(--borderRadiusMiddle);
+  border-radius: var(--borderRadius-base);
   transition: var(--transition-all);
 }
 #settings-modal-content .input:focus {

--- a/assets/css/settings.css
+++ b/assets/css/settings.css
@@ -14,7 +14,7 @@
   background-color: var(--settingsInputBackground);
   color: var(--settingsInput);
   border: 1px solid var(--settingsInputBorder);
-  border-radius: var(--borderRadius);
+  border-radius: var(--borderRadiusOuter);
   transition: var(--transition-all);
 }
 #settings-modal-content .input:focus {

--- a/assets/css/settings.css
+++ b/assets/css/settings.css
@@ -14,7 +14,7 @@
   background-color: var(--settingsInputBackground);
   color: var(--settingsInput);
   border: 1px solid var(--settingsInputBorder);
-  border-radius: var(--borderRadiusOuter);
+  border-radius: var(--borderRadiusMiddle);
   transition: var(--transition-all);
 }
 #settings-modal-content .input:focus {

--- a/assets/css/tabset.css
+++ b/assets/css/tabset.css
@@ -4,7 +4,7 @@
   margin: var(--baseLineHeight) 0;
   border: var(--borderWidth) solid var(--tabBorder);
   padding: 0 var(--tabsetPadding);
-  border-radius: var(--borderRadiusOuter);
+  border-radius: var(--borderRadius-lg);
 }
 
 .tabset-tablist {

--- a/assets/css/tabset.css
+++ b/assets/css/tabset.css
@@ -4,7 +4,7 @@
   margin: var(--baseLineHeight) 0;
   border: var(--borderWidth) solid var(--tabBorder);
   padding: 0 var(--tabsetPadding);
-  border-radius: var(--borderRadius);
+  border-radius: var(--borderRadiusOuter);
 }
 
 .tabset-tablist {

--- a/assets/css/toast.css
+++ b/assets/css/toast.css
@@ -10,7 +10,7 @@
   padding: .7rem 1.2rem;
   text-align: center;
   font-weight: 700;
-  border-radius: var(--borderRadiusOuter);
+  border-radius: var(--borderRadiusMiddle);
   border: 1px solid var(--codeBorder);
   background-color: var(--codeBackground);
   color: var(--textBody);

--- a/assets/css/toast.css
+++ b/assets/css/toast.css
@@ -10,7 +10,7 @@
   padding: .7rem 1.2rem;
   text-align: center;
   font-weight: 700;
-  border-radius: var(--borderRadius);
+  border-radius: var(--borderRadiusOuter);
   border: 1px solid var(--codeBorder);
   background-color: var(--codeBackground);
   color: var(--textBody);

--- a/assets/css/toast.css
+++ b/assets/css/toast.css
@@ -10,7 +10,7 @@
   padding: .7rem 1.2rem;
   text-align: center;
   font-weight: 700;
-  border-radius: var(--borderRadiusMiddle);
+  border-radius: var(--borderRadius-base);
   border: 1px solid var(--codeBorder);
   background-color: var(--codeBackground);
   color: var(--textBody);

--- a/assets/css/tooltips.css
+++ b/assets/css/tooltips.css
@@ -29,7 +29,7 @@ as it has absolute positioning, so doesn't impact the layout and click events pa
 
 .tooltip .tooltip-body {
   border: 1px solid var(--codeBorder);
-  border-radius: var(--borderRadiusInner);
+  border-radius: var(--borderRadius-sm);
   overflow: auto;
 }
 

--- a/assets/css/tooltips.css
+++ b/assets/css/tooltips.css
@@ -29,7 +29,7 @@ as it has absolute positioning, so doesn't impact the layout and click events pa
 
 .tooltip .tooltip-body {
   border: 1px solid var(--codeBorder);
-  border-radius: var(--borderRadiusOuter);
+  border-radius: var(--borderRadiusInner);
   overflow: auto;
 }
 

--- a/assets/css/tooltips.css
+++ b/assets/css/tooltips.css
@@ -29,7 +29,7 @@ as it has absolute positioning, so doesn't impact the layout and click events pa
 
 .tooltip .tooltip-body {
   border: 1px solid var(--codeBorder);
-  border-radius: var(--borderRadius);
+  border-radius: var(--borderRadiusOuter);
   overflow: auto;
 }
 


### PR DESCRIPTION
One reason for this suggestion is avoiding the optical mismatch between inner and outer frames:

![image](https://github.com/user-attachments/assets/6b439c55-2cc3-44ec-8910-f8a2a1d6b528)

This introduces an inner radius and an outer radius:

![image](https://github.com/user-attachments/assets/37cb9b4e-bdaa-4d06-b05e-e588a13ccc26)

Summary:

- Most elements' border radii are reduced to 3px; nearer to what they were before, but still very slightly rounder if I'm not mistaken, and so not such a stark change.
- Tabset frames' border radius is increased to 12px.
- Admonitions being set to the 'inner', smaller radius is the biggest difference to the last release; here they are more square, despite, of course, not always appearing within another frame. I don't mind this, but thought it worth flagging.

![Screenshot from 2025-01-27 23 04 23](https://github.com/user-attachments/assets/3d8ee1a5-439d-4f7e-ac7e-1699cb052a34)

![Screenshot from 2025-01-27 23 04 05](https://github.com/user-attachments/assets/d0405839-b3b2-438b-9c94-15cbfb7b2940)

<strike>This also introduces the inner/small radius to callback/function headings:</strike>

Draft status as there are likely more outers to change to inners. I'll wait to hear whether or not this approach is desired.