### PR TITLE
Fix dark Erlang visited link colour

### DIFF
--- a/assets/css/custom-props/_elixir.css
+++ b/assets/css/custom-props/_elixir.css
@@ -8,11 +8,11 @@
   --searchBarFocusColor:  #8E7CE6;
   --searchBarBorderColor: rgba(142, 124, 230, 0.25);
 
-  --link-color:            var(--mainDark);
-  --link-visited-color:     var(--mainDarkest);
+  --link-color:           var(--mainDark);
+  --link-visited-color:   var(--mainDarkest);
 }
 
 body.dark {
-  --link-color:            var(--mainLightest);
-  --link-visited-color:     var(--mainLight);
+  --link-color:           var(--mainLightest);
+  --link-visited-color:   var(--mainLight);
 }

--- a/assets/css/custom-props/_erlang.css
+++ b/assets/css/custom-props/_erlang.css
@@ -8,11 +8,11 @@
   --searchBarFocusColor:  hsl(0, 100%, 50%);
   --searchBarBorderColor: rgb(255, 71, 71, 0.1);
 
-  --link-color:            #0969da;
-  --link-visited-color:     #085fc4;
+  --link-color:           hsl(212, 96%, 45%);
+  --link-visited-color:   hsl(212, 96%, 40%);
 }
 
 body.dark {
-  --link-color:            #71b7ff;
-  --link-visited-color:     #d0adef;
+  --link-color:           hsl(212, 56%, 72%);
+  --link-visited-color:   hsl(212, 56%, 67%);
 }


### PR DESCRIPTION
Also converts language colours from hex to hsl.

Before:
![Screenshot from 2025-01-28 15 37 25](https://github.com/user-attachments/assets/1edbd35b-f90a-4e79-bf62-5be6cb9315c8)

After:
![Screenshot from 2025-01-28 15 38 21](https://github.com/user-attachments/assets/9576363f-aa49-4aab-bd81-c2da3e92c3c6)
