### PR TITLE
Use a fixed makeup group_prefix for reproducible HTML output

### DIFF
--- a/lib/ex_doc/doc_ast.ex
+++ b/lib/ex_doc/doc_ast.ex
@@ -246,7 +246,7 @@ defmodule ExDoc.DocAST do
             try do
               Makeup.highlight_inner_html(code,
                 lexer: lexer,
-                lexer_options: lexer_opts,
+                lexer_options: Keyword.put_new(lexer_opts, :group_prefix, "group"),
                 formatter_options: opts
               )
             rescue


### PR DESCRIPTION
makeup's lexers default to a random 10-digit group_prefix, generated anew on every lexer invocation, so every data-group-id attribute in highlighted code blocks differs between two builds of the same docs.

Group ids only need to be unique within a single code block: the hover-highlighting JS (assets/js/makeup.js) resolves them through parentElement, never across blocks. Passing a fixed prefix therefore changes nothing functionally while making the generated HTML (and the content-hashed search_data/sidebar file names derived from it) reproducible.

See https://reproducible-builds.org/ for why this is good.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds). This patch helps erlang-doc to be more deterministic. A 2nd patch for epub is needed to make erlang-doc build fully deterministic.