### PR TITLE
Prevent fake italic in autocompletion results text

### DIFF
--- a/assets/css/autocomplete.css
+++ b/assets/css/autocomplete.css
@@ -27,7 +27,6 @@
   justify-content: space-between;
   gap: 8px;
   color: var(--autocompleteResults);
-  font-family: var(--sansFontFamily);
   font-weight: 300;
   font-size: 0.9rem;
   font-style: italic;


### PR DESCRIPTION
The Lato font, used at the front of the `sansFontFamily` stack, does not currently have its italic style loaded, resulting in artificially skewed/fake italic characters.

<img width="1012" height="438" alt="image" src="https://github.com/user-attachments/assets/53814713-8292-4ec4-b6e6-d3508c61c9a9" />

Rather than add the italic style just for this "autocompletion results" text, we can drop back to the stack starting with system-ui font, as per the search results list below, making it likely that true italic will be used. Example with my browser set to use Inter:

<img width="1021" height="430" alt="image" src="https://github.com/user-attachments/assets/103e0da2-362b-4556-89a5-e995965d98b1" />

