### PR TITLE
Prevent recent heading size changes from applying to docstring headings

### DIFF
--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -81,14 +81,15 @@ which we style as h2 and h3. */
   }
 
   & h2,
-  & :is(#summary, #callbacks, #functions) h1 {
+  & :is(#summary, #callbacks, #functions) > h1.section-heading {
     font-size: 1.75rem;
     margin-top: 1.5em;
     margin-bottom: 0.5em;
   }
 
   & h3,
-  & :is(#summary, #callbacks, #functions) h2 {
+  & :is(#summary, #callbacks, #functions) > h2.section-heading,
+  & #summary :is(.summary-callbacks, .summary-functions) h2 {
     font-size: 1.45rem;
     margin-top: 1.5em;
     margin-bottom: 0.5em;


### PR DESCRIPTION
Reverts docstring h2 and h3 headings to 0.39.1 sizes.

---

**0.39.1:**

<img width="1120" height="1198" alt="Image" src="https://github.com/user-attachments/assets/10d93cad-fb25-45e9-8b10-6695f1e4b5fb" />

---

**0.39.3:**

<img width="1117" height="1224" alt="Image" src="https://github.com/user-attachments/assets/0900c75b-f413-41c0-ae0f-63d41429d2dd" />

---