### PR TITLE
Fix strip_app to always rewrap in a list

### DIFF
--- a/lib/ex_doc/language/erlang.ex
+++ b/lib/ex_doc/language/erlang.ex
@@ -418,15 +418,15 @@ defmodule ExDoc.Language.Erlang do
   end
 
   defp strip_app([{:code, attrs, [code], meta}], app) do
-    [{:code, attrs, strip_app(code, app), meta}]
+    [{:code, attrs, List.wrap(strip_app(code, app)), meta}]
   end
 
   defp strip_app(code, app) when is_binary(code) do
-    String.trim_leading(code, "//#{app}/")
+    List.wrap(String.trim_leading(code, "//#{app}/"))
   end
 
   defp strip_app(other, _app) do
-    other
+    List.wrap(other)
   end
 
   defp warn_ref(href, config) do


### PR DESCRIPTION
The crash I described in #2122 was not because of edoc producing docs without a list wrapper, but because the Erlang layer in ExDoc did so. My initial suggestion just happened to work as it also fixed this issue, but the final fix of normalizting edoc input did not as it happened to early.

This PR fixes the issue though I could not manage to create a testcase that replicates it.