### PR TITLE
epub: void elements, such `wbr`, must be terminated by the matching end-tag

### DIFF
--- a/lib/ex_doc/formatter/html/templates.ex
+++ b/lib/ex_doc/formatter/html/templates.ex
@@ -15,10 +15,10 @@ defmodule ExDoc.Formatter.HTML.Templates do
   end
 
   @doc """
-  Returns the title with `<wbr>` after each fullstop, allowing word breaks in long module names.
+  Returns the title with `<wbr />` after each fullstop, allowing word breaks in long module names.
   """
   def breakable_module_title(title) when is_binary(title) do
-    String.replace(title, ".", ".<wbr>")
+    String.replace(title, ".", ".<wbr />")
   end
 
   @doc """

--- a/test/ex_doc/formatter/epub/templates_test.exs
+++ b/test/ex_doc/formatter/epub/templates_test.exs
@@ -116,7 +116,7 @@ defmodule ExDoc.Formatter.EPUB.TemplatesTest do
       content = Templates.module_template(formatter_config(), module_node)
 
       assert content =~ ~r{<title>XPTO.NestedModule [^<]*</title>}
-      assert content =~ ~r{<h1 id="content">\s*XPTO.<wbr>NestedModule\s*}
+      assert content =~ ~r{<h1 id="content">\s*XPTO.<wbr />NestedModule\s*}
     end
 
     test "outputs the functions and docstrings" do

--- a/test/ex_doc/formatter/html/templates_test.exs
+++ b/test/ex_doc/formatter/html/templates_test.exs
@@ -525,7 +525,7 @@ defmodule ExDoc.Formatter.HTML.TemplatesTest do
     test "add word breaks to title", context do
       content = get_module_template([CompiledWithDocs.Nested], context)
 
-      assert content =~ "CompiledWithDocs.<wbr>Nested"
+      assert content =~ "CompiledWithDocs.<wbr />Nested"
     end
 
     test "do not output overlapping functions, causing duplicate IDs", context do

--- a/test/ex_doc/formatter/html_test.exs
+++ b/test/ex_doc/formatter/html_test.exs
@@ -117,7 +117,7 @@ defmodule ExDoc.Formatter.HTMLTest do
     assert content =~ ~r{<p>moduledoc</p>}
 
     assert content =~
-             ~r{<a href="CompiledWithDocs.Nested.html" translate="no">CompiledWithDocs.<wbr>Nested</a>}
+             ~r{<a href="CompiledWithDocs.Nested.html" translate="no">CompiledWithDocs.<wbr />Nested</a>}
 
     assert content =~
              ~r{<a href="Mix.Tasks.TaskWithDocs.html" translate="no">mix task_with_docs</a>}


### PR DESCRIPTION
Otherwise, it will produce an error while parsing the XHTML file in some EPUB readers.