### PR TITLE
Increase code font size

### DIFF
--- a/assets/css/content/functions.css
+++ b/assets/css/content/functions.css
@@ -59,7 +59,7 @@
 
 .content-inner .specs pre {
   font-family: var(--monoFontFamily);
-  font-size: var(--text-xs);
+  font-size: var(--text-sm);
   font-style: normal;
   line-height: 24px;
   white-space: pre-wrap;

--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -241,7 +241,7 @@
   font-style: normal;
   line-height: 24px;
   font-weight: 400;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 @media screen and (max-width: 768px) {

--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -241,7 +241,7 @@
   font-style: normal;
   line-height: 24px;
   font-weight: 400;
-  font-size: 14px;
+  font-size: var(--text-sm);
 }
 
 @media screen and (max-width: 768px) {

--- a/assets/css/content/summary.css
+++ b/assets/css/content/summary.css
@@ -11,7 +11,7 @@
 
 .content-inner .summary .summary-row .summary-signature {
   font-family: var(--monoFontFamily);
-  font-size: 13px;
+  font-size: var(--text-sm);
   font-weight: 700;
 }
 


### PR DESCRIPTION
Adjust font sizes for better readability and refactor CSS to utilize variables for consistency across the styles.

The font is smaller that before on windows and is harder to read, bringing it up to 14px makes it easier to read