### PR TITLE
Experimental code for a new `@doc copy: true` or `@doc copy: {m, f, a}` feature

### DIFF
--- a/lib/ex_doc/language/elixir.ex
+++ b/lib/ex_doc/language/elixir.ex
@@ -289,7 +289,7 @@ defmodule ExDoc.Language.Elixir do
         {:local, :..}
 
       ["//", "", ""] ->
-        {:local, :..//}
+        {:local, :"..//"}
 
       ["", ""] ->
         {:local, :.}

--- a/test/ex_doc/retriever/elixir_test.exs
+++ b/test/ex_doc/retriever/elixir_test.exs
@@ -282,11 +282,14 @@ defmodule ExDoc.Retriever.ElixirTest do
         defdelegate downcase(str), to: String
 
         defdelegate upcase(str), to: String
+
+        @doc copy: true
+        defdelegate first(str), to: String
       end
       """)
 
       {[mod], []} = Retriever.docs_from_modules([Mod], %ExDoc.Config{})
-      [downcase, upcase] = mod.docs
+      [downcase, first, upcase] = mod.docs
 
       assert downcase.id == "downcase/1"
       assert downcase.signature == "downcase(str)"
@@ -297,6 +300,28 @@ defmodule ExDoc.Retriever.ElixirTest do
       assert upcase.signature == "upcase(str)"
       assert upcase.specs == []
       assert upcase.doc == ExDoc.Markdown.to_ast("See `String.upcase/1`.")
+
+      assert first.id == "first/1"
+      assert first.signature == "first(str)"
+      assert first.specs == []
+
+      assert first.doc ==
+               ExDoc.Markdown.to_ast("""
+               Returns the first grapheme from a UTF-8 string,
+               `nil` if the string is empty.
+
+               ## Examples
+
+                   iex> String.first("elixir")
+                   "e"
+
+                   iex> String.first("եոգլի")
+                   "ե"
+
+                   iex> String.first("")
+                   nil
+
+               """)
     end
 
     test "signatures", c do


### PR DESCRIPTION
# New Feature
This code introduces a new `@doc copy: true` feature for `defdelegate` functions (see the test for some usage, should even work with @doc copy: {m, f, a}``) which would extract the doc from another `{m, f, a}` and copy it to the function with the tag. This is especially interesting for `defdelegate` functions to have proper documentation (instead of the `see ...`) without having to write it twice.
 
***Note:*** This is some experimental code, rather quickly hacked together (happy to clean it up if there is interest in something like this)

# Background
In my library I"m making use of `defdelegate` to define a module is auto-generated and that dispatches functions to a couple of other modules. I do want to have the documentation in a single place, so I neither want to have no documentation nor do I want the  `see ...` referring to the implementing documentation.

I tried to copy the documentation from the other module in the dispatching module by having
```elixir
    @doc Fledex.Color.Names.DocUtils.extract_doc(module, name, 1)
``` 
This works, but not reliably, because (and this is my guess) the files are not yet written when I try to extract the documentation from the modules. So sometimes it works sometimes it doesn't.

I tried to use `mix xref` to see that the `compile` dependencies are correct and with some tricks I did managed to ensure that the dependencies are correct, but still sometimes the retrieving of the docs results in `nil`, i.e. we fall back to the `see ....` documentation.

This made me think that actually it would be much nicer if ex_doc would have the ability to copy the documentation from another function

# Question
Do you think it makes sense to provide such functionality? 
* If, so I'm happy to clean up the code and bring it to prod quality
* If not, then feel free to simply close this PR :-)