### PR TITLE
fix: reference missing section

### DIFF
--- a/lib/ex_doc.ex
+++ b/lib/ex_doc.ex
@@ -64,7 +64,7 @@ defmodule ExDoc do
       and plain text pages to add to the documentation. You can also specify keyword pairs to
       customize the generated filename, title and source file, and search content of each extra page;
       default: `[]`. Example: `["README.md", "LICENSE", "CONTRIBUTING.md": [filename: "contributing",
-      title: "Contributing", source: "CONTRIBUTING.mdx"]]` See the Customizing Extras section for
+      title: "Contributing", source: "CONTRIBUTING.mdx"]]`. See the [Additional pages (extras)](#module-additional-pages-extras) section for
       more.
 
     * `:favicon` - Path to a favicon image file for the project. Must be PNG, JPEG or SVG. When


### PR DESCRIPTION
## Before
The documentation for `generate/4 > Options > :extras` mentions more configuration details can be found under the "Configuring Extras" section.

But no such section exists.

The closes thing i can find is the "Additional pages (extras)" section.

## After
Add a link to the existing section with more configuration details.
Also added a period to the end of the previous example.