### PR TITLE
Default to README for main page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ end
 
 defp docs do
   [
-    main: "MyApp", # The main page in the docs
+    main: "readme", # can be changed to a module name, if you prefer
     logo: "path/to/logo.png",
     extras: ["README.md"]
   ]


### PR DESCRIPTION
In many projects, I find that important documentation is included in the README in the git repo, but the default in hexdocs is the module name, which is often quite sparse comparatively.

This PR changes the default example to use the README as the main page, which I think will be the most useful starting point for most projects. The comment explains that it can be set to a module name instead, if desired.