### PR TITLE
Make sidebar subheadings bold for improved visibility

### DIFF
--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -157,6 +157,7 @@
   font-size: var(--text-sm);
   color: var(--sidebarSubheadings);
   white-space: nowrap;
+  font-weight: bold;
 }
 
 .sidebar .sidebar-list-nav li {


### PR DESCRIPTION
before
<img width="280" height="156" alt="image" src="https://github.com/user-attachments/assets/be2c8b26-20e2-4e4a-b122-0e7b4f2b92cd" />

after
<img width="280" height="156" alt="image" src="https://github.com/user-attachments/assets/47db8830-2212-491e-83db-3450ab2625a1" />
