### PR TITLE
Fix markdown backend code fence language and opaque type display

### DIFF
--- a/lib/ex_doc/formatter/markdown/templates/detail_template.eex
+++ b/lib/ex_doc/formatter/markdown/templates/detail_template.eex
@@ -6,7 +6,7 @@
 <% end %>
 
 <%= if node.source_specs != [] do %>
-```elixir
+```<%= module.language.highlight_info().language_name %>
 <%= for spec <- node.source_specs do %><%= module.language.format_spec_attribute(node) %> <%= module.language.format_spec(spec) %>
 <% end %>```
 <% end %>

--- a/lib/ex_doc/language/erlang.ex
+++ b/lib/ex_doc/language/erlang.ex
@@ -207,19 +207,6 @@ defmodule ExDoc.Language.Erlang do
     nil
   end
 
-  def autolink_spec({:attribute, _, :opaque, ast}, _opts) do
-    {name, _, args} = ast
-
-    args =
-      for arg <- args do
-        {:var, _, name} = arg
-        Atom.to_string(name)
-      end
-      |> Enum.intersperse(", ")
-
-    IO.iodata_to_binary([Atom.to_string(name), "(", args, ")"])
-  end
-
   def autolink_spec(ast, %Autolink{} = config) do
     {name, anno, quoted} =
       case ast do
@@ -232,11 +219,7 @@ defmodule ExDoc.Language.Erlang do
 
           {mn, anno, Enum.map(ast, &Code.Typespec.spec_to_quoted(name, &1))}
 
-        {:attribute, anno, :type, ast} ->
-          {name, _, _} = ast
-          {name, anno, Code.Typespec.type_to_quoted(ast)}
-
-        {:attribute, anno, :nominal, ast} ->
+        {:attribute, anno, kind, ast} when kind in [:type, :opaque, :nominal] ->
           {name, _, _} = ast
           {name, anno, Code.Typespec.type_to_quoted(ast)}
       end
@@ -510,10 +493,17 @@ defmodule ExDoc.Language.Erlang do
 
     options = [linewidth: 98 + offset]
 
-    :erl_pp.attribute(ast, options)
-    |> IO.chardata_to_string()
-    |> String.trim()
-    |> String.trim_leading("-#{Atom.to_string(type)} ")
+    spec =
+      :erl_pp.attribute(ast, options)
+      |> IO.chardata_to_string()
+      |> String.trim()
+      |> String.trim_leading("-#{Atom.to_string(type)} ")
+
+    if type == :opaque do
+      String.replace(spec, ~r/ ::.*$/s, "")
+    else
+      spec
+    end
   end
 
   # Traverses quoted and formatted string of the typespec AST, replacing refs with links.

--- a/test/ex_doc/formatter/erlang_test.exs
+++ b/test/ex_doc/formatter/erlang_test.exs
@@ -56,7 +56,7 @@ defmodule ExDoc.Formatter.ErlangTest do
     -module(bar).
     -moduledoc("bar module.").
     -export([bar/1, baz/0]).
-    -export_type([t/0]).
+    -export_type([t/0, o/0]).
 
     -doc("bar/1 function.").
     -spec bar(t()) -> t().
@@ -68,6 +68,9 @@ defmodule ExDoc.Formatter.ErlangTest do
 
     -doc("t/0 type.").
     -type t() :: atom().
+
+    -doc("o/0 opaque.").
+    -opaque o() :: {atom(), integer()}.
     """)
 
     generate(c)
@@ -104,13 +107,20 @@ defmodule ExDoc.Formatter.ErlangTest do
     assert markdown =~ "bar/1 function."
     assert markdown =~ "baz/0 function."
 
-    # Check specs in markdown
-    assert markdown =~ "-spec bar(t()) -> t()."
-    assert markdown =~ "-spec baz() -> atom()."
+    # Check specs in markdown use erlang code fences
+    assert markdown =~ "```erlang\n-spec bar(t()) -> t()."
+    assert markdown =~ "```erlang\n-spec baz() -> atom()."
 
     # Check type in markdown
-    assert markdown =~ "-type t() :: atom()."
+    assert markdown =~ "```erlang\n-type t() :: atom()."
     assert markdown =~ "t/0 type."
+
+    # Opaque types hide their internals in both HTML and markdown
+    assert html =~ ~s|-opaque</span> o()|
+    refute html =~ ~s|o() :: {|
+    assert markdown =~ "```erlang\n-opaque o()\n```"
+    refute markdown =~ "o() ::"
+    assert markdown =~ "o/0 opaque."
   end
 
   defp generate(c) do

--- a/test/ex_doc/retriever/erlang_test.exs
+++ b/test/ex_doc/retriever/erlang_test.exs
@@ -299,7 +299,7 @@ defmodule ExDoc.Retriever.ErlangTest do
       assert opaque1.doc |> DocAST.to_html() =~ "opaque1/0 docs."
 
       assert hd(opaque1.source_specs) |> format_spec() ==
-               "opaque1() :: atom()."
+               "opaque1()"
 
       assert nominal1.id == "t:nominal1/0"
       assert nominal1.type == @nominal_type
@@ -514,7 +514,7 @@ defmodule ExDoc.Retriever.ErlangTest do
       assert opaque1.doc |> DocAST.to_html() =~ "opaque1/0 docs."
 
       assert hd(opaque1.source_specs) |> format_spec() ==
-               "opaque1() :: atom()."
+               "opaque1()"
 
       assert nominal1.id == "t:nominal1/0"
       assert nominal1.type == @nominal_type


### PR DESCRIPTION
Use the module's language for code fences instead of hardcoded "elixir", and hide opaque type internals in Erlang's format_spec.