### PR TITLE
Document the requirement to push releases

### DIFF
--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -61,10 +61,9 @@ defmodule Mix.Tasks.Docs do
   > #### Tip {: .info}
   >
   > If you set `:source_url` to a GitHub/GitLab/BitBucket repo then whenever you
-  > publish a release you should publish the release to the repo (which will
-  > push a tag). If the release exists in the repo then ex_doc will generate
-  > links to the specific version of the code that the user is currently
-  > browsing.
+  > publish a new version of your package, you should run `git tag vVERSION`
+  > and push the tag. This way, ExDoc will generate links to the specific version
+  > the docs were generated for.
 
   ExDoc also allows configuration specific to the documentation to
   be set. The following options should be put under the `:docs` key

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -58,13 +58,6 @@ defmodule Mix.Tasks.Docs do
         ]
       end
 
-  > #### Tip {: .info}
-  >
-  > If you set `:source_url` to a GitHub/GitLab/BitBucket repo then whenever you
-  > publish a new version of your package, you should run `git tag vVERSION`
-  > and push the tag. This way, ExDoc will generate links to the specific version
-  > the docs were generated for.
-
   ExDoc also allows configuration specific to the documentation to
   be set. The following options should be put under the `:docs` key
   in your project's main configuration. The `:docs` options should
@@ -205,13 +198,13 @@ defmodule Mix.Tasks.Docs do
         * `%{path}`: the path of a file in the repo
         * `%{line}`: the line number in the file
 
-      For GitLab/GitHub:
+      For self-hosted GitLab/GitHub:
 
       ```text
       https://mydomain.org/user_or_team/repo_name/blob/main/%{path}#L%{line}
       ```
 
-      For Bitbucket:
+      For self-hosted Bitbucket:
 
       ```text
       https://mydomain.org/user_or_team/repo_name/src/main/%{path}#cl-%{line}
@@ -220,6 +213,37 @@ defmodule Mix.Tasks.Docs do
       If a function, then it must be a function that takes two arguments, path and line,
       where path is either an relative path from the cwd, or an absolute path. The function
       must return the full URI as it should be placed in the documentation.
+
+  ### Using `:source_url` and `:source_ref` together
+
+  A common setup for a project or library is to set both `:source_url` and `:source_ref`. Setting
+  both of them will allow ExDoc to link to specific version of the code for a function or module
+  that matches the version of the docs. So if the docs have been generated for version 1.0.5 then
+  clicking on the source link in the docs will take the browser to the source code for the 1.0.5
+  version of the code instead of only the primary ref (e.g. `main`).
+
+  A example setup looks like:
+
+      @version "0.30.10"
+      def project do
+        [
+          ...
+          version: @version,
+          docs: docs(),
+          ...
+        ]
+      end
+
+      def docs do
+        ...
+        source_ref: "v#{@version}",
+        source_url: @source_url,
+        ...
+      end
+
+  If you use `source_ref: "v#{@version}"` then when publishing a new version of your package you
+  should run `git tag vVERSION` and push the tag. This way, ExDoc will generate links to the
+  specific version the docs were generated for.
 
   ## Groups
 

--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -58,6 +58,14 @@ defmodule Mix.Tasks.Docs do
         ]
       end
 
+  > #### Tip {: .info}
+  >
+  > If you set `:source_url` to a GitHub/GitLab/BitBucket repo then whenever you
+  > publish a release you should publish the release to the repo (which will
+  > push a tag). If the release exists in the repo then ex_doc will generate
+  > links to the specific version of the code that the user is currently
+  > browsing.
+
   ExDoc also allows configuration specific to the documentation to
   be set. The following options should be put under the `:docs` key
   in your project's main configuration. The `:docs` options should


### PR DESCRIPTION
Currently there isn't any documentation about the requirement to push releases/tags to the `source_url` to get links to specific versions of the code. So this PR adds this documentation.

I couldn't find a general spot where `source_url` is talked about so I added an admonition near where it is first introduced.

Background: recently (in https://github.com/PostHog/posthog-elixir/pull/14#issuecomment-2778825519) I was asked where the requirement for pushing git tags comes from. I wasn't able to find any official documentation (here or in https://hexdocs.pm/elixir/writing-documentation.html) so I have created this PR.

Here's what it looks like when I build the documentation locally:
![Screenshot 2025-04-06 07-48-40@2x](https://github.com/user-attachments/assets/9e27634d-6fb7-49b1-a243-f5e6383ab90b)
