### PR TITLE
Fix so that `fun()` in Erlang does not try to generate any link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,10 @@ jobs:
           # Test Erlang without -doc attribute support
           - elixir: "1.16"
             otp: "26"
-          # Test Erlang with -doc attribute support
+          # Test with initial Erlang doc attribute support
           - elixir: "1.17"
+            otp: "27"
+          - elixir: "1.18"
             otp: "27"
             lint: true
     steps:

--- a/lib/ex_doc/language/elixir.ex
+++ b/lib/ex_doc/language/elixir.ex
@@ -289,7 +289,7 @@ defmodule ExDoc.Language.Elixir do
         {:local, :..}
 
       ["//", "", ""] ->
-        {:local, :"..//"}
+        {:local, :..//}
 
       ["", ""] ->
         {:local, :.}

--- a/lib/ex_doc/language/erlang.ex
+++ b/lib/ex_doc/language/erlang.ex
@@ -571,7 +571,7 @@ defmodule ExDoc.Language.Erlang do
                 name == :record and acc != [] ->
                   {ast, acc}
 
-                name in [:"::", :when, :%{}, :{}, :|, :->, :...] ->
+                name in [:"::", :when, :%{}, :{}, :|, :->, :..., :fun] ->
                   {ast, acc}
 
                 # %{required(...) => ..., optional(...) => ...}

--- a/test/ex_doc/language/erlang_test.exs
+++ b/test/ex_doc/language/erlang_test.exs
@@ -814,6 +814,14 @@ defmodule ExDoc.Language.ErlangTest do
       end
     end
 
+    test "function - specific arity", c do
+      assert autolink_spec(~s"-spec foo() -> fun((t()) -> t()) | erlang_bar:t().", c) ==
+               ~s[foo() -> fun((<a href="#t:t/0">t</a>()) -> <a href="#t:t/0">t</a>()) | <a href="erlang_bar.html#t:t/0">erlang_bar:t</a>().]
+
+      assert autolink_spec(~s"-spec foo() -> fun((t(), t()) -> t()) | erlang_bar:t().", c) ==
+               ~s[foo() -> fun((<a href="#t:t/0">t</a>(), <a href="#t:t/0">t</a>()) -> <a href="#t:t/0">t</a>()) | <a href="erlang_bar.html#t:t/0">erlang_bar:t</a>().]
+    end
+
     test "local type", c do
       assert autolink_spec(~S"-spec foo() -> t().", c) ==
                ~s|foo() -> <a href="#t:t/0">t</a>().|


### PR DESCRIPTION
Turns out that there actually was a test for this, but as the codepath was Elixir 1.18 only it was never tested in CI. So this PR adds Elixir 1.18 to the CI matrix and fixes the fun problem.

Fixes regression in #1980