### PR TITLE
epub: fix links to extra documents

### DIFF
--- a/lib/ex_doc/formatter/epub/templates/content_template.eex
+++ b/lib/ex_doc/formatter/epub/templates/content_template.eex
@@ -17,7 +17,7 @@
   <manifest>
     <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav scripted"/>
     <item id="cover" href="title.xhtml" media-type="application/xhtml+xml" properties="scripted"/>
-    <%= for {_title, extras} <- extras, extra <- extras do %>
+    <%= for extra <- extras do %>
       <item id="<%= URI.encode extra.id %>" href="<%= URI.encode extra.id %>.xhtml" media-type="application/xhtml+xml" properties="scripted"/>
     <% end %>
     <%= for node <- modules ++ tasks do %>
@@ -36,7 +36,7 @@
   <spine>
     <itemref idref="cover"/>
     <itemref idref="nav"/>
-    <%= for {_title, extras} <- extras, extra <- extras do %>
+    <%= for extra <- extras do %>
       <itemref idref="<%= URI.encode extra.id %>"/>
     <% end %>
     <%= for node <- modules ++ tasks do %>

--- a/test/ex_doc/formatter/epub/templates_test.exs
+++ b/test/ex_doc/formatter/epub/templates_test.exs
@@ -88,6 +88,24 @@ defmodule ExDoc.Formatter.EPUB.TemplatesTest do
 
       assert content =~ ~S|<itemref idref="XPTOModule"/>|
     end
+
+    test "includes extras as resource" do
+      node =
+        %ExDoc.ExtraNode{
+          id: "changelog",
+          title: "Changelog",
+          doc: nil,
+          type: :extra
+        }
+
+      content =
+        Templates.content_template(formatter_config(), [], [], [node], "uuid", "datetime", [])
+
+      assert content =~
+               ~S|<item id="changelog" href="changelog.xhtml" media-type="application/xhtml+xml" properties="scripted"/>|
+
+      assert content =~ ~S|<itemref idref="changelog"/>|
+    end
   end
 
   describe "module_template/2" do


### PR DESCRIPTION
`ex_doc` was silently failing to link extra documents in the _package document_, which describes the rendering of an EPUB publication.

The consequence of this is that links from a module (e.g., `Application.xhtml`) to the extra guides (e.g., Design-related anti-patterns) were broken.

I added a unit test to prevent a future regression.