### PR TITLE
New Feature: Copy documentation (Continuation of PR #2115)

### DIFF
--- a/lib/ex_doc/config.ex
+++ b/lib/ex_doc/config.ex
@@ -8,6 +8,9 @@ defmodule ExDoc.Config do
   def before_closing_head_tag(_), do: ""
   def before_closing_footer_tag(_), do: ""
   def before_closing_body_tag(_), do: ""
+  def copy_doc_decorator(doc, {m, f, a}) do
+    doc <> "\n\nNote: documentation was copied from: `#{m}#{f}/#{a}`"
+  end
   def annotations_for_docs(_), do: []
   def skip_undefined_reference_warnings_on(_string), do: false
   def skip_code_autolink_to(_string), do: false
@@ -22,6 +25,7 @@ defmodule ExDoc.Config do
             before_closing_footer_tag: &__MODULE__.before_closing_footer_tag/1,
             before_closing_head_tag: &__MODULE__.before_closing_head_tag/1,
             canonical: nil,
+            copy_doc_decorator: &__MODULE__.copy_doc_decorator/2,
             cover: nil,
             deps: [],
             docs_groups: [],
@@ -66,6 +70,7 @@ defmodule ExDoc.Config do
           before_closing_footer_tag: (atom() -> String.t()) | mfa() | map(),
           before_closing_head_tag: (atom() -> String.t()) | mfa() | map(),
           canonical: nil | String.t(),
+          copy_doc_decorator: (String.t, {String.t, String.t, non_neg_integer} -> String.t),
           cover: nil | Path.t(),
           deps: [{ebin_path :: String.t(), doc_url :: String.t()}],
           docs_groups: [String.t()],

--- a/lib/ex_doc/copy_doc_utils.ex
+++ b/lib/ex_doc/copy_doc_utils.ex
@@ -1,0 +1,174 @@
+defmodule ExDoc.CopyDocUtils do
+  alias ExDoc.DocAST
+
+  def copy_doc_info(metadata, {doc_file, doc_line} = _dbg_info \\ {__ENV__.file, __ENV__.line}) do
+    delegate_to = metadata[:delegate_to]
+
+    case metadata[:copy] do
+      copy when is_boolean(copy) and copy == true ->
+        if delegate_to == nil do
+          ExDoc.Utils.warn("no `delegate_to` specified",
+            file: doc_file,
+            line: doc_line
+          )
+          nil
+        else
+          delegate_to
+        end
+      {_m, _f, _a} = copy -> copy
+      _ -> nil
+    end
+  end
+
+  def extract_doc({m, f, a}, config) do
+    case get_docs(m, [:function]) do
+      {nil, nil, nil} ->
+        nil
+
+      {_language, format, docs} ->
+        case extract_function_doc(docs, f, a) do
+          nil ->
+            nil
+
+          :none ->
+            nil
+
+          %{"en" => doc} ->
+            module = remove_leading_elixir(m)
+            function = Atom.to_string(f)
+
+            # IO.puts("doc: " <> inspect doc)
+            rewrite_doc(doc, {m, f, a})
+            |> config.copy_doc_decorator.({module, function, a})
+            |> DocAST.parse!(format, [])
+        end
+    end
+  end
+
+  @doc """
+  Extract docs from a module, filtered by the kinds (list of :function, :type, ...)
+  """
+  # TODO: see whether we can merge this with Retriever.get_docs, because they are similar
+  def get_docs(module, kinds) do
+    case Code.fetch_docs(module) do
+      {:docs_v1, _number, language, format, _module_doc, _donno, docs} ->
+        docs =
+          for {{kind, _name, _arity}, _info, _type, _txt, _donno} = doc <- docs,
+              kind in kinds,
+              do: doc
+
+        {language, format, docs}
+
+      {:error, _msg} ->
+        {nil, nil, nil}
+    end
+  end
+
+  def extract_function_doc(docs, function, arity) do
+    case Enum.find(docs, nil, fn {{_type, func_name, func_arity}, _info, _types, _doc, _opts} ->
+           func_name === function && func_arity === arity
+         end) do
+      nil ->
+        nil
+
+      {_def, _info, _types, doc, _opts} ->
+        doc
+    end
+  end
+
+  def rewrite_doc(doc, mfa) do
+    # we don't need to rewrite code blocks
+    Regex.replace(
+      ~r/[`]([^`]+)[`]/,
+      doc,
+      fn _full, ref ->
+        "`#{rewrite_ref(ref, mfa)}`"
+      end,
+      global: true
+    )
+  end
+
+  def rewrite_ref(ref, {module, _function, _arity}) do
+    parts =
+      Regex.named_captures(
+        ~r/(?<type>[ct]:){0,1}(?:Elixir\.)?(?<module>(?:[^.]*[.])*)?(?<func>.*)\/(?<arity>\d+)/,
+        ref
+      )
+
+    if parts != nil do
+      parts
+      |> cleanup()
+      |> build_new_ref(module)
+    else
+      ref
+    end
+  end
+
+  defp cleanup(%{"type" => type, "module" => module, "func" => func, "arity" => arity}) do
+    %{
+      type: type,
+      module: String.trim(module) |> String.replace_trailing("\.", ""),
+      func: func,
+      arity: Integer.parse(arity) |> elem(0)
+    }
+  end
+
+  @spec build_new_ref(%{
+    type: String.t(),
+    module: String.t(),
+    func: String.t(),
+    arity: non_neg_integer()
+    }, module()) :: String.t()
+  def build_new_ref(%{
+      type: ref_type,
+      module: ref_module,
+      func: ref_func,
+      arity: ref_arity
+      }, module) do
+    empty_ref_module =  String.length(ref_module) == 0
+    # is_ref_module_func = is_module_ref?(source_module, ref_func, ref_arity)
+    is_module_func = is_module_ref?(module, ref_func, ref_arity)
+
+    ref_module =
+        # NOTE: we could stop the rewriting of a ref IF the function exists
+        #       in the calling module. However that function might not be
+        #       a delegated function and therefore would be wrong. We play it safe
+        #       and ALWAYS add the module name to which we delegate.
+        case {empty_ref_module, is_module_func} do
+        {true, true} -> remove_leading_elixir(module)
+        _ -> if String.length(ref_module) > 0, do: ref_module <> ".", else: ""
+      end
+
+    "#{ref_type}#{ref_module}#{ref_func}/#{ref_arity}"
+  end
+
+  def is_module_ref?(module, func, arity) do
+    func = String.to_atom(func)
+
+    function_exported?(module, func, arity) or
+      callback_func?(module, func, arity) or
+      type_func(module, func, arity)
+  end
+
+  defp type_func(module, func, arity) do
+    {_lang, _format, funcs} = get_docs(module, [:type])
+
+    Enum.filter(funcs, fn {{this_type, this_func, this_arity}, _, _, _, _} ->
+      {this_type, this_func, this_arity} == {:type, func, arity}
+    end)
+    |> length() > 0
+  end
+
+  defp callback_func?(module, func, arity) do
+    if function_exported?(module, :behaviour_info, 1) do
+      callbacks = module.behaviour_info(:callbacks)
+      {func, arity} in callbacks
+    else
+      false
+    end
+  end
+
+  def remove_leading_elixir(module) do
+    String.replace_leading(Atom.to_string(module), "Elixir.", "") <> "."
+  end
+end

--- a/lib/ex_doc/language/elixir.ex
+++ b/lib/ex_doc/language/elixir.ex
@@ -289,7 +289,7 @@ defmodule ExDoc.Language.Elixir do
         {:local, :..}
 
       ["//", "", ""] ->
-        {:local, :..//}
+        {:local, :"..//"}
 
       ["", ""] ->
         {:local, :.}

--- a/lib/ex_doc/retriever.ex
+++ b/lib/ex_doc/retriever.ex
@@ -181,13 +181,19 @@ defmodule ExDoc.Retriever do
   def extract_doc(module, function, arity) do
     case get_docs(module, [:function]) do
       {nil, nil, nil} ->
-        IO.puts("extract_doc failed" <> inspect({module, function, arity}))
+        # IO.puts("extract_doc failed" <> inspect({module, function, arity}))
         nil
 
       {_language, format, docs} ->
-        doc = extract_function_doc(docs, function, arity)
-        doc_ast(format, doc, [])
-    end
+        case extract_function_doc(docs, function, arity) do
+          nil ->
+            # IO.puts("doc: No doc found")
+            nil
+          doc ->
+            # IO.puts("doc: " <> inspect doc)
+            doc_ast(format, doc, [])
+        end
+      end
   end
 
   def extract_function_doc(docs, function, arity) do
@@ -216,7 +222,7 @@ defmodule ExDoc.Retriever do
 
         {language, format, docs}
 
-      {:error, _msg} ->
+      {:error, msg} ->
         # IO.puts("error: " <> inspect {msg, module})
         {nil, nil, nil}
     end

--- a/test/ex_doc/copy_doc_utils_test.exs
+++ b/test/ex_doc/copy_doc_utils_test.exs
@@ -1,0 +1,164 @@
+defmodule ExDoc.CopyDocUtilsTest do
+  use ExUnit.Case, async: true
+
+  alias ExDoc.Config
+  alias ExDoc.CopyDocUtils
+
+  import ExUnit.CaptureIO
+  import TestHelper
+
+  @moduletag :tmp_dir
+
+  test "copy_doc_info" do
+    assert {CopyDocUtilsTest, :func, 2} == CopyDocUtils.copy_doc_info(%{delegate_to: {CopyDocUtilsTest, :func, 2}, copy: true})
+    assert nil == CopyDocUtils.copy_doc_info(%{delegate_to: {CopyDocUtilsTest, :func, 2}, copy: false})
+    assert {CopyDocUtilsTest, :func, 2} == CopyDocUtils.copy_doc_info(%{copy: {CopyDocUtilsTest, :func, 2}})
+    assert capture_io(:stderr, fn -> assert nil == CopyDocUtils.copy_doc_info(%{copy: true}) end) =~ "no `delegate_to` specified"
+  end
+
+  @project "Elixir"
+  @version "1"
+  test "extract_doc",c  do
+    elixirc(c, ~S"""
+      defmodule Orig do
+        @doc "Some doc `local_link1/1`"
+        def local_link1(_str) do
+          :ok
+        end
+      end
+      defmodule Orig2 do
+        def local_link1(_str) do
+          :ok
+        end
+      end
+      """)
+    new_doc = CopyDocUtils.extract_doc(
+      {Orig, :local_link1, 1},
+      Config.build(@project, @version, copy_doc_decorator: fn doc, {m, f, a} ->
+        assert m == "Orig."
+        assert f == "local_link1"
+        assert a == 1
+        doc
+      end))
+
+      assert new_doc == ExDoc.Markdown.to_ast("Some doc `Orig.local_link1/1`")
+
+    config =Config.build(@project, @version, copy_doc_decorator: fn doc, {_m, _f, _a} -> doc end)
+    assert CopyDocUtils.extract_doc({Orig2, :local_link1, 1}, config) == nil
+    assert CopyDocUtils.extract_doc({Orig2, :local_link2, 1}, config) == nil
+    assert CopyDocUtils.extract_doc({NonExisting, :local_link2, 1}, config) == nil
+  end
+
+  test "rewrite_doc", c do
+    elixirc(c, ~S"""
+      defmodule Orig do
+      def local_link1(_str) do
+        :ok
+      end
+    end
+    """)
+
+    mfa = {Orig, :local_link1, 1}
+    doc = "The `local_link1/1` gets rewritten"
+    assert CopyDocUtils.rewrite_doc(doc, mfa) == "The `Orig.local_link1/1` gets rewritten"
+  end
+
+  test "rewrite_ref", c do
+    elixirc(c, ~S"""
+      defmodule Orig do
+      def local_link1(_str) do
+        :ok
+      end
+    end
+    """)
+
+    mfa = {Orig, :local_link1, 1}
+    assert CopyDocUtils.rewrite_ref("local_link1/1", mfa) == "Orig.local_link1/1"
+  end
+
+  test "build_new_ref", c do
+    # This test is a cut down version of the copy_doc_test app
+    elixirc(c, ~S"""
+    defmodule Imported do
+      def imported_link(_str), do: :ok
+    end
+    defmodule Orig do
+      import Imported
+      defmodule Orig2 do
+      end
+      @type special_values :: :none | :all | :some
+      @callback callback_link1(String.t()) :: :ok
+      @spec local_link1(String.t()) :: :ok
+      def local_link1(_str) do
+        :ok
+      end
+      @spec local_link2(String.t()) :: :ok
+      def local_link2(some_string)
+      def local_link2(str) do
+        imported_link(str)
+      end
+      def local_link3(_str) do
+        :ok
+      end
+      def local_link5(_str) do
+        :ok
+      end
+    end
+    """)
+    mfa = {Orig, :local_link1, 1}
+    # code requiring rewrite
+    # * `local_link2/1` (should become `Orig.local_link2/1`)
+    # * `c:callback_link1/1` (callback should become `c:Orig.callback_link1/1`)
+    # * `local_link3/1` (local function in Orig, but not in Delegate, should become `Orig.local_link3/1`)
+    # * `t:special_values/0` (typespec should become `t:Orig.special_values/0`)
+    assert CopyDocUtils.rewrite_ref("local_link2/1", mfa) == "Orig.local_link2/1"
+    assert CopyDocUtils.rewrite_ref("c:callback_link1/1", mfa) == "c:Orig.callback_link1/1"
+    assert CopyDocUtils.rewrite_ref("local_link3/1", mfa) == "Orig.local_link3/1"
+    assert CopyDocUtils.rewrite_ref("t:special_values/0", mfa) == "t:Orig.special_values/0"
+
+    # code not requiring rewrite
+    # * `:local_link1` (just an atom, not even a link)
+    # * `local_link4/1` (local function in Delegate, but not in Orig)
+    # * `Orig.local_link2(_str)` (just some code, not even a link)
+    # * `Kernel.and/2` (function in other modules)
+    # * `and/2` (Kernel modules with the implicit module name)
+    # * `imported_link/1` (an imported function, but it requires a full qualifier, not even a link)
+    # * `Imported.imported_link/1` (now with full qualifier it beomes a link, but no need to rewrite)
+    # * `m:Orig2` (not fully qualified, not even a link)
+    # * `m:Orig.Orig2` (now fully qualified and should be a link, but does not need rewriting)
+    assert CopyDocUtils.rewrite_ref(":local_link1", mfa) == ":local_link1"
+    assert CopyDocUtils.rewrite_ref("local_link4/1", mfa) == "local_link4/1"
+    assert CopyDocUtils.rewrite_ref("Orig.local_link2(_str)", mfa) == "Orig.local_link2(_str)"
+    assert CopyDocUtils.rewrite_ref("Kernel.and/2", mfa) == "Kernel.and/2"
+    assert CopyDocUtils.rewrite_ref("and/2", mfa) == "and/2"
+    assert CopyDocUtils.rewrite_ref("imported_link/1", mfa) == "imported_link/1"
+    assert CopyDocUtils.rewrite_ref("Imported.imported_link/1", mfa) == "Imported.imported_link/1"
+    assert CopyDocUtils.rewrite_ref("m:Orig2", mfa) == "m:Orig2"
+    assert CopyDocUtils.rewrite_ref("m:Orig.Orig2", mfa) == "m:Orig.Orig2"
+  end
+
+  test "is_module_ref?", c do
+    elixirc(c, ~S"""
+      defmodule TestModule do
+        @callback callback_func() :: :ok
+        @type type_func :: :ok
+        def normal_func() do
+          private_func()
+          :ok
+        end
+        defp private_func(), do: :ok
+      end
+    """)
+
+    assert CopyDocUtils.is_module_ref?(TestModule, "normal_func", 0) == true
+    assert CopyDocUtils.is_module_ref?(TestModule, "private_func", 0) == false
+    assert CopyDocUtils.is_module_ref?(TestModule, "callback_func", 0) == true
+    assert CopyDocUtils.is_module_ref?(TestModule, "callback_func2", 0) == false
+    assert CopyDocUtils.is_module_ref?(TestModule, "type_func", 0) == true
+  end
+
+  test "remove_leading_elixir" do
+    assert Atom.to_string(__MODULE__) == "Elixir.ExDoc.CopyDocUtilsTest"
+    assert CopyDocUtils.remove_leading_elixir(__MODULE__) == "ExDoc.CopyDocUtilsTest."
+  end
+end

--- a/test/ex_doc/retriever/elixir_test.exs
+++ b/test/ex_doc/retriever/elixir_test.exs
@@ -282,11 +282,14 @@ defmodule ExDoc.Retriever.ElixirTest do
         defdelegate downcase(str), to: String
 
         defdelegate upcase(str), to: String
+
+        @doc copy: true
+        defdelegate first(str), to: String
       end
       """)
 
       {[mod], []} = Retriever.docs_from_modules([Mod], %ExDoc.Config{})
-      [downcase, upcase] = mod.docs
+      [downcase, first, upcase] = mod.docs
 
       assert downcase.id == "downcase/1"
       assert downcase.signature == "downcase(str)"
@@ -297,6 +300,28 @@ defmodule ExDoc.Retriever.ElixirTest do
       assert upcase.signature == "upcase(str)"
       assert upcase.specs == []
       assert upcase.doc == ExDoc.Markdown.to_ast("See `String.upcase/1`.")
+
+      assert first.id == "first/1"
+      assert first.signature == "first(str)"
+      assert first.specs == []
+
+      assert first.doc ==
+               ExDoc.Markdown.to_ast("""
+               Returns the first grapheme from a UTF-8 string,
+               `nil` if the string is empty.
+
+               ## Examples
+
+                   iex> String.first("elixir")
+                   "e"
+
+                   iex> String.first("եոգլի")
+                   "ե"
+
+                   iex> String.first("")
+                   nil
+
+               """)
     end
 
     test "signatures", c do

--- a/test/ex_doc/retriever/elixir_test.exs
+++ b/test/ex_doc/retriever/elixir_test.exs
@@ -321,6 +321,9 @@ defmodule ExDoc.Retriever.ElixirTest do
                    iex> String.first("")
                    nil
 
+
+
+               Note: documentation was copied from: `String.first/1`
                """)
     end
 


### PR DESCRIPTION
This is a continuation of the PR #2115 that can copy the documentation from another module/function and it rewrites the documentation so that the links are updated correctly

I have created a [small test application](https://github.com/a-maze-d/copy_doc_test) to cover as many cases as possible for the rewriting of the documentation. Those cases made it then also into the unit tests, but it's potentially easier to see how the output looks

One thing that is not done is to add documentation (because I'm not sure where the best place would be). I'm happy to add this in another commit. but here are the highlights:

* add `@doc copy: true` to copy the documentation of a `defdelegate` to copy it's documentation
* add `@doc copy: {m, f, a}` to copy the documentation as specified by `{m, f, a}
* You can specify a new config parameter `:copy_doc_decorator` to decorate the documentation to your liking to indicate that the documentation was copied. The [default](https://github.com/a-maze-d/ex_doc/blob/copy_doc/lib/ex_doc/config.ex#L11) will add at the end: "Note: documentation was copied from: `#{m}#{f}/#{a}`" If you provide your own decorator, then you have to provide a function that returns an updated `doc` (`String`). The function gets called with 2 arguments:

  * `doc` (`String`): the documentation with rewritten code snippets, so links point the correct direction
  * `{m, f, a}` (`Tuple`): This provides information from where the documentation was copied from
 
Note:
I have tested as many cases that I could think of, the code I added received unit tests (100% code coverage). I'm happy to fix anything I might have missed.