### PR TITLE
Fix code highlighting for languages with non-alphanumeric characters

### DIFF
--- a/lib/ex_doc/doc_ast.ex
+++ b/lib/ex_doc/doc_ast.ex
@@ -165,7 +165,7 @@ defmodule ExDoc.DocAST do
 
     ## Html cannot be parsed with regex, but we try our best...
     Regex.replace(
-      ~r/<pre(\s[^>]*)?><code(?:\s+class="(\w*)")?>([^<]*)<\/code><\/pre>/,
+      ~r/<pre(\s[^>]*)?><code(?:\s+class="([^"]*)")?>([^<]*)<\/code><\/pre>/,
       html,
       &highlight_code_block(&1, &2, &3, &4, highlight_info, opts)
     )

--- a/lib/ex_doc/doc_ast.ex
+++ b/lib/ex_doc/doc_ast.ex
@@ -165,7 +165,7 @@ defmodule ExDoc.DocAST do
 
     ## Html cannot be parsed with regex, but we try our best...
     Regex.replace(
-      ~r/<pre(\s[^>]*)?><code(?:\s+class="([^"]*)")?>([^<]*)<\/code><\/pre>/,
+      ~r/<pre(\s[^>]*)?><code(?:\s+class="([^"\s]*)")?>([^<]*)<\/code><\/pre>/,
       html,
       &highlight_code_block(&1, &2, &3, &4, highlight_info, opts)
     )


### PR DESCRIPTION
Currently `` ```c++ `` is not highlighted, because `+` does not match `\w` in the regex. We could allow list `+`, but I relaxed the regex to pick up any class name.