### PR TITLE
Set minimum elixir on the `README.md` to 1.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can use ExDoc with Mix (recommended for Elixir projects), with Rebar (recomm
 
 ### Mix
 
-ExDoc requires Elixir v1.12 or later. Then add ExDoc as a dependency:
+ExDoc requires Elixir v1.15 or later. Then add ExDoc as a dependency:
 
 ```elixir
 def deps do


### PR DESCRIPTION
This PR sets the minimum version of elixir on the `README.md` to match with what is inside the `project/0`
![image](https://github.com/user-attachments/assets/ab173ae4-3579-44cf-b02a-aeab1d5e86cd)
