### PR TITLE
Skip HTML comments when computing synopsis

### DIFF
--- a/lib/ex_doc/doc_ast.ex
+++ b/lib/ex_doc/doc_ast.ex
@@ -166,6 +166,7 @@ defmodule ExDoc.DocAST do
     to_html({:p, [], remove_ids(inner), meta})
   end
 
+  def synopsis([{:comment, _, _, _} | rest]), do: synopsis(rest)
   def synopsis([head | _]), do: synopsis(head)
   def synopsis(_other), do: ""
 

--- a/test/ex_doc/doc_ast_test.exs
+++ b/test/ex_doc/doc_ast_test.exs
@@ -147,6 +147,10 @@ defmodule ExDoc.DocASTTest do
                "<p>Example function: Summary should display trailing period :.</p>"
     end
 
+    test "skips html comments" do
+      assert synopsis("<!-- comment -->\nSynopsis.") == "<p>Synopsis.</p>"
+    end
+
     defp synopsis(markdown) do
       markdown
       |> parse!("text/markdown")


### PR DESCRIPTION
In Erlang you can have external files that contain the docs (like https://github.com/erlang/otp/blob/master/lib/stdlib/doc/src/ms_transform.md?plain=1). These files have a comment at the start as a copyright header and that comment is used by ex_doc as the synopsis instead of the first paragraph.

This PR fixes synopsis generation to ignore comments.