### PR TITLE
Increase margin-bottom of last textual element in tabset content

### DIFF
--- a/assets/css/tabset.css
+++ b/assets/css/tabset.css
@@ -71,6 +71,14 @@
   }
 }
 
+/* tabpanel content: top margin of first and bottom margin of last */
+@media screen and (max-width: 768px) {
+  .tabset-panel > :is(:first-child) {
+    &:is(table) {
+      margin: .5em 0;
+    }
+  }
+}
 @media screen and (min-width: 769px) {
   .tabset-panel > :is(:first-child) {
     &:is(blockquote, .admonition) {

--- a/assets/css/tabset.css
+++ b/assets/css/tabset.css
@@ -72,7 +72,26 @@
 }
 
 @media screen and (min-width: 769px) {
-  .tabset-panel > *:last-child:not(pre) {
-    margin-bottom: 1.25em;
+  .tabset-panel > :is(:first-child) {
+    &:is(blockquote, .admonition) {
+      margin-top: 1.5em;
+    }
+    &:is(p:has(img)) {
+      margin-top: 1.25em;
+    }
+    &:is(table) {
+      margin-top: .75em;
+    }
+  }
+  .tabset-panel > :is(:last-child) {
+    &:is(blockquote, .admonition) {
+      margin-bottom: 1.5em;
+    }
+    &:is(p:not(:has(img)), ul, ol) {
+      margin-bottom: 1.25em;
+    }
+    &:is(table) {
+      margin-bottom: .75em;
+    }
   }
 }

--- a/assets/css/tabset.css
+++ b/assets/css/tabset.css
@@ -70,3 +70,9 @@
     border-right-width: 0;
   }
 }
+
+@media screen and (min-width: 769px) {
+  .tabset-panel > *:last-child:not(pre) {
+    margin-bottom: 1.25em;
+  }
+}


### PR DESCRIPTION
Increases margin of last element unless it's a `pre` (code box).

Left: before. Right: after.

![image](https://github.com/user-attachments/assets/b5aa87b0-5ad3-4898-9fa7-a81f04d415d5)
