### PR TITLE
Automatically close the sidebar when navigating sections on mobile

### DIFF
--- a/assets/js/sidebar/sidebar-drawer.js
+++ b/assets/js/sidebar/sidebar-drawer.js
@@ -51,6 +51,8 @@ if (!isEmbedded) {
   // We observe on mousedown because we only care about user resize.
   sidebar.addEventListener('mousedown', () => resizeObserver.observe(sidebar))
   sidebar.addEventListener('mouseup', () => resizeObserver.unobserve(sidebar))
+
+  window.addEventListener('hashchange', maybeCloseSidebarOnNavigate)
 }
 
 function setDefaultSidebarState () {
@@ -113,4 +115,14 @@ function transitionSidebar (open) {
  */
 export function openSidebar () {
   return transitionSidebar(true)
+}
+
+/**
+ * Closes the sidebar on small screens when navigating between sections
+ * on the page, for consistency with full page transitions
+ */
+function maybeCloseSidebarOnNavigate () {
+  if (smallScreenQuery.matches && isSidebarOpen()) {
+    transitionSidebar(false)
+  }
 }


### PR DESCRIPTION
I've been reading quite a few ExDoc sites from my mobile lately and I've found it slightly frustrating that clicking on some headings causes a full page change and the nav is closed, but within a module the sidebar stays open and it's unclear that you've even navigated

An example of the previous behaviour:

https://github.com/user-attachments/assets/b8e0090b-b1eb-4e5d-a101-4dd8bcb5c88a

