### PR TITLE
Preserve styling of user 'Search' headings and raise on extras that conflict with reserved filenames

### DIFF
--- a/assets/css/search.css
+++ b/assets/css/search.css
@@ -1,39 +1,3 @@
-#search {
-  min-height: 200px;
-  position: relative;
-}
-
-#search .loading {
-  height: 64px;
-  width: 64px;
-  position: absolute;
-  top: 50%;
-  left: calc(50% - 32px);
-}
-
-#search .loading div {
-  box-sizing: border-box;
-  display: block;
-  position: absolute;
-  width: 51px;
-  height: 51px;
-  margin: 6px;
-  border: 6px solid var(--coldGray);
-  border-radius: 50%;
-  animation: loading 1.2s cubic-bezier(.5, 0, .5, 1) infinite;
-  border-color: var(--coldGray) transparent transparent transparent;
-}
-
-#search .loading div:nth-child(1) {
-  animation-delay: -.45s;
-}
-#search .loading div:nth-child(2) {
-  animation-delay: -.3s;
-}
-#search .loading div:nth-child(3) {
-  animation-delay: -.15s;
-}
-
 @keyframes loading {
   0% {
     transform: rotate(0deg);
@@ -43,36 +7,72 @@
   }
 }
 
-#search .result {
-  margin: 2em 0;
-}
+.page-search #search {
+  min-height: 200px;
+  position: relative;
 
-#search .result p {
-  margin: 0;
-}
+  & .loading {
+    height: 64px;
+    width: 64px;
+    position: absolute;
+    top: 50%;
+    left: calc(50% - 32px);
+  }
 
-#search .result-id {
-  font-size: 1.4em;
-  margin: 0;
-}
+  & .loading div {
+    box-sizing: border-box;
+    display: block;
+    position: absolute;
+    width: 51px;
+    height: 51px;
+    margin: 6px;
+    border: 6px solid var(--coldGray);
+    border-radius: 50%;
+    animation: loading 1.2s cubic-bezier(.5, 0, .5, 1) infinite;
+    border-color: var(--coldGray) transparent transparent transparent;
+  }
 
-#search .result-id a {
-  text-decoration: none;
-  color: var(--textHeaders);
-  transition: var(--transition-colors);
-}
-#search .result-id a:is(:visited, :active) {
-  color: var(--textHeaders);
-}
-#search .result-id a:is(:hover, :focus) {
-  color: var(--main);
-}
+  & .loading div:nth-child(1) {
+    animation-delay: -.45s;
+  }
+  & .loading div:nth-child(2) {
+    animation-delay: -.3s;
+  }
+  & .loading div:nth-child(3) {
+    animation-delay: -.15s;
+  }
 
-#search :is(.result-id, .result-elem) em {
-  font-style: normal;
-  color: var(--main);
-}
+  & .result {
+    margin: 2em 0;
+  }
 
-#search .result-id small {
-  font-weight: normal;
+  & .result p {
+    margin: 0;
+  }
+
+  & .result-id {
+    font-size: 1.4em;
+    margin: 0;
+  }
+
+  & .result-id a {
+    text-decoration: none;
+    color: var(--textHeaders);
+    transition: var(--transition-colors);
+  }
+  & .result-id a:is(:visited, :active) {
+    color: var(--textHeaders);
+  }
+  & .result-id a:is(:hover, :focus) {
+    color: var(--main);
+  }
+
+  & :is(.result-id, .result-elem) em {
+    font-style: normal;
+    color: var(--main);
+  }
+
+  & .result-id small {
+    font-weight: normal;
+  }
 }

--- a/lib/ex_doc/extras.ex
+++ b/lib/ex_doc/extras.ex
@@ -3,6 +3,8 @@ defmodule ExDoc.Extras do
 
   alias ExDoc.{Config, Markdown, Utils}
 
+  @reserved_filenames ~w(404.html search.html)
+
   @doc """
   Build a list of `ExDoc.ExtraNode` and `ExDoc.URLNode`.
   """
@@ -13,6 +15,7 @@ defmodule ExDoc.Extras do
       extras_input
       |> Enum.map(&build_extra(&1, groups, config))
 
+    validate_no_reserved_filenames!(extras)
     validate_no_duplicate_extras!(extras)
 
     ids_count = Enum.reduce(extras, %{}, &Map.update(&2, &1.id, 1, fn c -> c + 1 end))
@@ -23,6 +26,24 @@ defmodule ExDoc.Extras do
     end)
     |> elem(0)
     |> Enum.sort_by(fn extra -> Config.index(groups, extra.group) end)
+  end
+
+  defp validate_no_reserved_filenames!(extras) do
+    conflicts =
+      extras
+      |> Enum.filter(&match?(%ExDoc.ExtraNode{}, &1))
+      |> Enum.filter(fn extra -> "#{extra.id}.html" in @reserved_filenames end)
+
+    if conflicts != [] do
+      entries =
+        Enum.map_join(conflicts, ", ", fn extra ->
+          "#{inspect(extra.source_path)} would generate #{extra.id}.html"
+        end)
+
+      raise ArgumentError,
+            "extra(s) would conflict with built-in ExDoc page(s): #{entries}; " <>
+              "rename your extra file(s) or use the :filename option to set different output filename(s)"
+    end
   end
 
   # Detects duplicate ExtraNode entries by checking for collisions on the

--- a/test/ex_doc/extras_test.exs
+++ b/test/ex_doc/extras_test.exs
@@ -390,6 +390,22 @@ defmodule ExDoc.ExtrasTest do
       end
     end
 
+    test "raises when extra would generate search.html", %{tmp_dir: tmp_dir} do
+      File.write!("#{tmp_dir}/search.md", "# Search")
+
+      assert_raise ArgumentError, ~r/would conflict with built-in ExDoc page/, fn ->
+        Extras.build(["#{tmp_dir}/search.md"], config())
+      end
+    end
+
+    test "raises when extra with filename option would generate search.html", %{tmp_dir: tmp_dir} do
+      File.write!("#{tmp_dir}/searching.md", "# Search")
+
+      assert_raise ArgumentError, ~r/would conflict with built-in ExDoc page/, fn ->
+        Extras.build([{"#{tmp_dir}/searching.md", [filename: "search"]}], config())
+      end
+    end
+
     test "handles extras with keyword list options", %{tmp_dir: tmp_dir} do
       File.write!("#{tmp_dir}/page.md", "# Page")
 


### PR DESCRIPTION
The search CSS file now uses `.page-search` in the selector so as to avoid affecting users' "Search" headings, and uses the `&` nesting selector throughout to avoid repeating.

Example error:

> ** (ArgumentError) extra(s) would conflict with built-in ExDoc page(s): "Search.md" would generate search.html, "404.md" would generate 404.html; rename your extra file(s) or use the :filename option to set different output filename(s)
    (ex_doc 0.40.1) lib/ex_doc/extras.ex:43: ExDoc.Extras.validate_no_reserved_filenames!/1
    (ex_doc 0.40.1) lib/ex_doc/extras.ex:18: ExDoc.Extras.build/2
    (ex_doc 0.40.1) lib/ex_doc.ex:532: ExDoc.generate/4
    (ex_doc 0.40.1) lib/mix/tasks/docs.ex:155: Mix.Tasks.Docs.run/3
    (mix 1.17.2) lib/mix/task.ex:495: anonymous fn/3 in Mix.Task.run_task/5
    mix.exs:145: ExDoc.Mixfile.docs/1
    (mix 1.17.2) lib/mix/task.ex:574: Mix.Task.run_alias/6
    (mix 1.17.2) lib/mix/cli.ex:96: Mix.CLI.run_task/2

Fixes #2233