### PR TITLE
Load discovered makeup apps for cli

### DIFF
--- a/lib/ex_doc/cli.ex
+++ b/lib/ex_doc/cli.ex
@@ -76,6 +76,13 @@ defmodule ExDoc.CLI do
     for path <- Keyword.get_values(opts, :paths),
         path <- Path.wildcard(path) do
       Code.prepend_path(path)
+      app(path) |> Application.load()
+    end
+
+    # Start all applications with the makeup prefix
+    for {app, _, _} <- Application.loaded_applications(),
+        match?("makeup_" <> _, Atom.to_string(app)) do
+      Application.ensure_all_started(app)
     end
 
     opts =


### PR DESCRIPTION
The `ex_doc` cli will not load apps from the provided `--paths` argument when `ExDoc.Application` start. When prepend the `paths`, the `.app` should be loaded so that the `makeup_` applications can be started before generating.

This scenario occurs when using `rebar3_ex_doc`, which use the cli underlying.