### PR TITLE
Auto link extras: fail on bad path

### DIFF
--- a/lib/ex_doc.ex
+++ b/lib/ex_doc.ex
@@ -249,6 +249,10 @@ defmodule ExDoc do
     * `:title` - The title of the extra page. If not provided, the title will be inferred from the extra name.
     * `:url` - The external url to link to from the sidebar.
 
+  Bare filenames such as `[Intro](intro.md)` use the legacy filename-based lookup against the flattened output.
+  Links with a directory component, such as `[Intro](guides/intro.md)`, `[Intro](../guides/intro.md)`, or
+  `[Intro](/guides/intro.md)`, are resolved against the extra source path (or project root for `/`).
+
   ### Customizing search data
 
   It is possible to fully customize the way a given extra is indexed, both in autocomplete and in search.

--- a/lib/ex_doc/autolink.ex
+++ b/lib/ex_doc/autolink.ex
@@ -52,7 +52,7 @@ defmodule ExDoc.Autolink do
     :language,
     file: "nofile",
     apps: [],
-    extras: [],
+    extras: %{},
     deps: [],
     ext: ".html",
     current_kfa: nil,
@@ -217,7 +217,7 @@ defmodule ExDoc.Autolink do
     with %{scheme: nil, host: nil, path: path} = uri <- URI.parse(link),
          true <- is_binary(path) and path != "" and not (path =~ ref_regex()),
          true <- Path.extname(path) in @builtin_ext do
-      if file = config.extras[Path.basename(path)] do
+      if file = resolve_extra_target(path, config) do
         append_fragment(file <> config.ext, uri.fragment)
       else
         maybe_warn(config, nil, nil, %{file_path: path, original_text: link})
@@ -225,6 +225,26 @@ defmodule ExDoc.Autolink do
       end
     else
       _ -> nil
+    end
+  end
+
+  defp resolve_extra_target(path, config) do
+    filename = Path.basename(path)
+
+    case path do
+      "/" <> absolute_path ->
+        config.extras[absolute_path]
+
+      ^filename ->
+        config.extras[filename]
+
+      relative_path ->
+        path =
+          relative_path
+          |> Path.expand(Path.dirname(config.file))
+          |> Path.relative_to_cwd()
+
+        config.extras[path]
     end
   end
 

--- a/lib/ex_doc/formatter.ex
+++ b/lib/ex_doc/formatter.ex
@@ -314,7 +314,10 @@ defmodule ExDoc.Formatter do
 
       %ExDoc.ExtraNode{source_path: source_path, id: id}, acc when is_binary(source_path) ->
         base = Path.basename(source_path)
-        Map.put(acc, base, id)
+
+        acc
+        |> Map.put(source_path, id)
+        |> Map.put(base, id)
 
       _extra, acc ->
         acc

--- a/test/ex_doc/language/elixir_test.exs
+++ b/test/ex_doc/language/elixir_test.exs
@@ -259,7 +259,9 @@ defmodule ExDoc.Language.ElixirTest do
 
     test "extras" do
       opts = [
+        file: "guides/current.md",
         extras: %{
+          "guide/Foo Bar.md" => "foo-bar",
           "Foo Bar.md" => "foo-bar",
           "Bar Baz.livemd" => "bar-baz",
           "Bar Baz.cheatmd" => "bar-baz"
@@ -284,6 +286,45 @@ defmodule ExDoc.Language.ElixirTest do
                ~s|<a href="http://example.com/foo.md">Foo</a>|
 
       assert autolink_doc("[Foo](#baz)", opts) == ~s|<a href="#baz">Foo</a>|
+    end
+
+    test "path-qualified extra links use the extra source path" do
+      opts = [
+        file: "guides/current.md",
+        extras: %{"guides/Foo Bar.md" => "foo-bar", "Foo Bar.md" => "legacy-foo"}
+      ]
+
+      assert autolink_doc("[Foo](./Foo Bar.md)", opts) ==
+               ~s|<a href="foo-bar.html">Foo</a>|
+
+      assert autolink_doc("[Foo](../guides/Foo Bar.md)", opts) ==
+               ~s|<a href="foo-bar.html">Foo</a>|
+
+      assert autolink_doc("[Foo](/guides/Foo Bar.md)", opts) ==
+               ~s|<a href="foo-bar.html">Foo</a>|
+    end
+
+    test "bare filename extra links use legacy lookup" do
+      opts = [
+        file: "guides/current.md",
+        extras: %{"guides/Foo Bar.md" => "relative-foo", "Foo Bar.md" => "legacy-foo"}
+      ]
+
+      assert autolink_doc("[Foo](Foo Bar.md)", opts) ==
+               ~s|<a href="legacy-foo.html">Foo</a>|
+    end
+
+    test "extras with bad directories warn instead of silently matching by basename" do
+      opts = [
+        warnings: :send,
+        file: "guides/current.md",
+        extras: %{"guide/Foo Bar.md" => "foo-bar", "Foo Bar.md" => "foo-bar"}
+      ]
+
+      assert warn(fn ->
+               assert autolink_doc("[Foo](/bad_dir/Foo Bar.md)", opts) ==
+                        ~s|<a href="/bad_dir/Foo Bar.md">Foo</a>|
+             end) =~ ~s|documentation references file "/bad_dir/Foo Bar.md" but it does not exist|
     end
 
     test "special case links" do

--- a/test/ex_doc/language/erlang_test.exs
+++ b/test/ex_doc/language/erlang_test.exs
@@ -669,6 +669,16 @@ defmodule ExDoc.Language.ErlangTest do
       extras: %{"Foo Bar.md" => "foo-bar", "Bar Baz.livemd" => "bar-baz"}
     ]
 
+    @relative_opts [
+      file: "guides/current.md",
+      extras: %{
+        "guide/Foo Bar.md" => "foo-bar",
+        "guide/Bar Baz.livemd" => "bar-baz",
+        "Foo Bar.md" => "foo-bar",
+        "Bar Baz.livemd" => "bar-baz"
+      }
+    ]
+
     test "extras", c do
       assert autolink_doc("[Foo](Foo Bar.md)", c, @opts) ==
                ~s|<a href="foo-bar.html">Foo</a>|
@@ -690,7 +700,7 @@ defmodule ExDoc.Language.ErlangTest do
     end
 
     test "extras relative", c do
-      assert autolink_doc("[Foo](../guide/Foo Bar.md)", c, @opts) ==
+      assert autolink_doc("[Foo](../guide/Foo Bar.md)", c, @relative_opts) ==
                ~s|<a href="foo-bar.html">Foo</a>|
     end
   end


### PR DESCRIPTION
Verify paths in links to `:extras` pages when the link includes a directory component.
Doesn't affect bare filename links such as `test.md`.

## Before
Before this change, ExDoc effectively matched extra links by `Path.basename(path)`, so a link like `[Guide](guides/bad_dir/guide.md)` could still resolve if there was any extra named `guide.md` in the flattened output namespace.

## After
After this change, ExDoc keeps bare filename links as the legacy flattened lookup, but treats links with a directory component as path-qualified and resolves them through the extra source tree instead.

## Design Decision
The main design question in this PR is how to interpret links to extras depending on the shape of the markdown path.

| Link form | Example | Lookup base before | Lookup base after |
| --- | --- | --- | --- |
| Bare filename | `[Intro](intro.md)` | Flattened output filename | Flattened output filename |
| Implicit path | `[Intro](guides/intro.md)` | Flattened output filename | Current extra source file directory |
| Explicit relative path | `[Intro](../guides/intro.md)` | Flattened output filename | Current extra source file directory |
| Explicit absolute-style path | `[Intro](/guides/intro.md)` | Flattened output filename | Project root |

More concretely, if the current extra source file is `guides/current.md`:

| Link | Resolves after this PR |
| --- | --- |
| `intro.md` | legacy flattened lookup for `intro.md` |
| `./intro.md` | `guides/intro.md` |
| `guides/intro.md` | `guides/guides/intro.md` |
| `../guides/intro.md` | `guides/intro.md` |
| `/guides/intro.md` | `guides/intro.md` from project root |

So `guides/intro.md` is **not** project-root-relative. Only `/guides/intro.md` is.

This keeps the legacy behavior for bare filename links while making path-qualified links fail loudly when the specified path is wrong.
