### PR TITLE
Fix positioning of top content heading action icon focus outline

### DIFF
--- a/assets/css/content/general.css
+++ b/assets/css/content/general.css
@@ -50,7 +50,7 @@
       }
 
       & .icon-action {
-        padding-top: 1.7rem; /* vertically align with x-height of first line of heading */
+        margin-top: 1rem; /* vertically align with x-height of first line of heading */
       }
     }
   }


### PR DESCRIPTION
Fixes #2237

<img width="370" height="196" alt="image" src="https://github.com/user-attachments/assets/4c936db2-3c4d-4da2-b7e9-0f5f4d8e2625" />

I'm looking at adding a small `outline-offset` to these kinds of buttons so that the focus outline doesn't touch the icons, but that can be a separate PR.